### PR TITLE
Fixes #419 Changed footer to use the '-small' social media logos for issue #419

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
@@ -88,10 +88,10 @@
         @RenderBody()
         <footer>
             <p class="text-center">
-                <a href="https://www.facebook.com/allReadyApp/"> <img src="~/images/fb.png" alt="Go to allReady on Facebook" /></a>
-                <a href="https://twitter.com/htbox"><img src="~/images/twitter.png" alt="Follow Humanitarian Toolbox on Twitter" /></a>
-                <a href="https://twitter.com/HTbox/media"> <img src="~/images/instagram.png" alt="Instagram account" /> </a>
-                <a href="https://www.youtube.com/watch?v=BgV9jUJduwE&index=3&list=PLReL099Y5nRfJCkJtGFHZlVCvx2t8OWdA"><img src="~/images/youtube.png" alt="YouTube" /></a>
+                <a href="https://www.facebook.com/allReadyApp/"> <img src="~/images/fb-small.png" alt="Go to allReady on Facebook" /></a>
+                <a href="https://twitter.com/htbox"><img src="~/images/twitter-small.png" alt="Follow Humanitarian Toolbox on Twitter" /></a>
+                <a href="https://twitter.com/HTbox/media"> <img src="~/images/instagram-small.png" alt="Instagram account" /> </a>
+                <a href="https://www.youtube.com/watch?v=BgV9jUJduwE&index=3&list=PLReL099Y5nRfJCkJtGFHZlVCvx2t8OWdA"><img src="~/images/youtube-small.png" alt="YouTube" /></a>
             </p>
             <p class="text-center">Powered by <br /><a href="http://www.htbox.org/">Humanitarian Toolbox</a></p>
 

--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_LayoutMainPage.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_LayoutMainPage.cshtml
@@ -47,10 +47,10 @@
     </div>
     <footer class="main-page-footer">
         <p class="text-center">
-            <a href="https://www.facebook.com/allReadyApp/"> <img src="~/images/fb.png" alt="Go to allReady on Facebook" /></a> 
-            <a href="https://twitter.com/htbox"><img src="~/images/twitter.png" alt="Follow Humanitarian Toolbox on Twitter" /></a> 
-            <a href="https://twitter.com/HTbox/media"> <img src="~/images/instagram.png" alt="Instagram account" /> </a>
-            <a href="https://www.youtube.com/watch?v=BgV9jUJduwE&index=3&list=PLReL099Y5nRfJCkJtGFHZlVCvx2t8OWdA"><img src="~/images/youtube.png" alt="YouTube" /></a>
+            <a href="https://www.facebook.com/allReadyApp/"> <img src="~/images/fb-small.png" alt="Go to allReady on Facebook" /></a> 
+            <a href="https://twitter.com/htbox"><img src="~/images/twitter-small.png" alt="Follow Humanitarian Toolbox on Twitter" /></a> 
+            <a href="https://twitter.com/HTbox/media"> <img src="~/images/instagram-small.png" alt="Instagram account" /> </a>
+            <a href="https://www.youtube.com/watch?v=BgV9jUJduwE&index=3&list=PLReL099Y5nRfJCkJtGFHZlVCvx2t8OWdA"><img src="~/images/youtube-small.png" alt="YouTube" /></a>
         </p>
         <p class="text-center">Powered by <br /><a href="http://www.htbox.org/">Humanitarian Toolbox</a></p>
     </footer>


### PR DESCRIPTION
I have updated both layout pages to make use of the small 30x30 social media logos instead of the 60x60 logos.
![home_page_-_allready_-_internet_explorer_2015-12-07_12-08-29](https://cloud.githubusercontent.com/assets/838529/11626509/43b36c60-9cdb-11e5-8837-b51487ee94f5.png)
