### PR TITLE
Adding disply of user name from profile

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Security/ClaimTypes.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/ClaimTypes.cs
@@ -14,5 +14,10 @@
         /// The type of user
         /// </summary>
         public const string UserType = "ar:usertype";
+
+        /// <summary>
+        /// The display name of the user
+        /// </summary>
+        public const string DisplayName = "ar:displayname";
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Security/ClaimsExtensions.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/ClaimsExtensions.cs
@@ -43,6 +43,17 @@ namespace AllReady.Security
             return result;
         }
 
+        public static string GetDisplayName(this ClaimsPrincipal user)
+        {
+            var username = user.GetUserName();
+            if (user.Claims.FirstOrDefault(c => c.Type == ClaimTypes.DisplayName) != null)
+            {
+                username = user.Claims.Single(c => c.Type == ClaimTypes.DisplayName).Value;
+            }
+            return username;
+
+        }
+
         public static int? GetTenantId(this ApplicationUser user)
         {
             int? result = null;

--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_LoginPartial.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_LoginPartial.cshtml
@@ -1,11 +1,13 @@
 ﻿@using System.Security.Claims
+@using System.Threading.Tasks
+@using AllReady.Security
 
 @if (User.Identity.IsAuthenticated)
 {
     <form asp-controller="Account" asp-action="LogOff" method="post" id="logoutForm">
         <ul class="nav navbar-nav navbar-right login-status">
             <li>
-                <a asp-controller="Manage" asp-action="Index" title="Manage">Hello @User.GetUserName()!</a>
+                <a asp-controller="Manage" asp-action="Index" title="Manage">Hello @User.GetDisplayName()!</a>
             </li>
             <li><a href="javascript:document.getElementById('logoutForm').submit()"><i class="fa fa-sign-out"></i>&nbsp;&nbsp;Log off</a></li>
         </ul>


### PR DESCRIPTION
When adding or modifying the name on the profile, the appropriate claim is also updated. This negates the need to go to the database to look up the user's name from their profile. Would be better (long term) to have this be something that is processed through Mediator.

 - added claim type
 - updated controller
 - added view

Resolves #273