### PR TITLE
Updated Registration to allow organization admins to register with em…

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/MakeUserTenantAdmin.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/MakeUserTenantAdmin.cshtml
@@ -31,6 +31,7 @@
                 <div class="form-group">
                     <div class="col-md-offset-2 col-md-10">
                         <button type="submit" class="btn btn-default">Make user as Tenant Admin</button>
+                        <span class="success">@ViewData["result"]</span>
                     </div>
                 </div>
             </form>

--- a/AllReadyApp/Web-App/AllReady/Controllers/AdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AdminController.cs
@@ -170,7 +170,7 @@ namespace AllReady.Controllers
             // this user as a Tenant Admin
             if(result.Succeeded)
             {
-                var callbackUrl = Url.Action(nameof(SiteController.MakeUserTenantAdmin), "Site", new { area = "Admin", Email=user.Email, TenantAdmin=false }, protocol: Context.Request.Scheme);
+                var callbackUrl = Url.Action(nameof(SiteController.MakeUserTenantAdmin), "Site", new { area = "Admin", Email=user.Email, TenantAdmin=true }, protocol: Context.Request.Scheme);
                 await _emailSender.SendEmailAsync(_config["DefaultAdminUsername"], "Approve Tenant user account",
                     "Please approve this account by clicking this <a href=\"" + callbackUrl + "\">link</a>");
             }

--- a/AllReadyApp/Web-App/AllReady/Services/MessageServices.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/MessageServices.cs
@@ -24,7 +24,7 @@ namespace AllReady.Services
             // Plug in your email service here to send an email.
             var myMessage = new SendGridMessage();
             myMessage.AddTo(email);
-            myMessage.From = new System.Net.Mail.MailAddress("Joe@contoso.com", "Joe S.");
+            myMessage.From = new System.Net.Mail.MailAddress(_config.Get("DefaultFromEmailAddress"), _config.Get("DefaultFromDisplayName"));
             myMessage.Subject = subject;
             myMessage.Text = message;
             myMessage.Html = message;
@@ -32,7 +32,10 @@ namespace AllReady.Services
                 _config["Authentication:SendGrid:UserName"],
                 _config["Authentication:SendGrid:Password"]);
             // Create a Web transport for sending email.
-            var transportWeb = new Web(credentials);
+            ITransportAdapter.Credentials = credentials;
+            ITransportAdapter.Config = _config;
+            var transportWeb = ITransportAdapter.Create();
+            
             // Send the email.
             if (transportWeb != null)
             {

--- a/AllReadyApp/Web-App/AllReady/Services/SendGridDevelopmentWeb.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/SendGridDevelopmentWeb.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Net.Mail;
+using Microsoft.Framework.Configuration;
+using SendGrid;
+using System.Net;
+
+namespace AllReady.Services
+{
+    public class SendGridDevelopmentWeb : ITransport
+    {
+        private IConfiguration _config;
+        public SendGridDevelopmentWeb(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        public Task DeliverAsync(ISendGrid message)
+        {
+            var client = new SmtpClient();
+            var resultObject = new object();
+            client.DeliveryMethod = SmtpDeliveryMethod.SpecifiedPickupDirectory;
+            client.PickupDirectoryLocation = _config.Get("DevelopmentEmailFolder");
+            client.SendAsync(new MailMessage(message.From.Address, message.To.FirstOrDefault().Address, message.Subject, message.Html), resultObject);
+            return Task.FromResult(resultObject);
+        }
+    }
+
+    public static class ITransportAdapter
+    {
+        public static ITransport SendGridTransport { private get; set; }
+        public static IConfiguration Config { private get; set; }
+        public static NetworkCredential Credentials { private get; set; }
+
+        private static bool isDebugMode = false;
+
+        static ITransportAdapter()
+        {
+            #if DEBUG
+                isDebugMode = true;
+            #endif
+        }
+
+        public static ITransport Create()
+        {
+            if(SendGridTransport != null)
+            {
+               return SendGridTransport;
+            }
+
+            if (isDebugMode && Config != null)
+            {
+                return new SendGridDevelopmentWeb(Config);
+            }
+            else if (Credentials != null)
+            {
+                return new Web(Credentials);
+            }
+
+            throw new Exception("SendGridWebAdapter requires an instance of ITransport, IConfiguration (and must be in debug mode), or Network Credentials");
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Views/Admin/ConfirmEmail.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Admin/ConfirmEmail.cshtml
@@ -5,6 +5,6 @@
 <h2>@ViewData["Title"].</h2>
 <div>
     <p>
-        Thank you for confirming your email. Please <a asp-controller="Admin" asp-action="Login">Click here to Log in</a>.
+        Thank you for confirming your email. You will be contacted once your account has been approved by an administrator.
     </p>
 </div>

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -1,45 +1,47 @@
 {
-  "DefaultAdminUsername": "Administrator@test.com",
-  "DefaultAdminPassword": "YouShouldChangeThisPassword1!",
-  "DefaultUsername": "User@test.com",
-  "DefaultTenantUsername": "tenant@test.com",
+    "DefaultAdminUsername": "Administrator@test.com",
+    "DefaultAdminPassword": "YouShouldChangeThisPassword1!",
+    "DefaultUsername": "User@test.com",
+    "DefaultTenantUsername": "tenant@test.com",
+    "DefaultFromEmailAddress": "Administrator@test.com",
+    "DefaultFromDisplayName": "allReady.com Administrator",
 
-  "ApplicationInsights": {
-    "InstrumentationKey": "[instrumentationkey]"
-  },
-  "Data": {
-    "DefaultConnection": {
-      "UseInMemory": "true",
-      "AzureConnectionString": "Server=[server],1433;Database=[database];User ID=[userid];Password=[password];Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
-      "LocalConnectionString": "Server=(localdb)\\mssqllocaldb;Database=AllReady;Integrated Security=true;"
+    "ApplicationInsights": {
+        "InstrumentationKey": "[instrumentationkey]"
     },
-    "InsertSampleData": "true",
-    "InsertTestUsers": "true",
-    "Storage": {
-      "AzureStorage": "[storagekey]"
+    "Data": {
+        "DefaultConnection": {
+            "UseInMemory": "true",
+            "AzureConnectionString": "Server=[server],1433;Database=[database];User ID=[userid];Password=[password];Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+            "LocalConnectionString": "Server=(localdb)\\mssqllocaldb;Database=AllReady;Integrated Security=true;"
+        },
+        "InsertSampleData": "true",
+        "InsertTestUsers": "true",
+        "Storage": {
+            "AzureStorage": "[storagekey]"
+        }
+    },
+    "Authentication": {
+        "Facebook": {
+            "AppId": "[facebookappId]",
+            "AppSecret": "[facebookappsecret]"
+        },
+        "Twitter": {
+            "ConsumerKey": "[twitterkey]",
+            "ConsumerSecret": "[twittersecret]"
+        },
+        "MicrosoftAccount": {
+            "ClientId": "[twitterclient]",
+            "ClientSecret": "[twittersecret]"
+        },
+        "SendGrid": {
+            "UserName": "[sendgriduser]",
+            "Password": "[sendgridpassword]"
+        },
+        "Twilio": {
+            "Sid": "[twiliosid]",
+            "Token": "[twiliotoken]",
+            "PhoneNo": "[twilionumber]"
+        }
     }
-  },
-  "Authentication": {
-    "Facebook": {
-      "AppId": "[facebookappId]",
-      "AppSecret": "[facebookappsecret]"
-    },
-    "Twitter": {
-      "ConsumerKey": "[twitterkey]",
-      "ConsumerSecret": "[twittersecret]"
-    },
-    "MicrosoftAccount": {
-      "ClientId": "[twitterclient]",
-      "ClientSecret": "[twittersecret]"
-    },
-    "SendGrid": {
-      "UserName": "[sendgriduser]",
-      "Password": "[sendgridpassword]"
-    },
-     "Twilio": {
-      "Sid": "[twiliosid]",
-      "Token": "[twiliotoken]",
-      "PhoneNo": "[twilionumber]"
-    }
-  }
 }


### PR DESCRIPTION
…ail and password on the site. SendGridDevelopmentWeb.cs prevents the need for an actual SendGrid account when performing registration (the new class saves the email as a .eml file on the local machine).

--

5.1.1.3.2 Allow organization ‘admins’ to register with username and password on AllReady site as well #33

@BillWagner @tonysurma Not sure if the way I did this is the best architecturally. I thought it might be possible to use IoC to configure whether or not the application should use SendGrid or the local file solution I created (SendGridDevelopmentWeb.cs), but I am not familiar with AspNet 5's IoC configuration. Also, I used a user secret for the "DevelopmentEmailFolder" key, which is where the application will write email files out when the application is run in debug mode.

Finally, the config.json file appears to be saying a lot changed, but I only added 2 keys ("DefaultFromEmailAddress", "DefaultFromDisplayName") - the rest should be the same.