### PR TITLE
changing test.com to example.com

### DIFF
--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -1,9 +1,9 @@
 {
-    "DefaultAdminUsername": "Administrator@test.com",
+    "DefaultAdminUsername": "Administrator@example.com",
     "DefaultAdminPassword": "YouShouldChangeThisPassword1!",
-    "DefaultUsername": "User@test.com",
-    "DefaultTenantUsername": "tenant@test.com",
-    "DefaultFromEmailAddress": "Administrator@test.com",
+    "DefaultUsername": "User@example.com",
+    "DefaultTenantUsername": "tenant@example.com",
+    "DefaultFromEmailAddress": "Administrator@example.com",
     "DefaultFromDisplayName": "allReady.com Administrator",
 
     "ApplicationInsights": {

--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ The URL of the AllReady web site is set in the **domainUrl** variable in the /ww
 Once you have set the required settings either in the config.json file or in the secrets manager, you can run and locally debug the projects. If you have not yet created a SQL Database in Azure, you should use either the in-memory data storage option or use `Data:DefaultConnection:LocalConnectionString` as the **connectionStringPath** value in Startup.cs.
 
 Currently there are hardcoded user accounts for limited testing (this will of course be changed soon)  For now:
-"DefaultAdminUsername": "Administrator@test.com", 
+"DefaultAdminUsername": "Administrator@example.com", 
 "DefaultAdminPassword": "YouShouldChangeThisPassword1!", 
-"DefaultUsername": "User@test.com", 
-"DefaultTenantUsername": "tenant@test.com", 
+"DefaultUsername": "User@example.com", 
+"DefaultTenantUsername": "tenant@example.com", 
 
 ###Deploy to Azure
 


### PR DESCRIPTION
test.com is a legitimate domain. Sample data should probably reference the
recommended example.com domain.  Changed the config file containing the
sample data and the readme to match.