### PR TITLE
Social login data collection

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -311,12 +311,16 @@ namespace AllReady.Controllers
                 {
                     return View("ExternalLoginFailure");
                 }
+
                 var user = new ApplicationUser
                 {
                     UserName = model.Email,
                     Email = model.Email,
-                    TimeZoneId = _generalSettings.DefaultTimeZone
+                    TimeZoneId = _generalSettings.DefaultTimeZone,
+                    Name = model.Name,
+                    PhoneNumber = model.PhoneNumber
                 };
+
                 var result = await _userManager.CreateAsync(user);
                 if (result.Succeeded)
                 {
@@ -327,6 +331,7 @@ namespace AllReady.Controllers
                         return RedirectToLocal(returnUrl, user);
                     }
                 }
+
                 AddErrors(result);
             }
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -174,7 +174,7 @@ namespace AllReady.Controllers
             // Generate the token and send it
             var user = GetCurrentUser();
             var code = await _userManager.GenerateChangePhoneNumberTokenAsync(user, model.PhoneNumber);
-            await _smsSender.SendSmsAsync(model.PhoneNumber, "Your security code is: " + code);
+            await _smsSender.SendSmsAsync(model.PhoneNumber, "Your allReady account security code is: " + code);
             return RedirectToAction(nameof(VerifyPhoneNumber), new { PhoneNumber = model.PhoneNumber });
         }
 
@@ -186,7 +186,7 @@ namespace AllReady.Controllers
             var user = GetCurrentUser();
             var code = await _userManager.GenerateChangePhoneNumberTokenAsync(user, phoneNumber);
 
-            await _smsSender.SendSmsAsync(phoneNumber, "Your security code is: " + code);
+            await _smsSender.SendSmsAsync(phoneNumber, "Your allReady account security code is: " + code);
 
             return RedirectToAction(nameof(VerifyPhoneNumber), new { PhoneNumber = phoneNumber });
         }

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -53,6 +53,7 @@ namespace AllReady.Controllers
                 HasPassword = await _userManager.HasPasswordAsync(user),
                 EmailAddress = user.Email,
                 IsEmailAddressConfirmed = user.EmailConfirmed,
+                IsPhoneNumberConfirmed = user.PhoneNumberConfirmed,
                 PhoneNumber = await _userManager.GetPhoneNumberAsync(user),
                 TwoFactor = await _userManager.GetTwoFactorEnabledAsync(user),
                 Logins = await _userManager.GetLoginsAsync(user),
@@ -175,6 +176,19 @@ namespace AllReady.Controllers
             var code = await _userManager.GenerateChangePhoneNumberTokenAsync(user, model.PhoneNumber);
             await _smsSender.SendSmsAsync(model.PhoneNumber, "Your security code is: " + code);
             return RedirectToAction(nameof(VerifyPhoneNumber), new { PhoneNumber = model.PhoneNumber });
+        }
+
+        // POST: /Account/ResendPhoneNumberConfirmation
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> ResendPhoneNumberConfirmation(string phoneNumber)
+        {
+            var user = GetCurrentUser();
+            var code = await _userManager.GenerateChangePhoneNumberTokenAsync(user, phoneNumber);
+
+            await _smsSender.SendSmsAsync(phoneNumber, "Your security code is: " + code);
+
+            return RedirectToAction(nameof(VerifyPhoneNumber), new { PhoneNumber = phoneNumber });
         }
 
         // POST: /Manage/EnableTwoFactorAuthentication

--- a/AllReadyApp/Web-App/AllReady/ViewModels/AccountViewModels.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/AccountViewModels.cs
@@ -9,6 +9,11 @@ namespace AllReady.Models
         [Required]
         [EmailAddress]
         public string Email { get; set; }
+
+        public string Name { get; set; }
+
+        [Display(Name="Phone number")]
+        public string PhoneNumber { get; set; }
     }
 
     public class SendCodeViewModel

--- a/AllReadyApp/Web-App/AllReady/ViewModels/ManageViewModels.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/ManageViewModels.cs
@@ -18,6 +18,8 @@ namespace AllReady.Models
 
         public bool IsEmailAddressConfirmed { get; set; }
 
+        public bool IsPhoneNumberConfirmed { get; set; }
+
         public bool HasPassword { get; set; }
 
         public IList<UserLoginInfo> Logins { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Views/Account/ExternalLoginConfirmation.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Account/ExternalLoginConfirmation.cshtml
@@ -24,6 +24,20 @@
         </div>
     </div>
     <div class="form-group">
+        <label asp-for="Name" class="col-md-2 control-label"></label>
+        <div class="col-md-10">
+            <input asp-for="Name" class="form-control" />
+            <span asp-validation-for="Name" class="text-danger"></span>
+        </div>
+    </div>
+    <div class="form-group">
+        <label asp-for="PhoneNumber" class="col-md-2 control-label"></label>
+        <div class="col-md-10">
+            <input asp-for="PhoneNumber" class="form-control" />
+            <span asp-validation-for="PhoneNumber" class="text-danger"></span>
+        </div>
+    </div>
+    <div class="form-group">
         <div class="col-md-offset-2 col-md-10">
             <button type="submit" class="btn btn-default">Register</button>
         </div>

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -21,21 +21,21 @@
                                title="@(Model.IsEmailAddressConfirmed ? "Your email address has been confirmed" : "")"></i> @Model.EmailAddress
                             @if (string.IsNullOrEmpty(Model.ProposedNewEmailAddress))
                             {
-                            <span> | <a asp-controller="Manage" asp-action="ChangeEmail">Change</a></span>
+                                <span> | <a asp-controller="Manage" asp-action="ChangeEmail">Change</a></span>
                             }
                         </span>
                         @if (!Model.IsEmailAddressConfirmed)
                         {
-                        <br />
-                        <div class="alert alert-warning" role="alert">
-                            <i class="fa fa-exclamation-circle"></i> Your email address has not been confirmed.
                             <br />
-                            allReady cannot send you email notifications until your email address has been confirmed.
-                            <br />
-                            Check your inbox for a confirmation email.
-                            <br />
-                            <button class="btn btn-default" type="submit">Send me a new confirmation email</button>
-                        </div>
+                            <div class="alert alert-warning" role="alert">
+                                <i class="fa fa-exclamation-circle"></i> Your email address has not been confirmed.
+                                <br />
+                                allReady cannot send you email notifications until your email address has been confirmed.
+                                <br />
+                                Check your inbox for a confirmation email.
+                                <br />
+                                <button class="btn btn-default" type="submit">Send me a new confirmation email</button>
+                            </div>
                         }
                     </p>
                 </div>
@@ -45,165 +45,181 @@
 
     @if (Model.ProposedNewEmailAddress != null)
     {
-    <div class="alert alert-warning" role="alert">
-        <p>
-            <i class="fa fa-exclamation-circle"></i> You have requested that your email address is changed to @Model.ProposedNewEmailAddress but this has not been confirmed.
-            <br />
-            allReady cannot update your email address until your new email address has been confirmed.
-            <br />
-            Check your inbox for a confirmation email.
-        </p>
-        <form asp-controller="Manage" asp-action="ResendChangeEmailConfirmation">
-            <br /><button class="btn btn-default" type="submit">Send me a new confirmation email</button>
-        </form>
-        <form asp-controller="Manage" asp-action="CancelChangeEmail">
-            <button class="btn btn-default" type="submit">Cancel email change</button>
-        </form>
-    </div>
+        <div class="alert alert-warning" role="alert">
+            <p>
+                <i class="fa fa-exclamation-circle"></i> You have requested that your email address is changed to @Model.ProposedNewEmailAddress but this has not been confirmed.
+                <br />
+                allReady cannot update your email address until your new email address has been confirmed.
+                <br />
+                Check your inbox for a confirmation email.
+            </p>
+            <form asp-controller="Manage" asp-action="ResendChangeEmailConfirmation">
+                <br /><button class="btn btn-default" type="submit">Send me a new confirmation email</button>
+            </form>
+            <form asp-controller="Manage" asp-action="CancelChangeEmail">
+                <button class="btn btn-default" type="submit">Cancel email change</button>
+            </form>
+        </div>
     }
 
     @using (Html.BeginForm())
     {
-    @Html.AntiForgeryToken()
+        @Html.AntiForgeryToken()
 
-    <hr />
-    <div class="form-horizontal">
-        <div class="form-group">
-            <label asp-for="Name" class="control-label col-md-2"></label>
-            <div class="col-md-10">
-                <input type="text" asp-for="Name" class="form-control" />
-                <span asp-validation-for="Name" class="text-danger"></span>
+        <hr />
+        <div class="form-horizontal">
+            <div class="form-group">
+                <label asp-for="Name" class="control-label col-md-2"></label>
+                <div class="col-md-10">
+                    <input type="text" asp-for="Name" class="form-control" />
+                    <span asp-validation-for="Name" class="text-danger"></span>
+                </div>
             </div>
-        </div>
 
-        <div class="form-group">
-            <label class="control-label col-md-2">Phone number</label>
-            <div class="col-md-10">
-                <p class="form-control-static">
-                    @(Model.PhoneNumber ?? "None")
-                    @if (Model.PhoneNumber != null)
+            <div class="form-group">
+                <label class="control-label col-md-2">Phone number</label>
+                <div class="col-md-10">
+                    <p class="form-control-static">
+                        @(Model.PhoneNumber ?? "None")
+                        @if (Model.PhoneNumber != null)
+                        {
+                            <a asp-controller="Manage" asp-action="AddPhoneNumber">Change</a>
+                                @: &nbsp;|&nbsp;
+                                <a asp-controller="Manage" asp-action="RemovePhoneNumber">Remove</a>
+                                @if (!Model.IsPhoneNumberConfirmed)
+                                {
+                                    @: &nbsp;|&nbsp;
+                                    <a asp-controller="Manage" asp-action="VerifyPhoneNumber" asp-route-phoneNumber="@Model.PhoneNumber">Verify</a>
+                                }
+                        }
+                        else
+                        {
+                            <a asp-controller="Manage" asp-action="AddPhoneNumber">Add</a>
+                        }
+                        @if (!Model.IsPhoneNumberConfirmed)
+                        {
+                            <br />
+                            <div class="alert alert-warning" role="alert">
+                                <i class="fa fa-exclamation-circle"></i> Your phone number has not been confirmed.
+                                <br />
+                                allReady cannot send you SMS notifications until your phone number has been confirmed.
+                                <br />
+                                Check your messages for your confirmation code.
+                            </div>
+                        }
+                    </p>
+                </div>
+            </div>
+            @if (User.IsOrganizationAdmin())
+                {
+                @if (User.IsUserType(UserType.SiteAdmin))
                     {
-                    <a asp-controller="Manage" asp-action="AddPhoneNumber">Change</a>
-                    @: &nbsp;|&nbsp;
-                    <a asp-controller="Manage" asp-action="RemovePhoneNumber">Remove</a>
-                    }
-                    else
-                    {
-                    <a asp-controller="Manage" asp-action="AddPhoneNumber">Add</a>
-                    }
-                </p>
-            </div>
-        </div>
-        @if (User.IsOrganizationAdmin())
-        {
-        @if (User.IsUserType(UserType.SiteAdmin))
-        {
-        <div class="form-group">
-            <label class="control-label col-md-2">Approve users</label>
-            <div class="col-md-10">
-                <p class="form-control-static">
-                    <a asp-controller="Site" asp-action="Index" asp-route-area="Admin">Find</a>
-                </p>
-            </div>
-        </div>
-        }
-        }
-        else
-        {
-        <div class="form-group">
-            <label class="control-label col-md-2">External logins</label>
-            <div class="col-md-10">
-                <p class="form-control-static">
-                    @Model.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]
-                </p>
-            </div>
-        </div>
-
-        }
-        <div class="form-group">
-            <label class="control-label col-md-2">Password</label>
-            <div class="col-md-10">
-                <p class="form-control-static">
-                    @if (Model.HasPassword)
-                    {
-                    <a asp-controller="Manage" asp-action="ChangePassword">Change</a>
-                    }
-                    else
-                    {
-                    <a asp-controller="Manage" asp-action="SetPassword">Create</a>
-                    }
-                </p>
-            </div>
-        </div>
-        <div class="form-group">
-            <label asp-for="TimeZoneId" class="control-label col-md-2"></label>
-            <div class="col-md-10">
-                <select asp-for="TimeZoneId" asp-items="@SelectListService.GetTimeZones()" class="form-control"></select>
-            </div>
-        </div>
-        <div class="form-group">
-            <label asp-for="AssociatedSkills" class="control-label col-md-2"></label>
-            <div class="col-md-10">
-                <div data-bind="foreach: skills">
-                    <div class="form-inline">
-                        <select class="form-control" data-bind="attr: { name: ControlName($index) }, options: $root.availableSkills, optionsText: 'Name', optionsValue: 'Id', value: Id"></select>
-                        <span class="fa fa-question-circle" data-bind="visible: Description, tooltip: { title: Description, placement: 'top' }" aria-hidden="true"></span>
-                        <a href="#" data-bind="click: $root.deleteSkill" title="Delete skill">
-                            <span class="fa fa-remove" aria-hidden="true"></span>
-                            Delete
-                        </a>
+                    <div class="form-group">
+                        <label class="control-label col-md-2">Approve users</label>
+                        <div class="col-md-10">
+                            <p class="form-control-static">
+                                <a asp-controller="Site" asp-action="Index" asp-route-area="Admin">Find</a>
+                            </p>
+                        </div>
+                    </div>
+                }
+            }
+            else
+            {
+                <div class="form-group">
+                    <label class="control-label col-md-2">External logins</label>
+                    <div class="col-md-10">
+                        <p class="form-control-static">
+                            @Model.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]
+                        </p>
                     </div>
                 </div>
-                <a href="#" data-bind="click: addSkill" title="Add skill">
-                    <span class="fa fa-plus" aria-hidden="true"></span>
-                    Add
-                </a>
+
+            }
+            <div class="form-group">
+                <label class="control-label col-md-2">Password</label>
+                <div class="col-md-10">
+                    <p class="form-control-static">
+                        @if (Model.HasPassword)
+                        {
+                            <a asp-controller="Manage" asp-action="ChangePassword">Change</a>
+                        }
+                        else
+                        {
+                            <a asp-controller="Manage" asp-action="SetPassword">Create</a>
+                        }
+                    </p>
+                </div>
+            </div>
+            <div class="form-group">
+                <label asp-for="TimeZoneId" class="control-label col-md-2"></label>
+                <div class="col-md-10">
+                    <select asp-for="TimeZoneId" asp-items="@SelectListService.GetTimeZones()" class="form-control"></select>
+                </div>
+            </div>
+            <div class="form-group">
+                <label asp-for="AssociatedSkills" class="control-label col-md-2"></label>
+                <div class="col-md-10">
+                    <div data-bind="foreach: skills">
+                        <div class="form-inline">
+                            <select class="form-control" data-bind="attr: { name: ControlName($index) }, options: $root.availableSkills, optionsText: 'Name', optionsValue: 'Id', value: Id"></select>
+                            <span class="fa fa-question-circle" data-bind="visible: Description, tooltip: { title: Description, placement: 'top' }" aria-hidden="true"></span>
+                            <a href="#" data-bind="click: $root.deleteSkill" title="Delete skill">
+                                <span class="fa fa-remove" aria-hidden="true"></span>
+                                Delete
+                            </a>
+                        </div>
+                    </div>
+                    <a href="#" data-bind="click: addSkill" title="Add skill">
+                        <span class="fa fa-plus" aria-hidden="true"></span>
+                        Add
+                    </a>
+                </div>
+            </div>
+            <div class="form-group">
+                <div class="col-md-offset-2 col-md-10">
+                    <button type="submit" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
+                    <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.AssociatedSkills)" must be unique</span>
+                </div>
             </div>
         </div>
-        <div class="form-group">
-            <div class="col-md-offset-2 col-md-10">
-                <button type="submit" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
-                <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.AssociatedSkills)" must be unique</span>
-            </div>
-        </div>
-    </div>
     }
 </div>
 
 @section scripts {
-<script type="text/javascript">
-    (function (ko, $, skills, availableSkills) {
+    <script type="text/javascript">
+        (function (ko, $, skills, availableSkills) {
 
-        function ManageUserViewModel(skills, availableSkills) {
+            function ManageUserViewModel(skills, availableSkills) {
 
-            function SkillObservable(skillModel) {
-                var ret = ko.utils.extend({}, skillModel);
-                ret.Id = ko.observable(ret.Id);
-                ret.ControlName = function (index) {
-                    return 'AssociatedSkills[' + ko.unwrap(index) + '].SkillId';
+                function SkillObservable(skillModel) {
+                    var ret = ko.utils.extend({}, skillModel);
+                    ret.Id = ko.observable(ret.Id);
+                    ret.ControlName = function (index) {
+                        return 'AssociatedSkills[' + ko.unwrap(index) + '].SkillId';
+                    };
+                    ret.Description = ko.computed(function () {
+                        var skill = availableSkills.filter(function (skill) { return skill.Id === ret.Id(); })[0];
+                        return (skill && skill.Description) || "";
+                    });
+                    return ret;
+                }
+                skills = (skills || []).map(SkillObservable);
+
+                var self = this;
+                this.skills = ko.observableArray(skills).uniqueValidator("Id");
+                this.availableSkills = ko.observableArray(availableSkills);
+                this.addSkill = function() {
+                    self.skills.push(SkillObservable());
                 };
-                ret.Description = ko.computed(function () {
-                    var skill = availableSkills.filter(function (skill) { return skill.Id === ret.Id(); })[0];
-                    return (skill && skill.Description) || "";
-                });
-                return ret;
+                this.deleteSkill = function(skill) {
+                    self.skills.remove(skill);
+                };
             }
-            skills = (skills || []).map(SkillObservable);
 
-            var self = this;
-            this.skills = ko.observableArray(skills).uniqueValidator("Id");
-            this.availableSkills = ko.observableArray(availableSkills);
-            this.addSkill = function() {
-                self.skills.push(SkillObservable());
-            };
-            this.deleteSkill = function(skill) {
-                self.skills.remove(skill);
-            };
-        }
-
-        ko.applyBindings(new ManageUserViewModel(skills, availableSkills));
-    })(ko, $,
-        @Json.Serialize(Model.AssociatedSkills.Select(rs => new { Id = rs.SkillId })),
-        @Json.Serialize(SelectListService.GetSkills()));
-</script>
+            ko.applyBindings(new ManageUserViewModel(skills, availableSkills));
+        })(ko, $,
+            @Json.Serialize(Model.AssociatedSkills.Select(rs => new { Id = rs.SkillId })),
+            @Json.Serialize(SelectListService.GetSkills()));
+    </script>
 }

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -96,7 +96,7 @@
                         {
                             <a asp-controller="Manage" asp-action="AddPhoneNumber">Add</a>
                         }
-                        @if (!Model.IsPhoneNumberConfirmed)
+                        @if (!Model.IsPhoneNumberConfirmed && Model.PhoneNumber != null)
                         {
                             <br />
                             <div class="alert alert-warning" role="alert">
@@ -104,7 +104,7 @@
                                 <br />
                                 allReady cannot send you SMS notifications until your phone number has been confirmed.
                                 <br />
-                                Check your messages for your confirmation code.
+                                Please check your messages for your confirmation code.
                             </div>
                         }
                     </p>

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/VerifyPhoneNumber.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/VerifyPhoneNumber.cshtml
@@ -25,6 +25,14 @@
     </div>
 </form>
 
+<form asp-controller="Manage" asp-action="ResendPhoneNumberConfirmation" asp-route-phoneNumber="@Model.PhoneNumber" method="post" class="form-horizontal" role="form">
+    <div class="form-group">
+        <div class="col-md-offset-2 col-md-10">
+            <button type="submit" class="btn btn-default">Resend code</button>
+        </div>
+    </div>
+</form>
+
 @section Scripts {
     @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
 }

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -34,8 +34,8 @@
   },
   "Authentication": {
     "Facebook": {
-      "AppId": "[facebookappId]",
-      "AppSecret": "[facebookappsecret]"
+      "AppId": "167952183568521",
+      "AppSecret": "a8053ceca7eefbaa4821ca531929f339"
     },
     "Twitter": {
       "ConsumerKey": "[twitterkey]",


### PR DESCRIPTION
WIP for issue #261 

I've opened this to see if this is the correct approach for the issue at hand. There were a couple of possible ways to achieve this and I've taken what I think is the easiest for now. I've added the Name and Phone Number fields to the external callback page so that these can be optionally entered.

Since the flow from the manage page is the require the SMS code to be provided before the number is added I've tweaked the UI a little to put up a UI prompt when the phone number is not yet confirmed in /Manage

This may not be the preferred approach since the phone number is in the DB at this stage before confirmation, although the confirmed flag is not set. We could adjust the flow if preferred to instead send the user directly to the confirm code page as if they had added a new phone number but for now I kept the path of least resistance to redirect to the redirectUrl.

I've also added a verify link on the Manage page which takes the user to the screen to supply the code. I've also added a resend code button as that might be useful.

Opinions welcomed :-)

This will conflict with changes in PR #484 as well so whichever is last to be completed I'll need to rebase and fixup the conflict since I've edited a few of the same files in each PR.