### PR TITLE
Fix for crash when editing activities

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ActivityAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ActivityAdminController.cs
@@ -175,12 +175,16 @@ namespace AllReady.Areas.Admin.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(Activity activity)
         {
-            Campaign campaign = _dataAccess.GetCampaign(activity.CampaignId);
-            if (campaign == null || !User.IsTenantAdmin(campaign.ManagingTenantId))
+            if (activity == null)
+            {
+                return HttpBadRequest();
+            }
+
+            int campaignId = _dataAccess.GetManagingTenantId(activity.Id);            
+            if (!User.IsTenantAdmin(campaignId))
             {
                 return HttpUnauthorized();
             }
-            activity.Campaign = campaign;
             if (ModelState.IsValid)
             {
                 if (activity.RequiredSkills != null && activity.RequiredSkills.Count > 0)
@@ -190,7 +194,8 @@ namespace AllReady.Areas.Admin.Controllers
                 await _dataAccess.UpdateActivity(activity);
                 return RedirectToAction("Index", new { campaignId = activity.CampaignId });
             }
-
+            Campaign campaign = _dataAccess.GetCampaign(activity.CampaignId);
+            activity.Campaign = campaign;
             return View(activity);
         }
 

--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Activity.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Activity.cs
@@ -77,6 +77,11 @@ namespace AllReady.Models
                 .SingleOrDefault(a => a.Id == activityId);
         }
 
+        int IAllReadyDataAccess.GetManagingTenantId(int activityId)
+        {
+            return _dbContext.Activities.Where(a => a.Id == activityId).Select(a => a.Campaign.ManagingTenantId).FirstOrDefault();
+        }
+
         IEnumerable<ActivitySignup> IAllReadyDataAccess.GetActivitySignups(int activityId, string userId)
         {
             return _dbContext.ActivitySignup

--- a/AllReadyApp/Web-App/AllReady/DataAccess/IAllReadyDataAccess.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/IAllReadyDataAccess.cs
@@ -12,6 +12,7 @@ namespace AllReady.Models
         #region Activity CRUD
         IEnumerable<Activity> Activities { get; }
         Activity GetActivity(int activityId);
+        int GetManagingTenantId(int activityId);
         Task AddActivity(Activity value);
         Task DeleteActivity(int id);
         IEnumerable<ActivitySignup> GetActivitySignups(string userId);


### PR DESCRIPTION
Resolves issue #136 
Bit of a workaround in this bug fix. What we need is a better way to sometimes query our data model with NoTracking to avoid this type of problem. I am hoping to pair up with James and refactor one of the controller to show what that would look like. In the mean time this fixes the crash when editing activities