### PR TITLE
Fixes #370 - Password requirements

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -72,7 +72,8 @@ namespace AllReady.Controllers
         [AllowAnonymous]
         public IActionResult Register()
         {
-            return View();
+            var model = new RegisterViewModel();
+            return View(model);
         }
 
         //

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -177,7 +177,8 @@ namespace AllReady.Controllers
         [AllowAnonymous]
         public IActionResult ResetPassword(string code = null)
         {
-            return code == null ? View("Error") : View();
+            var model = new ResetPasswordViewModel();
+            return code == null ? View("Error") : View(model);
         }
 
         //

--- a/AllReadyApp/Web-App/AllReady/Security/PasswordRequirements.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/PasswordRequirements.cs
@@ -1,0 +1,58 @@
+﻿using System.Text;
+
+namespace AllReady.Security
+{
+    /// <summary>
+    /// Central class for password requirements and user helpers
+    /// </summary>
+    public class PasswordRequirements
+    {
+        /// <summary>
+        /// The password length used within the application
+        /// </summary>
+        public const int PASSWORD_LENGTH = 10;
+
+        /// <summary>
+        /// If the password requires a digit
+        /// </summary>
+        public const bool REQUIRE_DIGIT = true;
+
+        /// <summary>
+        /// If the password requires a digit or non alphabetical letter
+        /// </summary>
+        public const bool REQUIRE_NON_ALPHA_OR_DIGIT = false;
+
+        /// <summary>
+        /// If the password must have an uppercase character
+        /// </summary>
+        public const bool REQUIRE_UPPERCASE = false;
+
+        /// <summary>
+        /// A user helper string describing the password policy requirements
+        /// </summary>
+        public static string PasswordGuidance
+        {
+            get
+            {
+                var output = new StringBuilder();
+
+                output.Append("Your password must be ");
+                output.Append(PASSWORD_LENGTH);
+                output.Append(" characters in length");
+
+                if (REQUIRE_NON_ALPHA_OR_DIGIT && !REQUIRE_UPPERCASE)
+                    output.Append(" and one symbol or number");
+                else if (REQUIRE_NON_ALPHA_OR_DIGIT && REQUIRE_UPPERCASE)
+                    output.Append(", one symbol or number and one uppercase letter");
+                else if (REQUIRE_DIGIT && REQUIRE_UPPERCASE)
+                    output.Append(", one number and one uppercase letter");
+                else if (REQUIRE_DIGIT)
+                    output.Append(" and must include one number");
+
+                output.Append(".");
+
+                return output.ToString();
+            }
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -80,10 +80,10 @@ namespace AllReady
             // Add Identity services to the services container.
             services.AddIdentity<ApplicationUser, IdentityRole>(options =>
                     {
-                        options.Password.RequiredLength = 10;
-                        options.Password.RequireNonLetterOrDigit = false;
-                        options.Password.RequireDigit = true;
-                        options.Password.RequireUppercase = false;
+                        options.Password.RequiredLength = PasswordRequirements.PASSWORD_LENGTH;
+                        options.Password.RequireNonLetterOrDigit = PasswordRequirements.REQUIRE_NON_ALPHA_OR_DIGIT;
+                        options.Password.RequireDigit = PasswordRequirements.REQUIRE_DIGIT;
+                        options.Password.RequireUppercase = PasswordRequirements.REQUIRE_UPPERCASE;
                     })
                      .AddEntityFrameworkStores<AllReadyContext>()
                      .AddDefaultTokenProviders();

--- a/AllReadyApp/Web-App/AllReady/ViewModels/AccountViewModels.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/AccountViewModels.cs
@@ -47,7 +47,7 @@ namespace AllReady.Models
         public string Email { get; set; }
 
         [Required]
-        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 6)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = PasswordRequirements.PASSWORD_LENGTH)]
         [DataType(DataType.Password)]
         public string Password { get; set; }
 
@@ -57,6 +57,8 @@ namespace AllReady.Models
         public string ConfirmPassword { get; set; }
 
         public string Code { get; set; }
+
+        public string PasswordGuidance = PasswordRequirements.PasswordGuidance;
     }
 
     public class ForgotPasswordViewModel

--- a/AllReadyApp/Web-App/AllReady/ViewModels/AccountViewModels.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/AccountViewModels.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNet.Mvc.Rendering;
+using AllReady.Security;
 
 namespace AllReady.Models
 {
@@ -87,7 +88,7 @@ namespace AllReady.Models
         public string Email { get; set; }
 
         [Required]
-        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 6)]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = PasswordRequirements.PASSWORD_LENGTH)]
         [DataType(DataType.Password)]
         [Display(Name = "Password")]
         public string Password { get; set; }
@@ -96,6 +97,8 @@ namespace AllReady.Models
         [Display(Name = "Confirm password")]
         [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; }
+
+        public string PasswordGuidance = PasswordRequirements.PasswordGuidance;
     }
 
     public class SearchViewModel

--- a/AllReadyApp/Web-App/AllReady/Views/Account/Register.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Account/Register.cshtml
@@ -7,6 +7,7 @@
 
 <form asp-controller="Account" asp-action="Register" method="post" class="form-horizontal" role="form">
     <h4>Create a new account.</h4>
+    <p>Password guidance: @Model.PasswordGuidance</p>
     <hr />
     <div asp-validation-summary="ValidationSummary.All" class="text-danger"></div>
     <div class="form-group">

--- a/AllReadyApp/Web-App/AllReady/Views/Account/ResetPassword.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Account/ResetPassword.cshtml
@@ -7,6 +7,7 @@
 
 <form asp-controller="Account" asp-action="ResetPassword" method="post" class="form-horizontal" role="form">
     <h4>Reset your password.</h4>
+    <p>Password guidance: @Model.PasswordGuidance</p>
     <hr />
     <div asp-validation-summary="ValidationSummary.All" class="text-danger"></div>
     <input asp-for="Code" type="hidden" />


### PR DESCRIPTION
fixes #370 

I've added a base PasswordRequirements class to contain the password options as constants which can then be referenced where needed through the application.

I've linked the RegisterViewModel in the Register action as this was missing previously and added a string to the model which uses the PasswordRequirements generated user friendly string to give password guidance. Hopefully this then allow easier changes to these settings in the future without having to remember to make multiple changes to annotations etc if this is used.

I've also applied this on the reset password model and view as well.

It's my first go at contributing a pull request and hoping this is correct + the code makes sense!