### PR TITLE
Restore tota11y accessibility visualization toolkit

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Campaign/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Campaign/Index.cshtml
@@ -78,19 +78,6 @@
             </table>
         </div>
     </div>
-    <environment names="Development">
-        <script src="~/lib/jquery/dist/jquery.js"></script>
-        <script src="~/lib/knockout/dist/knockout.js"></script>
-        <script src="~/js/tota11y.min.js"></script>
-    </environment>
-    <environment names="Staging,Production">
-        <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.4.min.js"
-                asp-fallback-src="~/lib/jquery/dist/jquery.min.js"
-                asp-fallback-test="window.jQuery">
-        </script>
-        <script src="//ajax.aspnetcdn.com/ajax/knockout/knockout-3.3.0.js"></script>
-    </environment>
-    <script src="~/js/site.js"></script>
 </div>
 
 @section scripts {

--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
@@ -91,9 +91,7 @@
             <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
             <script src="~/lib/knockout/dist/knockout.js"></script>
             <script src="~/lib/moment/moment.js"></script>
-            <script src="~/js/site.js" asp-file-version="true"></script>
-            <script src="~/js/tota11y.min.js"></script>
-            <script src="~/js/tota11y.min.js"></script>
+            <script src="~/lib/tota11y/build/tota11y.js"></script>
         </environment>
         <environment names="Staging,Production">
             <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.4.min.js"
@@ -113,8 +111,8 @@
                     asp-fallback-src="~/lib/bootstrap-touch-carousel/dist/js/bootstrap-touch-carousel.js"
                     asp-fallback-test="window.Hammer && window.Hammer.Instance">
             </script>
-            <script src="~/js/site.js" asp-file-version="true"></script>
         </environment>
+        <script src="~/js/site.js" asp-file-version="true"></script>
 
         @RenderSection("scripts", required: false)
     </body>

--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_LayoutMainPage.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_LayoutMainPage.cshtml
@@ -53,7 +53,7 @@
         <script src="~/lib/jquery/dist/jquery.js"></script>
         <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
         <script src="~/lib/knockout/dist/knockout.js"></script>
-        <script src="~/js/tota11y.min.js"></script>
+        <script src="~/lib/tota11y/build/tota11y.js"></script>
     </environment>
     <environment names="Staging,Production">
         <script src="//ajax.aspnetcdn.com/ajax/jquery/jquery-2.1.4.min.js"

--- a/AllReadyApp/Web-App/AllReady/bower.json
+++ b/AllReadyApp/Web-App/AllReady/bower.json
@@ -13,6 +13,7 @@
     "jquery-validation-unobtrusive": "3.2.2",
     "font-awesome": "4.3.0",
     "knockout": "3.3.0",
-    "moment": "2.10.6"
+    "moment": "2.10.6",
+    "tota11y": "0.1.2"
   }
 }


### PR DESCRIPTION
* Restore reference to tota11y accessibility visualization toolkit (should only appear for "Development" environment).
* Remove redundant script references from Campaign index view
