### PR TITLE
Implement filtering old campaigns in tenant detail page

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Tenant/Tenant.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Tenant/Tenant.cshtml
@@ -8,11 +8,29 @@
 </div>
 <div class="row">
     <div class="col-md-12">
-        <h3>Organization's campaigns</h3>
-        <ul>
-            @foreach (var campaign in Model.Campaigns) {
-                <li><a asp-controller="Campaign" asp-action="Details" asp-route-id="@campaign.Id">@campaign.Name</a></li>
-            }
+        <h3>
+            Organization's campaigns
+            <button type="button" class="btn" data-bind="css: { active: campaigns.showOld }, click: campaigns.showOld.toggle">
+                <i class="fa" data-bind="css: { 'fa-square-o': !campaigns.showOld(), 'fa-check-square-o': campaigns.showOld }"></i>
+                Show Old
+            </button>
+        </h3>
+        <span data-bind="visible: !campaigns.filtered().length">
+            No current campaigns. Maybe look at an old campaign.
+        </span>
+        <ul data-bind="foreach: campaigns.filtered">
+            <li>
+                <a data-bind="attr: { href: '/Campaign/' + Id }, text: Name"></a>
+            </li>
         </ul>
     </div>
 </div>
+
+@section scripts {
+    <script>
+        var modelCampaigns = @Json.Serialize(Model.Campaigns);
+    </script>
+    <script type="text/javascript" src="~/js/ko.filterableList.js"></script>
+    <script type="text/javascript" src="~/js/tenant.js"></script>
+
+}

--- a/AllReadyApp/Web-App/AllReady/wwwroot/_references.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/_references.js
@@ -7,3 +7,4 @@
 /// <reference path="js/ko.filterablelist.js" />
 /// <reference path="js/myactivities.js" />
 /// <reference path="js/site.js" />
+/// <reference path="js/tenant.js" />

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/tenant.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/tenant.js
@@ -1,0 +1,11 @@
+﻿///<reference path="../lib/jquery/dist/jquery.js" />
+///<reference path="../lib/knockout/dist/knockout.js" />
+
+(function (ko, $, campaigns) {
+
+    function TenantViewModel(campaigns) {
+        this.campaigns = ko.observableArray(campaigns).filterBeforeDate("EndDateTimeUtc");
+    }
+
+    ko.applyBindings(new TenantViewModel(campaigns));
+})(ko, $, modelCampaigns);


### PR DESCRIPTION
Fixes #52 (despite the fact that the branch is called #51). Sorry.