### PR TITLE
Fix CampaignImpact to get activities back on the campaign detail page (yes, really)

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignController.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 using AllReady.Services;
 using AllReady.Extensions;
 
-namespace AllReady.Controllers
+namespace AllReady.Areas.Admin.Controllers
 {
     [Area("Admin")]
     [Authorize("TenantAdmin")]

--- a/AllReadyApp/Web-App/AllReady/Controllers/CampaignController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/CampaignController.cs
@@ -5,7 +5,7 @@ using AllReady.Models;
 using AllReady.ViewModels;
 using Microsoft.Data.Entity;
 
-namespace AllReady.Areas.Admin.Controllers
+namespace AllReady.Controllers
 {
     [Route("api/[controller]")]
     public class CampaignController : Controller

--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Campaign.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Campaign.cs
@@ -25,8 +25,8 @@ namespace AllReady.Models
         {
             return _dbContext.Campaigns
                 .Include(x => x.ManagingTenant)
-                .Include(x => x.CampaignImpact)
                 .Include(x => x.Activities)
+                .Include(x => x.CampaignImpact)
                 .Include(x => x.ParticipatingTenants)
                 .SingleOrDefault(x => x.Id == campaignId);
         }

--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Campaign.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Campaign.cs
@@ -25,8 +25,8 @@ namespace AllReady.Models
         {
             return _dbContext.Campaigns
                 .Include(x => x.ManagingTenant)
-                .Include(x => x.Activities)
                 .Include(x => x.CampaignImpact)
+                .Include(x => x.Activities)
                 .Include(x => x.ParticipatingTenants)
                 .SingleOrDefault(x => x.Id == campaignId);
         }

--- a/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
@@ -91,20 +91,22 @@ namespace AllReady.Models
                 ManagingTenant = htb
             };
             htb.Campaigns.Add(firePrev);
+            var smokeDetImpact = new CampaignImpact
+            {
+                ImpactType = ImpactType.Numeric,
+                NumericImpactGoal = 10000,
+                CurrentImpactLevel = 6722,
+                Display = true,
+                TextualImpactGoal = "Total number of smoke detectors installed."
+            };
+            _context.CampaignImpacts.Add(smokeDetImpact);
             Campaign smokeDet = new Campaign()
             {
                 Name = "Working Smoke Detectors Save Lives",
                 ManagingTenant = htb,
                 StartDateTimeUtc = DateTime.Today.AddMonths(-1).ToUniversalTime(),
                 EndDateTimeUtc = DateTime.Today.AddMonths(1).ToUniversalTime(),
-                CampaignImpact = new CampaignImpact
-                {
-                    ImpactType = ImpactType.Numeric,
-                    NumericImpactGoal = 10000,
-                    CurrentImpactLevel = 6722,
-                    Display=true,
-                    TextualImpactGoal = "Total number of smoke detectors installed."
-                }
+                CampaignImpact = smokeDetImpact
             };
             htb.Campaigns.Add(smokeDet);
             Campaign financial = new Campaign()

--- a/AllReadyApp/Web-App/AllReady/Migrations/20151115213625_DropCampaignImpact.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20151115213625_DropCampaignImpact.Designer.cs
@@ -8,9 +8,10 @@ using AllReady.Models;
 namespace AllReady.Migrations
 {
     [DbContext(typeof(AllReadyContext))]
-    partial class AllReadyContextModelSnapshot : ModelSnapshot
+    [Migration("20151115213625_DropCampaignImpact")]
+    partial class DropCampaignImpact
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .Annotation("ProductVersion", "7.0.0-beta8-15964")

--- a/AllReadyApp/Web-App/AllReady/Migrations/20151115213625_DropCampaignImpact.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20151115213625_DropCampaignImpact.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Migrations;
+
+namespace AllReady.Migrations
+{
+    public partial class DropCampaignImpact : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable("CampaignImpact");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CampaignImpact",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false),
+                    CurrentImpactLevel = table.Column<int>(nullable: false),
+                    Display = table.Column<bool>(nullable: false),
+                    ImpactType = table.Column<int>(nullable: false),
+                    NumericImpactGoal = table.Column<int>(nullable: false),
+                    TextualImpactGoal = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CampaignImpact", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CampaignImpact_Campaign_Id",
+                        column: x => x.Id,
+                        principalTable: "Campaign",
+                        principalColumn: "Id");
+                });
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20151115214252_ReAddCampaignImpact.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20151115214252_ReAddCampaignImpact.Designer.cs
@@ -8,9 +8,10 @@ using AllReady.Models;
 namespace AllReady.Migrations
 {
     [DbContext(typeof(AllReadyContext))]
-    partial class AllReadyContextModelSnapshot : ModelSnapshot
+    [Migration("20151115214252_ReAddCampaignImpact")]
+    partial class ReAddCampaignImpact
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .Annotation("ProductVersion", "7.0.0-beta8-15964")

--- a/AllReadyApp/Web-App/AllReady/Migrations/20151115214252_ReAddCampaignImpact.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20151115214252_ReAddCampaignImpact.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Migrations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace AllReady.Migrations
+{
+    public partial class ReAddCampaignImpact : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CampaignImpact",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    CurrentImpactLevel = table.Column<int>(nullable: false),
+                    Display = table.Column<bool>(nullable: false),
+                    ImpactType = table.Column<int>(nullable: false),
+                    NumericImpactGoal = table.Column<int>(nullable: false),
+                    TextualImpactGoal = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CampaignImpact", x => x.Id);
+                });
+            migrationBuilder.AddColumn<int>(
+                name: "CampaignImpactId",
+                table: "Campaign",
+                nullable: true);
+            migrationBuilder.AddForeignKey(
+                name: "FK_Campaign_CampaignImpact_CampaignImpactId",
+                table: "Campaign",
+                column: "CampaignImpactId",
+                principalTable: "CampaignImpact",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(name: "FK_Campaign_CampaignImpact_CampaignImpactId", table: "Campaign");
+            migrationBuilder.DropColumn(name: "CampaignImpactId", table: "Campaign");
+            migrationBuilder.DropTable("CampaignImpact");
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Models/Campaign.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Campaign.cs
@@ -45,6 +45,7 @@ namespace AllReady.Models
 
         public ApplicationUser Organizer { get; set; }
 
+        public int? CampaignImpactId { get; set; }
         public CampaignImpact CampaignImpact { get; set; }
 
         public Location Location { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Models/CampaignImpact.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/CampaignImpact.cs
@@ -8,7 +8,7 @@ namespace AllReady.Models
     public class CampaignImpact
     {
         public int Id { get; set; }
-        public Campaign Campaign { get; set; }
+
         public ImpactType ImpactType { get; set; }
         /// <summary>
         /// If the impact type is numeric, the value is the number


### PR DESCRIPTION
~~This is a **TEMPORARY** fix to #351. This will get activities to show up again on the campaign detail page but the main problem is that there are some problems with how the CampaignImpact table is defined in the database, but I haven'y fully figured that out yet. This can be merged, but there will be more to come.~~

Closes #351. The relationship between `CampaignImpact` and `Campaign` was messed up causing EF to behave in undesired, weird ways that I don't understand. The SQL schema generated for `CampaignImpact` made `Id` not a private key identity, but a foreign key link to `Campaign.Id`. This meant that the only possible valid `CampaignImpact` Ids are Campaign IDs and EF was having none of it. **Now**, I've added `Campaign.CampaignImpactId` as a foreign key to `CampaignImpact.Id` and `CampaignImpact.Id` is now a private key identity. 

**WARNING** This fix is destructive because it has to burn down and re-create the CampaignImpact table to ensure its `Id` column properly set up as a PKI. I thought I could get this done with incremental migrations, and even though there was a command in the migration that said to set the Id column to be an identity, SQL didn't make it happen. Bankruptcy was the only other way through.

Also fixed a namespace mixup between the `CampaignController` classes.