### PR TITLE
Remove font size from active. Fixes #315.

### DIFF
--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -136,7 +136,6 @@ Navigation
 
 .navbar-default .navbar-nav > li > a, .navbar-default .navbar-nav > li > a:active, .navbar-default .navbar-nav > li > a:visited, .navbar-default .navbar-nav > li > a:focus {
     color: #fff;
-    font-size: 1.4em;
 }
 
 .navbar-default .navbar-nav > li:hover, .navbar-default .navbar-nav > li:active, .navbar-default .navbar-nav > li:focus {


### PR DESCRIPTION
There should be no reason to override the font size in the active state. We should never be changing the fontsize in active or it look jaggidy, just allow the existing font size to cascade. 