### PR TITLE
Improvements to image handling in Admin Activity/Campaign pages

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignController.cs
@@ -57,50 +57,7 @@ namespace AllReady.Controllers
             return View("Edit", new CampaignSummaryModel());
         }
 
-        // POST: Campaign/Create
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Create(CampaignSummaryModel campaign, IFormCollection form)
-        {
-            if (campaign == null)
-            {
-                return HttpBadRequest();
-            }
-
-            if (!User.IsTenantAdmin(campaign.TenantId))
-            {
-                return HttpUnauthorized();
-            }
-
-            if (ModelState.IsValid)
-            {
-                if (form.Files.Count > 0)
-                {
-                    // If the form contains a file, upload it and update the ImageUrl.
-                    if (form.Files[0] != null)
-                    {
-                        var file = form.Files[0];
-
-                        if (file.IsAcceptableImageContentType())
-                        {
-                            campaign.ImageUrl = await _imageService.UploadCampaignImageAsync(campaign.Id, campaign.TenantId, form.Files[0]);
-                        }
-                        else
-                        {
-                            ModelState.AddModelError("ImageUrl", "You must upload a valid image file for the logo (.jpg, .png, .gif)");
-                            return View(campaign);
-                        }
-                    }
-                }
-
-                int id = _bus.Send(new EditCampaignCommand { Campaign = campaign });
-                return RedirectToAction("Details", new {id = id, area = "Admin" });
-            }
-
-            return View("Edit", campaign);
-        }
-
-        // GET: Campaign/Edit/5
+         // GET: Campaign/Edit/5
         public IActionResult Edit(int id)
         {
             CampaignSummaryModel campaign = _bus.Send(new CampaignSummaryQuery { CampaignId = id });
@@ -121,7 +78,7 @@ namespace AllReady.Controllers
         // POST: Campaign/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(CampaignSummaryModel campaign, IFormCollection form)
+        public async Task<IActionResult> Edit(CampaignSummaryModel campaign, IFormFile fileUpload)
         {
             if (campaign == null)
             {
@@ -135,22 +92,16 @@ namespace AllReady.Controllers
 
             if (ModelState.IsValid)
             {
-                if (form.Files.Count > 0)
+                if (fileUpload != null)
                 {
-                    // If the form contains a file, upload it and update the ImageUrl.
-                    if (form.Files[0] != null)
+                    if (fileUpload.IsAcceptableImageContentType())
                     {
-                        var file = form.Files[0];
-                        
-                        if (file.IsAcceptableImageContentType())
-                        {
-                            campaign.ImageUrl = await _imageService.UploadCampaignImageAsync(campaign.Id, campaign.TenantId, form.Files[0]);
-                        }
-                        else
-                        {
-                            ModelState.AddModelError("FileUpload", "You must upload a valid image file for the logo (.jpg, .png, .gif)");
-                            return View(campaign);
-                        }
+                        campaign.ImageUrl = await _imageService.UploadCampaignImageAsync(campaign.TenantId, campaign.Id, fileUpload);
+                    }
+                    else
+                    {
+                        ModelState.AddModelError("ImageUrl", "You must upload a valid image file for the logo (.jpg, .png, .gif)");
+                        return View(campaign);
                     }
                 }
 
@@ -192,17 +143,5 @@ namespace AllReady.Controllers
             return RedirectToAction("Index", new { area = "Admin" });
         }
 
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        public async Task<IActionResult> PostCampaignFile(int id, IFormFile file)
-        {
-            var campaign = _dataAccess.GetCampaign(id);
-
-            campaign.ImageUrl = await _imageService.UploadCampaignImageAsync(campaign.Id, campaign.ManagingTenantId, file);
-            await _dataAccess.UpdateCampaign(campaign);
-
-            return RedirectToRoute(new { controller = "Campaign", Area = "Admin", action = "Edit", id = id });
-
-        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/EditActivityCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/EditActivityCommandHandler.cs
@@ -31,6 +31,7 @@ namespace AllReady.Areas.Admin.Features.Activities
             activity.StartDateTimeUtc = message.Activity.StartDateTime;
             activity.EndDateTimeUtc = message.Activity.EndDateTime;
             activity.CampaignId = message.Activity.CampaignId;
+            activity.ImageUrl = message.Activity.ImageUrl;
             activity.TenantId = _context.Campaigns.Single(c => c.Id == activity.CampaignId).ManagingTenantId;
             activity.NumberOfVolunteersRequired = message.Activity.NumberOfVolunteersRequired;
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ActivitySummaryModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ActivitySummaryModel.cs
@@ -25,8 +25,10 @@ namespace AllReady.Areas.Admin.Models
         [Display(Name = "Organization")]
         public string TenantName { get; set; }
 
-        [Display(Name = "Browse for image")]
         public string ImageUrl { get; set; }
+
+        [Display(Name = "Browse for image")]
+        public string FileUpload { get; set; }
 
         [Display(Name = "Volunteers Required")]
         public int NumberOfVolunteersRequired { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Edit.cshtml
@@ -5,15 +5,18 @@
 @{
     //TODO: Need a better way of identifying Create vs Edit. Suggest not binding directly to model class, create view model instead
     var isEdit = Model.Id != 0;
+    string actionTitle;
     string cancelUrl;
     if (isEdit)
     {
         ViewBag.Title = $"Edit Activity";
+        actionTitle = "Save";
         cancelUrl = Url.Action("Details", "Activity", new { id = Model.Id, area = "Admin" });
     }
     else
     {
         ViewBag.Title = "Create Activity";
+        actionTitle = "Create";
         cancelUrl = Url.Action("Details", "Campaign", new { id = Model.CampaignId, area = "Admin" });
     }
 }
@@ -39,13 +42,12 @@
 
 <h2>@ViewBag.Title</h2>
 
-@using (Html.BeginForm())
-{
-    @Html.AntiForgeryToken()
+<form asp-controller="Activity" asp-route-area="Admin" method="post" enctype="multipart/form-data">
 
-    <div class="row">
+    <div class="form-horizontal">
+        <hr />
         <div class="form-horizontal col-lg-6 pull-left">
-            <div asp-validation-summary="ValidationSummary.ModelOnly" class="text-danger"></div>
+            <div asp-validation-summary="ValidationSummary.All" class="text-danger"></div>
             <input asp-for="Id" type="hidden" />
             <input asp-for="CampaignId" type="hidden" />
             <input asp-for="CampaignName" type="hidden" />
@@ -68,7 +70,7 @@
             <div class="form-group">
                 <label asp-for="NumberOfVolunteersRequired" class="control-label col-md-2"></label>
                 <div class="col-md-10">
-                    <input asp-for="NumberOfVolunteersRequired" class="form-control"></input>
+                    <input asp-for="NumberOfVolunteersRequired" class="form-control" />
                     <span asp-validation-for="NumberOfVolunteersRequired" class="text-danger"></span>
                 </div>
             </div>
@@ -87,7 +89,7 @@
                 </div>
             </div>
             <div class="form-group">
-                <label asp-for="RequiredSkills" class="control-label col-md-2"></label>
+                <label asp-for="RequiredSkills" class="control-label col-md-2" style="padding-top: 0"></label>
                 <div class="col-md-10">
                     <div data-bind="foreach: requiredSkills">
                         <div class="form-inline">
@@ -101,52 +103,46 @@
                     </div>
                     <a href="#" data-bind="click: addSkill" title="Add required skill">
                         <span class="fa fa-plus" aria-hidden="true"></span>
-                        Add
-                    </a>
+                        Add</a>
+                    <span class="label label-danger" data-bind="visible: !requiredSkills.isValid()">@Html.DisplayNameFor(m => m.RequiredSkills) must be unique</span>
                 </div>
             </div>
-            <div class="form-group">
-                <div class="col-md-offset-2 col-md-10">
-                    <button type="submit" class="btn btn-default" data-bind="enable: requiredSkills.isValid">Save</button>
-                    <a href="@cancelUrl" class="btn btn-default">Cancel</a>
-                    <span class="label label-danger" data-bind="visible: !requiredSkills.isValid()">@Html.DisplayNameFor(m => m.RequiredSkills)" must be unique</span>
-                </div>
-            </div>
+
         </div>
         <div class="col-lg-6 pull-right">
             <div id="mapArea" style="width:400px;height:400px"></div>
         </div>
-    </div>
- 
-}
 
-@if (isEdit)
-{
-    <h2>Image</h2>
-    <div class="form-horizontal">
-        <div class="form-group">
-            <div class="col-md-2">&nbsp;</div>
-            <div class="col-md-10">
-                <img src="@Model.ImageUrl" class="img-thumbnail img-responsive col-md-4" />
+        <h2>Image</h2>
+        <div class="form-horizontal col-lg-6 pull-left">
+            @if (!string.IsNullOrWhiteSpace(Model.ImageUrl))
+            {
+                <div class="form-group">
+                    <div class="col-md-2">&nbsp;</div>
+                    <div class="col-md-10">
+                        <img src="@Model.ImageUrl" class="img-thumbnail img-responsive col-md-4" />
+                    </div>
+                </div>
+            }
+            <div class="form-group">
+                <label asp-for="FileUpload" class="col-md-2 control-label"></label>
+                <div class="col-md-10">
+                    <input type="file" asp-for="FileUpload" class="control-label col-md-4" />
+                    <span asp-validation-for="FileUpload" class="text-danger col-md-12"></span>
+                </div>
             </div>
         </div>
-        <div class="form-group">
-            @Html.LabelFor(model => model.ImageUrl, htmlAttributes: new { @class = "control-label col-md-2" })
-            <div class="col-md-10">
-                <form action="~/Admin/Activity/PostActivityFile" method="post" enctype="multipart/form-data">
-                    @Html.AntiForgeryToken()
-                    <input type="hidden" name="id" id="activiteyId" value="@Model.Id" />
-                    <div class="form-group">
-                        <div class="col-md-10">
-                            <input type="file" name="file" id="newFile" class="control-label col-md-4" />
-                            <button type="submit" class="btn col-md-1">Upload</button>
-                        </div>
-                    </div>
-                </form>
-            </div>
+
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <button type="submit" value="@actionTitle" class="btn btn-default" data-bind="enable: requiredSkills.isValid">@actionTitle</button>
+            <a href="@cancelUrl" class="btn btn-default">Cancel</a>        
         </div>
     </div>
-}
+</form>
+
 
 @section scripts {
     <script src="~/js/activitymap.js"></script>


### PR DESCRIPTION
For review.

This fixes #48: the problem whereby the Admin Activity Create/Edit pages bombed on image upload if no image was selected.  Page was brought into line with recently completed Campaign Create/Edit page - that is, the file upload is now on the same form as everything else and images can be uploaded when creating an Activity.

Made a few minor HTML adjustments to tidy up page.  And removed a number of action methods that were now no longer being called: `AdminActivityController.PostActvityFile()`, `AdminCampaignController.PostCampaignFile()`, and `AdminCampaignController.Create()` (`POST` version). 

I also noticed and fixed a problem with the Campaign Create page, whereby the image was being uploaded before the Campaign was created, and so the image was being stored to `/tenantId/`0`/filename`.

It also fixes #328 where the Campaign Create/Edit page required an image to be selected for upload if the form was to be successfully processed.

Finally, I think it should close out #302 by fixing a lingering issue mentioned therein, whereby the calls to `UploadActivityImageAsync` and `UploadCampaignImageAsync` had two of their parameters in the wrong order.