### PR TITLE
Removal of extra class 'IRequestHandler<T>'

### DIFF
--- a/AllReadyApp/Web-App/AllReady/IRequestHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/IRequestHandler.cs
@@ -1,6 +1,0 @@
-﻿namespace AllReady.Areas.Admin.Features.Tenants
-{
-    public interface IRequestHandler<T>
-    {
-    }
-}


### PR DESCRIPTION
- not in use/wrong namespace/no matching signature implementation
- looks like it was added accidentally as part of an earlier commit