### PR TITLE
Re-displays 'Volunteer' link after successful unenroll

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Activity/Activity.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Activity/Activity.cshtml
@@ -104,33 +104,32 @@
     </div>
     <div class="col-sm-3">
         <div class="row">
-            <div class="col-sm-12">
-                @if (!Model.IsUserVolunteeredForActivity)
+            <div class="col-sm-12">               
+                @if (!User.IsSignedIn())
                 {
                     <h2>
-                        @if (!User.IsSignedIn())
-                        {
-                            <a asp-action="Login" asp-controller="Account" asp-route-ReturnUrl="/Activity/@Model.Id" class="btn btn-volunteer">Volunteer</a>
-                        }
-                        else
-                        {
-                            <a href="#" data-toggle="modal" data-target="#volunteerForm" class="btn btn-volunteer">Volunteer</a>
-                        }
+                        <a asp-action="Login" asp-controller="Account" asp-route-ReturnUrl="/Activity/@Model.Id" class="btn btn-volunteer">Volunteer</a>
                     </h2>
                 }
                 else
                 {
-                    <div class="volunteered">
-                        <center>
-                            Thanks for volunteering!
-                            <br />
-                            <a href="#" class="unvolunteer text-center" data-bind="click: function() {unenroll(@Model.Id);}">Unenroll</a>
-                        </center>
+                    <h2>
+                        <a href="#" data-toggle="modal" data-target="#volunteerForm" class="btn btn-volunteer" data-bind="visible: !enrolled()" style="display: none">Volunteer</a>
+                    </h2>
+                    <div class="volunteered" data-bind="visible: enrolled()" style="display: none">
+                        <div class="text-center">
+                            <p>Thanks for volunteering!</p>
+                            <p><a href="#" class="unvolunteer text-center" data-bind="click: function() {unenroll(@Model.Id);}">Unenroll</a></p>
+                            <p><span class="label label-danger" data-bind="visible: errorUnenrolling" style="display: none">There was a problem unenrolling; please try again.</span></p>
+                        </div>                      
+                        <div class="text-center" id="enrollUnenrollSpinner" style="display: none">
+                            <i class="fa fa-circle-o-notch fa-spin"></i>
+                        </div>
                     </div>
                 }
             </div>
         </div>
-        <div class="row" data-bind="visible: skills.length">
+        <div class="row" data-bind="visible: skills.length" style="display: none">
             <div class="col-sm-12">
                 <h3>Needed Skills</h3>
                 <ul data-bind="foreach: skills">
@@ -268,7 +267,12 @@
                     renderBingMap('bingMap', positionCoordsList);
                 });
         });
-        var modelStuff = @Json.Serialize(new { tasks = Model.Tasks, skills = Model.RequiredSkills, userSkills = Model.UserSkills });
+        var modelStuff = @Json.Serialize(new {
+                        tasks = Model.Tasks,
+                        skills = Model.RequiredSkills,
+                        userSkills = Model.UserSkills,
+                        isVolunteeredForActivity = Model.IsUserVolunteeredForActivity
+                    });
     </script>
     <script type="text/javascript" src="~/js/activity.js"></script>
     <script type="text/javascript" src="http://ecn.dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=7.0"></script>


### PR DESCRIPTION
For review.

This re-displays the 'Volunteer' link if the unenroll is successful.  It displays an error message on failure.  I put a font-awesome spinner in there, the one that has been previously used in `Activities.cshtml`.

I also added `style="display: none"` to those elements whose visibility depended in some way on the values bound by Knockout - this initial `display: none` stops that really annoying thing where the elements are initially flashed up for a second or two before the KO bindings kick in.

(Note that although there is the beginnings of an `enroll` AJAX call to the API it's not actually used; the enrolling is done by the `Signup` action on the `Activity` controller; it would probably be best at some point to make the volunteering use the API too).

Closes #236.