### PR TITLE
Simple HTML-enabling fix

### DIFF
--- a/AllReadyApp/AllReady.Models/Notifications/QueuedEmailMessage.cs
+++ b/AllReadyApp/AllReady.Models/Notifications/QueuedEmailMessage.cs
@@ -4,6 +4,7 @@
     {
         public string Recipient { get; set; }
         public string Message { get; set; }
+        public string HtmlMessage { get; set; }
         public string Subject { get; set; }
 
         // todo: augment this class to support mail service templates and/or html messages

--- a/AllReadyApp/NotificationsProcessor/Functions.cs
+++ b/AllReadyApp/NotificationsProcessor/Functions.cs
@@ -47,6 +47,7 @@ namespace NotificationsProcessor
             myMessage.AddTo(emailMessage.Recipient);
             myMessage.From = new MailAddress(from, "AllReady");
             myMessage.Subject = emailMessage.Subject;
+            myMessage.Html = emailMessage.HtmlMessage;
             myMessage.Text = emailMessage.Message;
 
             // Create credentials, specifying your user name and password.

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/MessageActivityVolunteersCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/MessageActivityVolunteersCommandHandler.cs
@@ -43,6 +43,7 @@ namespace AllReady.Areas.Admin.Features.Activities
                     SmsMessage = message.Model.Message,
                     SmsRecipients = smsRecipients,
                     EmailMessage = message.Model.Message,
+                    HtmlMessage = message.Model.Message,
                     EmailRecipients = emailRecipients,
                     Subject = message.Model.Subject
                 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/AssignTaskCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/AssignTaskCommandHandler.cs
@@ -74,6 +74,7 @@ namespace AllReady.Areas.Admin.Features.Tasks
                     SmsMessage = "You've been assigned a task from AllReady.",
                     SmsRecipients = smsRecipients,
                     EmailMessage = "You've been assigned a task from AllReady.",
+                    HtmlMessage = "You've been assigned a task from AllReady.",
                     EmailRecipients = emailRecipients,
                     Subject = "You've been assigned a task from AllReady."
                 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/MessageTaskVolunteersCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/MessageTaskVolunteersCommandHandler.cs
@@ -44,6 +44,7 @@ namespace AllReady.Areas.Admin.Features.Tasks
                     SmsMessage = message.Model.Message,
                     SmsRecipients = smsRecipients,
                     EmailMessage = message.Model.Message,
+                    HtmlMessage = message.Model.Message,
                     EmailRecipients = emailRecipients,
                     Subject = message.Model.Subject
                 }

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForActivitySignup.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForActivitySignup.cs
@@ -35,11 +35,13 @@ namespace AllReady.Features.Notifications
 
             if (campaign.Organizer != null)
             {
+                var message = $"Your {campaign.Name} campaign activity '{activity.Name}' has a new volunteer. {volunteer.UserName} can be reached at {volunteer.Email}. {link}";
                 var command = new NotifyVolunteersCommand
                 {
                     ViewModel = new NotifyVolunteersViewModel
                     {
-                        EmailMessage = $"Your {campaign.Name} campaign activity '{activity.Name}' has a new volunteer. {volunteer.UserName} can be reached at {volunteer.Email}. {link}",
+                        EmailMessage = message,
+                        HtmlMessage = message,
                         EmailRecipients = new List<string> { campaign.Organizer.Email },
                         Subject = subject
                     }

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForTaskSignupStatusChange.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForTaskSignupStatusChange.cs
@@ -46,17 +46,20 @@ namespace AllReady.Features.Notifications
             {
                 var link = $"View activity: http://{_options.Value.SiteBaseUrl}/Admin/Task/Details/{taskSignup.Task.Id}";
                 var subject = $"Task status changed ({taskSignup.Status}) for volunteer {volunteer.Name ?? volunteer.Email}";
+
+                var message = $@"A volunteer's status has changed for a task.
+                                    Volunteer: {volunteer.Name} ({volunteer.Email})
+                                    New status: {taskSignup.Status}
+                                    Task: {task.Name} {link}
+                                    Activity: {activity.Name}
+                                    Campaign: {campaign.Name}";
+
                 var command = new NotifyVolunteersCommand
                 {
                     ViewModel = new NotifyVolunteersViewModel
                     {
-                        EmailMessage = $@"A volunteer's status has changed for a task.
-
-Volunteer: {volunteer.Name} ({volunteer.Email})
-New status: {taskSignup.Status}
-Task: {task.Name} {link}
-Activity: {activity.Name}
-Campaign: {campaign.Name}",
+                        EmailMessage = message,
+                        HtmlMessage = message,
                         EmailRecipients = new List<string> { adminEmail },
                         Subject = subject
                     }

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteersHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteersHandler.cs
@@ -34,7 +34,8 @@ namespace AllReady.Features.Notifications
                 var queuedEmail = new QueuedEmailMessage
                 {
                     Recipient = recipient,
-                    Message = message.ViewModel.EmailMessage, 
+                    Message = message.ViewModel.EmailMessage,
+                    HtmlMessage = message.ViewModel.HtmlMessage,
                     Subject = message.ViewModel.Subject
                 };
                 var email = JsonConvert.SerializeObject(queuedEmail);

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteersViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteersViewModel.cs
@@ -15,5 +15,6 @@ namespace AllReady.Features.Notifications
         public string EmailMessage { get; set; }
         public List<string> EmailRecipients { get; set; }
         public string Subject { get; set; }
+        public string HtmlMessage { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Services/MessageServices.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/MessageServices.cs
@@ -22,6 +22,7 @@ namespace AllReady.Services
                 {
                     EmailMessage = message,
                     EmailRecipients = new List<string> {email},
+                    HtmlMessage = message,
                     Subject = subject
                 }
             };


### PR DESCRIPTION

This is not the be-all-end-all solution. We need to progress (longer term) the templates idea from SendGrid.

- extended models to add HTML field
- updated view models affected by HTML
- updated email confirmation to set HTML
- updated service to push HTML out with email

Fixes #359