### PR TITLE
Prompt for uploading image on Activity/Campaign pages set to 'Browse for image'

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ActivitySummaryModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ActivitySummaryModel.cs
@@ -25,6 +25,7 @@ namespace AllReady.Areas.Admin.Models
         [Display(Name = "Organization")]
         public string TenantName { get; set; }
 
+        [Display(Name = "Browse for image")]
         public string ImageUrl { get; set; }
 
         [Display(Name = "Volunteers Required")]

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/CampaignSummaryModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/CampaignSummaryModel.cs
@@ -29,7 +29,7 @@ namespace AllReady.Areas.Admin.Models
         [Display(Name = "Organization")]
         public string TenantName { get; set; }
 
-        [Display(Name = "Image URL")]
+        [Display(Name = "Browse for image")]
         public string ImageUrl { get; set; }
             
         [Display(Name = "Start Date")]

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Edit.cshtml
@@ -125,9 +125,14 @@
     <h2>Image</h2>
     <div class="form-horizontal">
         <div class="form-group">
-            @Html.LabelFor(model => model.ImageUrl, htmlAttributes: new { @class = "control-label col-md-2" })
+            <div class="col-md-2">&nbsp;</div>
             <div class="col-md-10">
                 <img src="@Model.ImageUrl" class="img-thumbnail img-responsive col-md-4" />
+            </div>
+        </div>
+        <div class="form-group">
+            @Html.LabelFor(model => model.ImageUrl, htmlAttributes: new { @class = "control-label col-md-2" })
+            <div class="col-md-10">
                 <form action="~/Admin/Activity/PostActivityFile" method="post" enctype="multipart/form-data">
                     @Html.AntiForgeryToken()
                     <input type="hidden" name="id" id="activiteyId" value="@Model.Id" />

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
@@ -116,9 +116,14 @@
     <h2>Image</h2>
     <div class="form-horizontal">
         <div class="form-group">
-            @Html.LabelFor(model => model.ImageUrl, htmlAttributes: new { @class = "control-label col-md-2" })
+            <div class="col-md-2">&nbsp;</div>
             <div class="col-md-10">
                 <img src="@Model.ImageUrl" class="img-thumbnail img-responsive col-md-4" />
+            </div>
+        </div>
+        <div class="form-group">
+            @Html.LabelFor(model => model.ImageUrl, htmlAttributes: new { @class = "control-label col-md-2" })
+            <div class="col-md-10">
                 <form action="~/Admin/Campaign/PostCampaignFile" method="post" enctype="multipart/form-data">
                     @Html.AntiForgeryToken()
                     <input type="hidden" name="id" id="campaignId" value="@Model.Id" />


### PR DESCRIPTION
For review.

This fixes #278.

It also does the same for the Campaign page.

And it adjusts the layout a bit so that the 'Browse' prompt is always inline with the file upload control, and not the image itself.

