### PR TITLE
Add display of assigned user to activity admin view

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ActivityAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ActivityAdminController.cs
@@ -62,6 +62,20 @@ namespace AllReady.Areas.Admin.Controllers
                 return new HttpStatusCodeResult(404);
             }
 
+            List<TaskViewModel> tasks = activity.Tasks.Select(t => new TaskViewModel
+            {
+                Id = t.Id,
+                ActivityId = id,
+                Name = t.Name,
+                Description = t.Description,
+                AssignedVolunteers = t.AssignedVolunteers?.Select(v => new TaskSignupViewModel()
+                {
+                    UserName = v.User.UserName,
+                    StatusDescription = v.StatusDescription,
+                }).ToList(),
+            })
+            .OrderBy(t => t.StartDateTime).ThenBy(t => t.Name).ToList();
+
             var avm = new AdminActivityViewModel
             {
                 Id = activity.Id,
@@ -71,13 +85,8 @@ namespace AllReady.Areas.Admin.Controllers
                 Description = activity.Description,
                 StartDateTime = activity.StartDateTimeUtc,
                 EndDateTime = activity.EndDateTimeUtc,
-                Volunteers = _dataAccess.ActivitySignups.Where(asup => asup.Activity.Id == id).Select(u => u.User.UserName).ToList(),
-                Tasks = activity.Tasks.Select(t => new TaskViewModel
-                { Id = t.Id,
-                    ActivityId =id,
-                    Name = t.Name,
-                    Description = t.Description })
-                    .OrderBy(t => t.StartDateTime).ThenBy(t=> t.Name).ToList(),
+                Volunteers = activity.UsersSignedUp?.Select(s => s.User.UserName).ToList(),
+                Tasks = tasks,
                 ImageUrl = activity.ImageUrl
             };
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
@@ -18,5 +18,28 @@
         <h2>@Model.Name <a asp-controller="Task" asp-action="Edit" asp-route-id="@Model.Id" class="btn"><i class="glyphicon glyphicon-edit"></i></a> <a asp-controller="Task" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="glyphicon glyphicon-trash"></i></a></h2>
         <p>@Model.Description</p>
         <p><strong>Duration: </strong> @Model.StartDateTime.Value.DateTime.ToString("d") - @Model.EndDateTime.Value.DateTime.ToString("d")</p>
+
+        @if (Model.AssignedVolunteers.Count > 0)
+        {
+            <h4>Volunteers</h4>
+
+            <table class="table">
+                <tr>
+                    <th>
+                        Volunteer Name
+                    </th>
+                    <th>
+                        Status
+                    </th>
+                </tr>
+                @foreach (var volunteer in Model.AssignedVolunteers)
+                {
+                    <tr>
+                        <td>@volunteer.UserName</td>
+                        <td>@(volunteer.StatusDescription ?? "*")</td>
+                    </tr>
+                }
+            </table>
+        }
     </div>
 </div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/_List.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/_List.cshtml
@@ -16,6 +16,12 @@
                     Name
                 </th>
                 <th>
+                    Assignee
+                </th>
+                <th>
+                    Status
+                </th>
+                <th>
                     Start
                 </th>
                 <th>
@@ -29,12 +35,28 @@
                     <td>
                         <a asp-controller="Task" asp-action="Details" asp-route-area="Admin" asp-route-activityId="@item.ActivityId" asp-route-id="@item.Id">@item.Name</a>
                     </td>
+                    @if (item.AssignedVolunteers == null || item.AssignedVolunteers.Count == 0)
+                    {
+                        <td>*</td>
+                        <td>*</td>
+                    }
+                    else if (item.AssignedVolunteers.Count == 1)
+                    {
+                        <td>@item.AssignedVolunteers[0].UserName</td>
+                        <td>@(item.AssignedVolunteers[0].StatusDescription ?? "*")</td>
+                    }
+                    else
+                    {
+                        <td><a asp-controller="Task" asp-action="Details" asp-route-area="Admin" asp-route-activityId="@item.ActivityId" asp-route-id="@item.Id">Multiple Volunteers</a></td>
+                        <td>@item.AcceptedVolunteerCount / @item.AssignedVolunteers.Count Accepted</td>
+                    }
+
                     <td>
                         @(item.StartDateTime.HasValue ? item.StartDateTime.Value.UtcDateTime.ToShortDateString() : "*")
                     </td>
                     <td>
                         @(item.EndDateTime.HasValue ? item.EndDateTime.Value.UtcDateTime.ToShortDateString() : "*")
-                    </td>                    
+                    </td>
                 </tr>
             }
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
@@ -50,7 +50,7 @@ namespace AllReady.Controllers
         public async Task<IActionResult> UpdateMyTasks(int id, [FromBody]List<TaskSignupViewModel> model) {
             var currentUser = _allReadyDataAccess.GetUser(User.GetUserId());
             foreach (var taskSignup in model) {
-                await _allReadyDataAccess.UpdateTaskSignupAsync(new TaskUsers {
+                await _allReadyDataAccess.UpdateTaskSignupAsync(new TaskSignup {
                     Id = taskSignup.Id,
                     StatusDateTimeUtc = DateTime.UtcNow,
                     StatusDescription = taskSignup.StatusDescription,

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -150,10 +150,10 @@ namespace AllReady.Controllers
 
             if (task.AssignedVolunteers == null)
             {
-                task.AssignedVolunteers = new List<TaskUsers>();
+                task.AssignedVolunteers = new List<TaskSignup>();
             }
 
-            task.AssignedVolunteers.Add(new TaskUsers
+            task.AssignedVolunteers.Add(new TaskSignup
             {
                 Task = task,
                 User = user,

--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Activity.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Activity.cs
@@ -102,9 +102,9 @@ namespace AllReady.Models
                         .OrderBy(x => x.Activity.StartDateTimeUtc);
         }
 
-        IEnumerable<TaskUsers> IAllReadyDataAccess.GetTasksAssignedToUser(int activityId, string userId)
+        IEnumerable<TaskSignup> IAllReadyDataAccess.GetTasksAssignedToUser(int activityId, string userId)
         {
-            var unfilteredTasks = _dbContext.TaskSignup
+            var unfilteredTasks = _dbContext.TaskSignups
                 .Include(ts => ts.Task)
                 .ThenInclude(t => t.Activity)
                 .Include(ts => ts.User)

--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Task.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Task.cs
@@ -25,7 +25,7 @@ namespace AllReady.Models
 
         AllReadyTask IAllReadyDataAccess.GetTask(int taskId, string userId)
         {
-            var taskUser = _dbContext.TaskSignup.Where(tu => tu.User.Id == userId).SingleOrDefault();
+            var taskUser = _dbContext.TaskSignups.Where(tu => tu.User.Id == userId).SingleOrDefault();
 
             return taskUser == null ? null :
                 _dbContext.Tasks
@@ -42,7 +42,7 @@ namespace AllReady.Models
                 .Include(x => x.Tenant)
                 .Include(x => x.Activity)
                 .Include(x => x.Activity.Campaign)
-                .Include(x => x.AssignedVolunteers)
+                .Include(x => x.AssignedVolunteers).ThenInclude(v => v.User)
                 .Include(x => x.RequiredSkills)
                 .Where(t => t.Id == taskId).SingleOrDefault();
         }

--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.TaskSignup.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.TaskSignup.cs
@@ -9,11 +9,11 @@ namespace AllReady.Models
 {
     public partial class AllReadyDataAccessEF7 : IAllReadyDataAccess
     {
-        IEnumerable<TaskUsers> IAllReadyDataAccess.TaskSignups
+        IEnumerable<TaskSignup> IAllReadyDataAccess.TaskSignups
         {
             get
             {
-                return _dbContext.TaskSignup
+                return _dbContext.TaskSignups
                           .Include(x => x.Task)
                           .Include(x => x.User)
                           .Include(x => x.Task.Activity)
@@ -23,9 +23,9 @@ namespace AllReady.Models
             }
         }
 
-        TaskUsers IAllReadyDataAccess.GetTaskSignup(int taskId, string userId)
+        TaskSignup IAllReadyDataAccess.GetTaskSignup(int taskId, string userId)
         {
-            return _dbContext.TaskSignup
+            return _dbContext.TaskSignups
               .Include(x => x.Task)
               .Include(x => x.User)
               .ToArray()
@@ -34,27 +34,27 @@ namespace AllReady.Models
               .SingleOrDefault();
         }
 
-        Task IAllReadyDataAccess.AddTaskSignupAsync(TaskUsers taskSignup)
+        Task IAllReadyDataAccess.AddTaskSignupAsync(TaskSignup taskSignup)
         {
-            _dbContext.TaskSignup.Add(taskSignup);
+            _dbContext.TaskSignups.Add(taskSignup);
             return _dbContext.SaveChangesAsync();
         }
 
         Task IAllReadyDataAccess.DeleteTaskSignupAsync(int taskSignupId)
         {
-            var taskSignup = _dbContext.TaskSignup.SingleOrDefault(c => c.Id == taskSignupId);
+            var taskSignup = _dbContext.TaskSignups.SingleOrDefault(c => c.Id == taskSignupId);
 
             if (taskSignup != null)
             {
-                _dbContext.TaskSignup.Remove(taskSignup);
+                _dbContext.TaskSignups.Remove(taskSignup);
                 return _dbContext.SaveChangesAsync();
             }
             return null;
         }
 
-        Task IAllReadyDataAccess.UpdateTaskSignupAsync(TaskUsers value)
+        Task IAllReadyDataAccess.UpdateTaskSignupAsync(TaskSignup value)
         {
-            _dbContext.TaskSignup.Update(value);
+            _dbContext.TaskSignups.Update(value);
             return _dbContext.SaveChangesAsync();
         }
     }

--- a/AllReadyApp/Web-App/AllReady/DataAccess/IAllReadyDataAccess.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/IAllReadyDataAccess.cs
@@ -73,15 +73,15 @@ namespace AllReady.Models
         #endregion
 
         #region TaskSignup CRUD
-        IEnumerable<TaskUsers> TaskSignups { get; }
+        IEnumerable<TaskSignup> TaskSignups { get; }
 
-        TaskUsers GetTaskSignup(int taskId, string userId);
+        TaskSignup GetTaskSignup(int taskId, string userId);
 
-        Task AddTaskSignupAsync(TaskUsers taskSignup);
+        Task AddTaskSignupAsync(TaskSignup taskSignup);
 
         Task DeleteTaskSignupAsync(int taskSignupId);
 
-        Task UpdateTaskSignupAsync(TaskUsers value);
+        Task UpdateTaskSignupAsync(TaskSignup value);
         #endregion
 
         #region AllReadyTask CRUD
@@ -96,7 +96,7 @@ namespace AllReady.Models
         Task DeleteTaskAsync(int taskId);
 
         Task UpdateTaskAsync(AllReadyTask value);
-        IEnumerable<TaskUsers> GetTasksAssignedToUser(int activityId, string userId);
+        IEnumerable<TaskSignup> GetTasksAssignedToUser(int activityId, string userId);
 
         #endregion
 

--- a/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
@@ -58,7 +58,8 @@ namespace AllReady.Models
             #endregion
 
             List<Location> locations = GetLocations();
-            List<TaskUsers> users = new List<TaskUsers>();
+            List<ApplicationUser> users = new List<ApplicationUser>();
+            List<TaskSignup> taskSignups = new List<TaskSignup>();
             List<Activity> activities = new List<Activity>();
             List<ActivitySkill> activitySkills = new List<ActivitySkill>();
             List<Campaign> campaigns = new List<Campaign>();
@@ -349,16 +350,33 @@ namespace AllReady.Models
 
             var user1 = new ApplicationUser { UserName = username1, Email = username1, EmailConfirmed = true };
             _userManager.CreateAsync(user1, _configuration["DefaultAdminPassword"]).Wait();
+            users.Add(user1);
             var user2 = new ApplicationUser { UserName = username2, Email = username2, EmailConfirmed = true };
             _userManager.CreateAsync(user2, _configuration["DefaultAdminPassword"]).Wait();
+            users.Add(user2);
             var user3 = new ApplicationUser { UserName = username3, Email = username3, EmailConfirmed = true };
             _userManager.CreateAsync(user3, _configuration["DefaultAdminPassword"]).Wait();
+            users.Add(user3);
             #endregion
 
             #region ActvitySignups
             activitySignups.Add(new ActivitySignup { Activity = madrona, User = user1, SignupDateTime = DateTime.UtcNow });
             activitySignups.Add(new ActivitySignup { Activity = madrona, User = user2, SignupDateTime = DateTime.UtcNow });
             activitySignups.Add(new ActivitySignup { Activity = madrona, User = user3, SignupDateTime = DateTime.UtcNow });
+            #endregion
+
+            #region TaskSignups
+            int i = 0;
+            foreach (var task in tasks.Where(t => t.Activity == madrona))
+            {
+                for (var j = 0; j < i; j++)
+                {
+                    taskSignups.Add(new TaskSignup() { Task = task, User = users[j] });
+                }
+
+                i = (i + 1) % users.Count;
+            }
+            _context.TaskSignups.AddRange(taskSignups);
             #endregion
 
             #region Wrap Up DB  

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
@@ -54,7 +54,7 @@ namespace AllReady.Models
         public DbSet<PostalCodeGeo> PostalCodes { get; set; }
         public DbSet<AllReadyTask> Tasks { get; set; }
         public DbSet<TaskSkill> TaskSkills { get; set; }
-        public DbSet<TaskUsers> TaskSignup { get; set; }
+        public DbSet<TaskSignup> TaskSignups { get; set; }
         public DbSet<Resource> Resources { get; set; }
         public DbSet<Skill> Skills { get; set; }
         public DbSet<UserSkill> UserSkills { get; set; }
@@ -72,7 +72,7 @@ namespace AllReady.Models
             Map(modelBuilder.Entity<ActivitySignup>());
             Map(modelBuilder.Entity<AllReadyTask>());
             Map(modelBuilder.Entity<TaskSkill>());
-            Map(modelBuilder.Entity<TaskUsers>());
+            Map(modelBuilder.Entity<TaskSignup>());
             Map(modelBuilder.Entity<Location>());
             Map(modelBuilder.Entity<PostalCodeGeo>());
             Map(modelBuilder.Entity<Skill>());
@@ -90,7 +90,7 @@ namespace AllReady.Models
             builder.HasOne(l => l.PostalCode);
         }
 
-        private void Map(EntityTypeBuilder<TaskUsers> builder)
+        private void Map(EntityTypeBuilder<TaskSignup> builder)
         {
             builder.HasOne(u => u.Task);
         }

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyTask.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyTask.cs
@@ -14,7 +14,7 @@ namespace AllReady.Models
         public Activity Activity { get; set; }
         public DateTime? StartDateTimeUtc { get; set; }
         public DateTime? EndDateTimeUtc { get; set; }
-        public List<TaskUsers> AssignedVolunteers { get; set; }
+        public List<TaskSignup> AssignedVolunteers { get; set; }
         public List<TaskSkill> RequiredSkills { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Models/TaskSignup.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/TaskSignup.cs
@@ -4,7 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AllReady.Models
 {
-  public class TaskUsers
+  public class TaskSignup
   {
     public int Id { get; set; }
     public AllReadyTask Task { get; set; }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/TaskSignupViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/TaskSignupViewModel.cs
@@ -19,7 +19,7 @@ namespace AllReady.ViewModels
 
         public TaskSignupViewModel() { }
 
-        public TaskSignupViewModel(TaskUsers taskSignup)
+        public TaskSignupViewModel(TaskSignup taskSignup)
         {
             Id = taskSignup.Id;
             Status = taskSignup.Status;

--- a/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
@@ -108,6 +108,8 @@ namespace AllReady.ViewModels
 
         public List<TaskSignupViewModel> AssignedVolunteers { get; set; } = new List<TaskSignupViewModel>();
 
+        public int AcceptedVolunteerCount => AssignedVolunteers?.Where(v => v.Status == "Accepted").Count() ?? 0;
+
         public TaskViewModel(AllReadyTask task, bool isUserSignedupForTask)
             : this(task)
         {
@@ -180,7 +182,7 @@ namespace AllReady.ViewModels
 
             if (taskViewModel.AssignedVolunteers != null && taskViewModel.AssignedVolunteers.Count > 0)
             {
-                var taskUsersList = taskViewModel.AssignedVolunteers.Select(tvm => new TaskUsers
+                var taskUsersList = taskViewModel.AssignedVolunteers.Select(tvm => new TaskSignup
                 {
                     Task = dbtask,
                     User = dataAccess.GetUser(tvm.UserId)
@@ -194,7 +196,7 @@ namespace AllReady.ViewModels
                 else
                 {
                     // Can probably rewrite this more efficiently.
-                    foreach (TaskUsers taskUsers in taskUsersList)
+                    foreach (TaskSignup taskUsers in taskUsersList)
                     {
                         if (!(from entry in dbtask.AssignedVolunteers
                               where entry.User.Id == taskUsers.User.Id


### PR DESCRIPTION
Resolves #44

This adds the usernames and status to the table of tasks on the admin
activity details page.
- No volunteers displays *
- One voluteer displays username + status
- Multiple volunteers shows a link to task details + "X / Y Accepted"

![image](https://cloud.githubusercontent.com/assets/1430011/11012818/4622a2c0-84af-11e5-9f6a-1b7d82d59cd2.png)


This also adds a similar table to the admin task page.

![image](https://cloud.githubusercontent.com/assets/1430011/11012820/55537062-84af-11e5-9bd9-df4512b22e84.png)


Note that nothing current sets the Status/StatusDescription for a
task->user signup, so it will be blank for now.