### PR TITLE
Password minimum length is now set to 10 (as per Identity service configuration in Startup.cs)

### DIFF
--- a/AllReadyApp/Web-App/AllReady/ViewModels/AccountViewModels.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/AccountViewModels.cs
@@ -46,7 +46,7 @@ namespace AllReady.Models
         public string Email { get; set; }
 
         [Required]
-        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 6)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 10)]
         [DataType(DataType.Password)]
         public string Password { get; set; }
 
@@ -87,7 +87,7 @@ namespace AllReady.Models
         public string Email { get; set; }
 
         [Required]
-        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 6)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 10)]
         [DataType(DataType.Password)]
         [Display(Name = "Password")]
         public string Password { get; set; }


### PR DESCRIPTION
Closes #386 