### PR TITLE
Updated AuthMessageSenderTests to be explicit about set properties.

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/AuthMessageSenderTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/AuthMessageSenderTests.cs
@@ -1,4 +1,7 @@
 ﻿
+using System.Collections.Generic;
+using System.Linq;
+using AllReady.Features.Notifications;
 using AllReady.Services;
 using MediatR;
 using Moq;
@@ -19,7 +22,14 @@ namespace AllReady.UnitTest.Services
             var bus = MockIMediator();
             var messageSender = new AuthMessageSender(bus.Object);
             messageSender.SendEmailAsync(emailRecipient, emailSubject, emailMessage);
-            bus.Verify(mock => mock.Send(It.IsAny<IRequest>()), Times.Exactly(1));
+
+            bus.Verify(mock => mock.Send(
+                It.Is<NotifyVolunteersCommand>(request => 
+                request.ViewModel.EmailMessage == emailMessage
+                && request.ViewModel.EmailRecipients.SequenceEqual(new List<string> {emailRecipient})
+                && request.ViewModel.HtmlMessage == emailMessage
+                && request.ViewModel.Subject == emailSubject)),
+                Times.Exactly(1));
         }
 
         [Fact]
@@ -32,18 +42,21 @@ namespace AllReady.UnitTest.Services
             var bus = MockIMediator();
             var messageSender = new AuthMessageSender(bus.Object);
             messageSender.SendSmsAsync(smsRecipient, smsMesssage);
-            bus.Verify(mock => mock.Send(It.IsAny<IRequest>()), Times.Exactly(1));
+            bus.Verify(mock => mock.Send(
+                It.Is<NotifyVolunteersCommand>(request => 
+                request.ViewModel.SmsMessage == smsMesssage
+                && request.ViewModel.SmsRecipients.SequenceEqual(new List<string> {smsRecipient}))),
+                Times.Exactly(1));
         }
 
         /// <summary>
         /// Mocks an IMediator.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        private Mock<IMediator> MockIMediator()
+        private static Mock<IMediator> MockIMediator()
         {
             var busMock = new Mock<IMediator>();
-            busMock.Setup(mock => mock.Send(It.IsAny<IRequest>())).Verifiable();
+            busMock.Setup(mock => mock.Send(It.IsAny<NotifyVolunteersCommand>())).Verifiable();
             return busMock;
         }
     }


### PR DESCRIPTION
In a recent PR a property was added to the NotifyVolunteersViewModel and the AuthMessageSendeTests did not break. This update should address that to encourage coverage.