### PR TITLE
Add a prerequisite for ASP.NET and Web Tools 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You will need the following to be able to run the allReady solution locally:
 
 + Visual Studio 2015, including the tools for Apache Cordova, and optionally the emulator for Android apps.  All of the needed tools are supported by all versions of Visual Studio 2015 including the free Community Edition  [Download Visual Studio 2015](https://www.visualstudio.com/downloads/download-visual-studio-vs)
 
-+ To use ASP.NET 5 beta7 and above with Visual Studio 2015, you will need to [download](https://www.microsoft.com/en-us/download/details.aspx?id=48738&fa43d42b-25b5-4a42-fe9b-1634f450f5ee=True) and install the beta7 version (14.0.60831.0) of ASP.NET and Web Tools 2015.
++ To use ASP.NET 5 beta8 with Visual Studio 2015, you will need to [download](http://www.microsoft.com/en-us/download/details.aspx?id=49442) and install the beta8 version of ASP.NET and Web Tools 2015.
 
 You will need the following to be able to run the allReady solution in Azure:
 + An active Microsoft Azure account to deploy the web app. You can sign-up for a free trial of Azure [here](https://azure.microsoft.com/en-us/pricing/free-trial/).

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ You will need the following to be able to run the allReady solution locally:
 
 + Visual Studio 2015, including the tools for Apache Cordova, and optionally the emulator for Android apps.  All of the needed tools are supported by all versions of Visual Studio 2015 including the free Community Edition  [Download Visual Studio 2015](https://www.visualstudio.com/downloads/download-visual-studio-vs)
 
++ To use ASP.NET 5 beta7 and above with Visual Studio 2015, you will need to [download](https://www.microsoft.com/en-us/download/details.aspx?id=48738&fa43d42b-25b5-4a42-fe9b-1634f450f5ee=True) and install the beta7 version (14.0.60831.0) of ASP.NET and Web Tools 2015.
+
 You will need the following to be able to run the allReady solution in Azure:
 + An active Microsoft Azure account to deploy the web app. You can sign-up for a free trial of Azure [here](https://azure.microsoft.com/en-us/pricing/free-trial/).
 


### PR DESCRIPTION
Starting with beta7 of ASP.NET one must download and install ASP.NET and Web Tools 2015 to be able to build the solution in VS 2015.  This took me a few hours to find, I'm hoping to save others some time.