### PR TITLE
Allow admins to send password resets to unconfirmed email addresses

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -109,15 +109,16 @@ namespace AllReady.Areas.Admin.Controllers
             return RedirectToAction(nameof(Index));
         }
 
+        //TODO: This should be an HttpPost but that also requires changes to the view that is calling this
         [HttpGet]
         public async Task<IActionResult> ResetPassword(string userId)
         {
             try
             {
                 var user = _dataAccess.GetUser(userId);
-                if (user == null || !(await _userManager.IsEmailConfirmedAsync(user)))
+                if (user == null)
                 {
-                    ViewBag.ErrorMessage = $"Failed to reset password for {user.UserName}, email not confirmed.";
+                    ViewBag.ErrorMessage = $"User not found.";
                     return View();
                 }
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
@@ -36,6 +36,10 @@
                         {
                             <span class="label label-default"><span class="fa fa-users"></span> Org</span>
                         }
+                        @if(!item.EmailConfirmed)
+                        {
+                            <span class="fa fa-exclamation-triangle text-warning" title="Email Address not confirmed"></span>
+                        }
                     </td>
                     <td>
                         <div class="btn-group btn-group-sm">


### PR DESCRIPTION
Also displaying a warning icon when user's email address is not verified so the admins know which email addresses are not verified.

Closes #365 
