### PR TITLE
Fixes #444 and #437 - Incorrect redirection with Admin/Tenant area

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/TenantControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/TenantControllerTests.cs
@@ -1,0 +1,71 @@
+﻿using AllReady.Areas.Admin.Controllers;
+using AllReady.Areas.Admin.Models;
+using MediatR;
+using Microsoft.AspNet.Mvc;
+using Moq;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Controllers
+{
+    public class TenantControllerTests
+    {
+        private readonly TenantEditModel _stubViewModel;
+
+        public TenantControllerTests()
+        {
+            _stubViewModel = new TenantEditModel
+            {
+                Id = 0,
+                LogoUrl = "http://www.example.com/image.jpg",
+                Name = "Test",
+                PrimaryContactFirstName = "FirstName",
+                PrimaryContactLastName = "LastName",
+                PrimaryContactPhoneNumber = "0123456798",
+                PrimaryContactEmail = "test@test.com",
+                WebUrl = "http://www.example.com"
+            };
+        }
+
+        [Fact]
+        public void CreateNewTenant()
+        {
+            //arrange
+            var sut = new TenantController(MockMediatorCreateTenant().Object);
+            //act
+            var result = sut.Create(_stubViewModel);
+            //assert
+            Assert.IsType<RedirectToActionResult>(result);
+        }
+
+        [Fact]
+        public void CreateNewTenantPostReturnsBadRequestForNullTenant()
+        {
+            //arrange
+            TenantEditModel viewmodel = null;
+            var sut = new TenantController(MockMediatorCreateTenant().Object);
+            //act
+            var result = sut.Create(viewmodel);
+            //assert 
+            Assert.IsType<BadRequestResult>(result);
+        }
+
+        [Fact]
+        public void CreateNewTenantInvalidModelReturnsCreateView()
+        {
+            //arrange
+            var sut = new TenantController(MockMediatorCreateTenant().Object);
+            sut.ModelState.AddModelError("foo", "bar");
+            //act
+            var result = sut.Create(_stubViewModel);
+            //assert
+            Assert.IsType<ViewResult>(result);
+            Assert.Equal("Create", ((ViewResult) result).ViewName);
+        }
+
+        private static Mock<IMediator> MockMediatorCreateTenant()
+        {
+            var mockMediator = new Mock<IMediator>();
+            return mockMediator;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/TenantControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/TenantControllerTests.cs
@@ -1,4 +1,6 @@
-﻿using AllReady.Areas.Admin.Controllers;
+﻿using System.Collections.Generic;
+using System.Linq;
+using AllReady.Areas.Admin.Controllers;
 using AllReady.Areas.Admin.Models;
 using MediatR;
 using Microsoft.AspNet.Mvc;
@@ -27,14 +29,18 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public void CreateNewTenant()
+        public void CreateNewTenantRedirectsToTenantList()
         {
             //arrange
             var sut = new TenantController(MockMediatorCreateTenant().Object);
+            var expectedRouteValues = new {controller = "Tenant", action = "Index"};
             //act
             var result = sut.Create(_stubViewModel);
             //assert
-            Assert.IsType<RedirectToActionResult>(result);
+            Assert.IsType<RedirectToRouteResult>(result);
+            Assert.Equal("areaRoute", ((RedirectToRouteResult) result).RouteName);
+            Assert.Equal("Tenant",((RedirectToRouteResult)result).RouteValues["controller"]); 
+            Assert.Equal("Index",((RedirectToRouteResult)result).RouteValues["action"]); 
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/TenantController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/TenantController.cs
@@ -53,7 +53,7 @@ namespace AllReady.Areas.Admin.Controllers
             if (ModelState.IsValid)
             {
                 int id = _bus.Send(new TenantEditCommand { Tenant = tenant });
-                return RedirectToAction("Index");
+                return RedirectToRoute("areaRoute", new {controller = "Tenant", action = "Index"});
             }
 
             return View("Create", tenant);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/TenantController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/TenantController.cs
@@ -48,13 +48,15 @@ namespace AllReady.Areas.Admin.Controllers
         [ValidateAntiForgeryToken]
         public  IActionResult Create(TenantEditModel tenant)
         {
+            if (tenant == null)
+                return new BadRequestResult();
             if (ModelState.IsValid)
             {
                 int id = _bus.Send(new TenantEditCommand { Tenant = tenant });
                 return RedirectToAction("Index");
             }
 
-            return View(tenant);
+            return View("Create", tenant);
         }
 
         // GET: Tenant/Edit/5

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Tenant/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Tenant/Details.cshtml
@@ -65,7 +65,7 @@
 <div class="row">
     <div class="col-md-12">
         @Html.ActionLink("Edit", "Edit", "Tenant", new { id = Model.Id }, new { @class = "btn btn-primary" }) 
-        @Html.RouteLink("Back to list", "areaRoute", new {area = "Admin", controller = "Tenant", action = "Index"}, new {@class = "btn btn-danger"})
+        @Html.RouteLink("Back to list", "areaRoute", new {area = "Admin", controller = "Tenant", action = "Index"}, new {@class = "btn"})
     </div>
 </div>
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Tenant/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Tenant/Details.cshtml
@@ -65,7 +65,7 @@
 <div class="row">
     <div class="col-md-12">
         @Html.ActionLink("Edit", "Edit", "Tenant", new { id = Model.Id }, new { @class = "btn btn-primary" }) 
-        @Html.ActionLink("Back to list", "Index", "Tenant", null, new { @class = "btn btn-cancel" })
+        @Html.RouteLink("Back to list", "areaRoute", new {area = "Admin", controller = "Tenant", action = "Index"}, new {@class = "btn btn-danger"})
     </div>
 </div>
 


### PR DESCRIPTION
I have updated the TenantController to redirect to the admin area, organizations instead of the main list of organizations. This is both when creating a new organization and when pressing back from within the Details view of an Organization.

I've also added some unit tests around the Admin\TenantController