### PR TITLE
Correcting reset password from admin page

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -125,8 +125,8 @@ namespace AllReady.Areas.Admin.Controllers
                 // Send an email with this link
                 var code = await _userManager.GeneratePasswordResetTokenAsync(user);
                 var callbackUrl = Url.Action("ResetPassword", "Admin", new { userId = user.Id, code = code }, protocol: HttpContext.Request.Scheme);
-                //await _emailSender.SendEmailAsync(user.Email, "Reset Password",
-                //   "Please reset your password by clicking here: <a href=\"" + callbackUrl + "\">link</a>");
+                await _emailSender.SendEmailAsync(user.Email, "Reset Password",
+                   "Please reset your password by clicking here: <a href=\"" + callbackUrl + "\">link</a>");
                 ViewBag.SuccessMessage = $"Sent password reset email for {user.UserName}.";
                 return View();
 


### PR DESCRIPTION
- code was commented out (not sure why)
- enabled the reset/send workflow for admins from the site page

Fixes #366