### PR TITLE
Changes to query structure to call the ToArray at end

### DIFF
--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Activity.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Activity.cs
@@ -68,10 +68,10 @@ namespace AllReady.Models
             return _dbContext.ActivitySignup
                         .Include(x => x.User)
                         .Include(x => x.Activity)
-                        .Include(x => x.Activity.Campaign)
-                        .ToArray()
+                        .Include(x => x.Activity.Campaign)                        
                         .Where(x => x.Activity.Id == activityId && x.User.Id == userId)
-                        .OrderBy(x => x.Activity.StartDateTime);
+                        .OrderBy(x => x.Activity.StartDateTime)
+                        .ToArray();
         }
 
         IEnumerable<ActivitySignup> IAllReadyDataAccess.GetActivitySignups(string userId)
@@ -79,10 +79,10 @@ namespace AllReady.Models
             return _dbContext.ActivitySignup
                         .Include(x => x.User)
                         .Include(x => x.Activity)
-                        .Include(x => x.Activity.Campaign)
-                        .ToArray()
+                        .Include(x => x.Activity.Campaign)                        
                         .Where(x => x.User.Id == userId)
-                        .OrderBy(x => x.Activity.StartDateTime);
+                        .OrderBy(x => x.Activity.StartDateTime)
+                        .ToArray();
         }
 
         IEnumerable<TaskSignup> IAllReadyDataAccess.GetTasksAssignedToUser(int activityId, string userId)


### PR DESCRIPTION
Per issue #406 small change on the Activity data access to prevent executing the Get Activities queries before supplying the Where and OrderBy clauses. This makes the SQL query more efficient and should return only the dataset required.