### PR TITLE
Adding test for anti forgery token attribute

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/GlobalControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/GlobalControllerTests.cs
@@ -1,0 +1,43 @@
+﻿using AllReady.Controllers;
+using Microsoft.AspNet.Mvc;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace AllReady.UnitTest.Controllers
+{
+    public class GlobalControllerTests
+    {
+        /// <summary>
+        /// A test to reflect across all controllers and valide all post requests also have the ValidateAntiForgeryToken attribute
+        /// </summary>
+        /// <remarks>Code credit - http://codiply.com/blog/test-for-omission-of-validateantiforgerytoken-attribute-in-asp-net-mvc"</remarks>
+        [Fact]
+        public void AllHttpPostControllerActionsShouldBeDecoratedWithValidateAntiForgeryTokenAttribute()
+        {
+            var allControllerTypes =
+                typeof(AccountController).Assembly.GetTypes()
+                .Where(type => typeof(Controller).IsAssignableFrom(type));
+            var allControllerActions = allControllerTypes.SelectMany(type => type.GetMethods());
+
+            var failingActions = allControllerActions
+                .Where(method =>
+                    Attribute.GetCustomAttribute(method, typeof(HttpPostAttribute)) != null)
+                .Where(method =>
+                    Attribute.GetCustomAttribute(method, typeof(ValidateAntiForgeryTokenAttribute)) == null)
+                .ToList();
+
+            var message = string.Empty;
+            if (failingActions.Any())
+            {
+                message =
+                    failingActions.Count() + " failing action" +
+                    (failingActions.Count() == 1 ? ":\n" : "s:\n") +
+                    failingActions.Select(method => method.Name + " in " + method.DeclaringType.Name)
+                        .Aggregate((a, b) => a + ",\n" + b);
+            }
+
+            Assert.False(failingActions.Any(), message);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
@@ -96,6 +96,7 @@ namespace AllReady.Controllers
         [HttpPost]
         [Route("/Activity/Signup")]
         [Authorize]
+        [ValidateAntiForgeryToken]
         public IActionResult Signup(ActivitySignupViewModel signupModel)
         {
             if (signupModel == null)


### PR DESCRIPTION
A quick lunchtime PR! While reviewing commit 229ece0aab95e7527009d2136674793910ffaffc from @Sobieck00 I saw the inclusion of a check for the Anti Forgery Token and thought about putting it into some of the tests I've written.

I then looked around for a solution to doing this in one place and found http://codiply.com/blog/test-for-omission-of-validateantiforgerytoken-attribute-in-asp-net-mvc

I've included this code in AllReady and it seems to work well. It picked up one failure for the ActivityController where this attribute was missing so I've fixed that up also. I consider this related to #59 

If this looks sensible to others then perhaps we can remove any per controller/action checks?

Note: This may be WIP depending on feedback but if others are happy then I'd consider this done and ready to merge.