### PR TITLE
When a Registered User Unvolunteers, notify organizer of any tasks that have been unassigned

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/ActivityApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/ActivityApiControllerTests.cs
@@ -11,6 +11,8 @@ using Xunit;
 using Moq;
 using System.Security.Claims;
 using System.Security.Principal;
+using AllReady.Features.Notifications;
+using MediatR;
 using Microsoft.AspNet.Http;
 
 namespace AllReady.UnitTest
@@ -20,6 +22,7 @@ namespace AllReady.UnitTest
         private static IServiceProvider _serviceProvider;
         private static bool populatedData = false;
         private static int activitiesAdded = 0;
+        private Mock<IMediator> _bus;
 
         public ActivityApiControllerTest()
         {
@@ -146,7 +149,10 @@ namespace AllReady.UnitTest
         {
             var allReadyContext = _serviceProvider.GetService<AllReadyContext>();
             var allReadyDataAccess = new AllReadyDataAccessEF7(allReadyContext);
-            var controller = new ActivityApiController(allReadyDataAccess);
+
+            _bus = new Mock<IMediator>();
+            var controller = new ActivityApiController(allReadyDataAccess, _bus.Object);
+
             PopulateData(allReadyContext);
             return controller;
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Notifications/GetUserUnenrollsNotificationModel.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Notifications/GetUserUnenrollsNotificationModel.cs
@@ -1,0 +1,139 @@
+﻿using System;
+using System.Collections.Generic;
+using AllReady.Features.Notifications;
+using AllReady.Models;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace AllReady.UnitTest.Notifications
+{
+    public class GetUserUnenrollsNotificationModel : InMemoryContextTest
+    {
+        private ApplicationUser _user1;
+        private Organization _htb;
+        private Campaign _firePrev;
+        private Activity _queenAnne;
+        private Contact _contact1;
+        private AllReadyTask _task1;
+
+        protected override void LoadTestData()
+        {
+            var context = ServiceProvider.GetService<AllReadyContext>();
+            _user1 = new ApplicationUser
+            {
+                UserName = "johndoe@example.com",
+                Name = "John Doe",
+                Email = "johndoe@example.com"
+            };
+            _contact1 = new Contact
+            {
+                Id = 1,
+                FirstName = "Jerry",
+                LastName = "Rodgers",
+                Email = "jerry@example.com",
+                PhoneNumber = "555.555.1234"
+            };
+
+            _htb = new Organization()
+            {
+                Name = "Humanitarian Toolbox",
+                LogoUrl = "http://www.htbox.org/upload/home/ht-hero.png",
+                WebUrl = "http://www.htbox.org",
+                Campaigns = new List<Campaign>()
+            };
+
+            _firePrev = new Campaign()
+            {
+                Name = "Neighborhood Fire Prevention Days",
+                ManagingOrganization = _htb,
+                CampaignContacts = new List<CampaignContact>()
+            };
+            _firePrev.CampaignContacts.Add(new CampaignContact
+            {
+                Campaign = _firePrev,
+                Contact = _contact1,
+                ContactType = (int)ContactTypes.Primary
+            });
+            _htb.Campaigns.Add(_firePrev);
+            _queenAnne = new Activity()
+            {
+                Id = 1,
+                Name = "Queen Anne Fire Prevention Day",
+                Campaign = _firePrev,
+                CampaignId = _firePrev.Id,
+                StartDateTime = new DateTime(2015, 7, 4, 10, 0, 0).ToUniversalTime(),
+                EndDateTime = new DateTime(2015, 12, 31, 15, 0, 0).ToUniversalTime(),
+                Location = new Location { Id = 1 },
+                RequiredSkills = new List<ActivitySkill>(),
+                Tasks = new List<AllReadyTask>()
+            };
+            _queenAnne.UsersSignedUp = new List<ActivitySignup>
+            {
+                new ActivitySignup
+                {
+                    Id = 1,
+                    PreferredEmail = "testuser@gmail.com",
+                    PreferredPhoneNumber = "(555)555-1234",
+                    User = _user1
+                }
+            };
+            _task1 = new AllReadyTask()
+            {
+               Id = 1,
+               Activity = _queenAnne,
+               Name = "Task 1",
+                StartDateTime = new DateTime(2015, 7, 4, 10, 0, 0).ToUniversalTime(),
+                EndDateTime = new DateTime(2015, 12, 31, 15, 0, 0).ToUniversalTime(),
+                Organization = _htb
+            };
+            _task1.AssignedVolunteers = new List<TaskSignup>()
+            {
+                new TaskSignup
+                {
+                    Id = 1,
+                    User = _user1,
+                    Task = _task1,
+                    Status = "Assigned",
+                    StatusDateTimeUtc = new DateTime(2015, 7, 4, 10, 0, 0).ToUniversalTime()
+                }
+            };
+            _queenAnne.Tasks.Add(_task1);
+            context.Users.Add(_user1);
+            context.Contacts.Add(_contact1);
+            context.Organizations.Add(_htb);
+            context.Activities.Add(_queenAnne);
+            context.SaveChanges();
+        }
+
+        [Fact]
+        public void ModelCanBeCreatedFomExistingActivity()
+        {
+            var context = ServiceProvider.GetService<AllReadyContext>();
+            var query = new UserUnenrollsNotificationQuery { ActivityId = 1 };
+            var handler = new UserUnenrollsNotificationQueryHandler(context);
+            var result = handler.Handle(query);
+            Assert.NotNull(result);
+            Assert.True(_queenAnne.Id == result.ActivityId, "ActivityId does not match");
+            Assert.True(_firePrev.Name == result.CampaignName, "CampaignName does not match");
+            Assert.True(_firePrev.Description == result.Description, "Campaign description does not match");
+            Assert.True(_queenAnne.UsersSignedUp.Count == result.UsersSignedUp.Count, "Count of signed up users does not match");
+            Assert.True(_queenAnne.NumberOfVolunteersRequired == result.NumberOfVolunteersRequired, "NumberOfvolunteersRequired doesn't match");
+            Assert.True(_queenAnne.Tasks.Count == result.Tasks.Count, "Count of tasks does not match");
+            Assert.True(_queenAnne.Tasks[0].Name == result.Tasks[0].Name, "Task name does not match");
+            Assert.True(_queenAnne.Tasks[0].AssignedVolunteers.Count == result.Tasks[0].AssignedVolunteers.Count, "Count of volunteers assigned to tak does not match");
+            Assert.True(_firePrev.CampaignContacts.Count == result.CampaignContacts.Count, "Count of campaign contacts does not match");
+            Assert.True(_firePrev.CampaignContacts[0].Contact.Email == result.CampaignContacts[0].Contact.Email, "Contact email does not match");
+        }
+
+        [Fact]
+        public void ActivityDoesNotExist()
+        {
+            var context = ServiceProvider.GetService<AllReadyContext>();
+            var query = new UserUnenrollsNotificationQuery { ActivityId = 999 };
+            var handler = new UserUnenrollsNotificationQueryHandler(context);
+            var result = handler.Handle(query);
+            Assert.Null(result);
+        }
+
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Notifications/GetUserUnenrollsNotificationModel.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Notifications/GetUserUnenrollsNotificationModel.cs
@@ -113,16 +113,10 @@ namespace AllReady.UnitTest.Notifications
             var handler = new UserUnenrollsNotificationQueryHandler(context);
             var result = handler.Handle(query);
             Assert.NotNull(result);
-            Assert.True(_queenAnne.Id == result.ActivityId, "ActivityId does not match");
-            Assert.True(_firePrev.Name == result.CampaignName, "CampaignName does not match");
-            Assert.True(_firePrev.Description == result.Description, "Campaign description does not match");
             Assert.True(_queenAnne.UsersSignedUp.Count == result.UsersSignedUp.Count, "Count of signed up users does not match");
-            Assert.True(_queenAnne.NumberOfVolunteersRequired == result.NumberOfVolunteersRequired, "NumberOfvolunteersRequired doesn't match");
             Assert.True(_queenAnne.Tasks.Count == result.Tasks.Count, "Count of tasks does not match");
-            Assert.True(_queenAnne.Tasks[0].Name == result.Tasks[0].Name, "Task name does not match");
             Assert.True(_queenAnne.Tasks[0].AssignedVolunteers.Count == result.Tasks[0].AssignedVolunteers.Count, "Count of volunteers assigned to tak does not match");
             Assert.True(_firePrev.CampaignContacts.Count == result.CampaignContacts.Count, "Count of campaign contacts does not match");
-            Assert.True(_firePrev.CampaignContacts[0].Contact.Email == result.CampaignContacts[0].Contact.Email, "Contact email does not match");
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady/Controllers/ActivityApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ActivityApiController.cs
@@ -11,6 +11,8 @@ using System.Linq;
 using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using AllReady.Features.Notifications;
+using MediatR;
 
 namespace AllReady.Controllers
 {
@@ -20,11 +22,13 @@ namespace AllReady.Controllers
     {
         private const double MILES_PER_METER = 0.00062137;
         private readonly IAllReadyDataAccess _allReadyDataAccess;
+        private readonly IMediator _bus;
 
 
-        public ActivityApiController(IAllReadyDataAccess allReadyDataAccess)
+        public ActivityApiController(IAllReadyDataAccess allReadyDataAccess, IMediator bus)
         {
             _allReadyDataAccess = allReadyDataAccess;
+            _bus = bus;
         }
 
         // GET: api/values
@@ -173,6 +177,10 @@ namespace AllReady.Controllers
             {
                 return HttpNotFound();
             }
+
+            //Notify admins 
+            _bus.Publish(new UserUnenrolls {ActivityId = signedUp.Activity.Id, UserId = signedUp.User.Id});
+
             await _allReadyDataAccess.DeleteActivitySignupAsync(signedUp.Id);
             return new HttpStatusCodeResult((int)HttpStatusCode.OK);
         }

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForUserUnenrolls.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForUserUnenrolls.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AllReady.Areas.Admin.Features.Activities;
+using AllReady.Features.Login;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Extensions.OptionsModel;
+
+namespace AllReady.Features.Notifications
+{
+    public class NotifyAdminForUserUnenrolls : INotificationHandler<UserUnenrolls>
+    {
+        private readonly IMediator _bus;
+        private readonly IOptions<GeneralSettings> _options;
+
+        public NotifyAdminForUserUnenrolls(IMediator bus, IOptions<GeneralSettings> options)
+        {
+            _bus = bus;
+            _options = options;
+        }
+
+        public void Handle(UserUnenrolls notification)
+        {
+            var model = _bus.Send(new UserUnenrollsNotificationQuery {ActivityId = notification.ActivityId});
+            var campaignContact = model.CampaignContacts.SingleOrDefault(tc => tc.ContactType == (int)ContactTypes.Primary);
+
+            if (string.IsNullOrWhiteSpace(campaignContact?.Contact.Email)) return;
+
+            var signup = model.UsersSignedUp.FirstOrDefault(s => s.User.Id == notification.UserId);
+
+            if (signup == null) return;
+
+            var activityLink = $"View activity: {_options.Value.SiteBaseUrl}Admin/Activity/Details/{model.ActivityId}";
+            var subject = $"A volunteer has unenrolled from {model.ActivityName}";
+
+            var message = new StringBuilder();
+            message.AppendLine($"A volunteer has unenrolled from an activity.");
+            message.AppendLine($"   Campaign: {model.CampaignName}");
+            message.AppendLine($"   Activity: {model.ActivityName} ({activityLink})");
+            message.AppendLine($"   Volunteer: {signup.User.UserName} ({signup.User.Email})");
+            message.AppendLine($"   Remaining Enrolled Volunteers: {model.UsersSignedUp.Count - 1}");
+            message.AppendLine();
+
+            var assignedTasks = model.Tasks.Where(t => t.AssignedVolunteers.Any(au => au.UserId == signup.User.Id)).ToList();
+            if (assignedTasks.Count == 0)
+            {
+                message.AppendLine("This volunteer had not been assigned to any tasks.");
+            }
+            else
+            {
+                message.AppendLine("This volunteer had been assigned to the following tasks:");
+                foreach (var task in assignedTasks)
+                {
+                    var taskLink = $"View task: {_options.Value.SiteBaseUrl}Admin/Task/Details/{task.Id}";
+                    message.AppendLine  ("   Name             Description               Start Date           TaskLink");
+                    message.AppendFormat("   {0}{1}{2:d}{3}",
+                        task.Name?.Substring(0, Math.Min(15, task.Name.Length)).PadRight(17, ' ') ?? "None".PadRight(17, ' '),
+                        task.Description?.Substring(0, Math.Min(25, task.Description.Length)).PadRight(26, ' ') ?? "None".PadRight(26,' '),
+                        task.StartDateTime?.Date.ToShortDateString().PadRight(21, ' ') ?? "".PadRight(21, ' '),
+                        taskLink);
+                }
+            }
+
+            var command = new NotifyVolunteersCommand
+            {
+                ViewModel = new NotifyVolunteersViewModel
+                {
+                    EmailMessage = message.ToString(),
+                    HtmlMessage = message.ToString(),
+                    EmailRecipients = new List<string> { campaignContact.Contact.Email },
+                    Subject = subject
+                }
+            };
+            _bus.Send(command);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForUserUnenrolls.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForUserUnenrolls.cs
@@ -40,7 +40,7 @@ namespace AllReady.Features.Notifications
             message.AppendLine($"   Campaign: {model.CampaignName}");
             message.AppendLine($"   Activity: {model.ActivityName} ({activityLink})");
             message.AppendLine($"   Volunteer: {signup.User.UserName} ({signup.User.Email})");
-            message.AppendLine($"   Remaining Enrolled Volunteers: {model.UsersSignedUp.Count - 1}");
+            message.AppendLine($"   Remaining/Required Volunteers: {model.UsersSignedUp.Count - 1}/{model.NumberOfVolunteersRequired}");
             message.AppendLine();
 
             var assignedTasks = model.Tasks.Where(t => t.AssignedVolunteers.Any(au => au.UserId == signup.User.Id)).ToList();

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/UserUnenrolls.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/UserUnenrolls.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Features.Notifications
+{
+    public class UserUnenrolls : INotification
+    {
+        public int ActivityId { get; set; }
+        public string UserId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/UserUnenrollsNotificationModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/UserUnenrollsNotificationModel.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using AllReady.Areas.Admin.Models;
+using AllReady.Models;
+
+namespace AllReady.Features.Notifications
+{
+    public class UserUnenrollsNotificationModel
+    {
+        public int ActivityId { get; set; }
+        public string CampaignName { get; set; }
+        public string ActivityName { get; set; }
+        public string Description { get; set; }
+        public int NumberOfVolunteersRequired { get; set; }
+        public List<TaskSummaryModel> Tasks { get; set; }
+        public List<CampaignContact> CampaignContacts { get; set; }
+        public List<ActivitySignup> UsersSignedUp { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/UserUnenrollsNotificationQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/UserUnenrollsNotificationQuery.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Notifications
+{
+    public class UserUnenrollsNotificationQuery : IRequest<UserUnenrollsNotificationModel>
+    {
+        public int ActivityId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/UserUnenrollsNotificationQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/UserUnenrollsNotificationQueryHandler.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using AllReady.Areas.Admin.Features.Activities;
+using AllReady.Areas.Admin.Models;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+
+namespace AllReady.Features.Notifications
+{
+    public class UserUnenrollsNotificationQueryHandler : IRequestHandler<UserUnenrollsNotificationQuery, UserUnenrollsNotificationModel>
+    {
+        private AllReadyContext _context;
+
+        public UserUnenrollsNotificationQueryHandler(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public UserUnenrollsNotificationModel Handle(UserUnenrollsNotificationQuery message)
+        {
+            UserUnenrollsNotificationModel result = null;
+
+            var activity = _context.Activities
+                .AsNoTracking()
+                .Include(a => a.Campaign)
+                .Include(a => a.Campaign.CampaignContacts).ThenInclude(c => c.Contact)
+                .Include(a => a.Tasks).ThenInclude(t => t.AssignedVolunteers).ThenInclude(av => av.User)
+                .Include(a => a.UsersSignedUp).ThenInclude(a => a.User)
+                .SingleOrDefault(a => a.Id == message.ActivityId);
+
+            if (activity != null)
+            {
+                result = new UserUnenrollsNotificationModel
+                {
+                    ActivityId = activity.Id,
+                    CampaignName = activity.Campaign.Name,
+                    CampaignContacts = activity.Campaign.CampaignContacts,
+                    ActivityName = activity.Name,
+                    Description = activity.Description,
+                    UsersSignedUp = activity.UsersSignedUp,
+                    NumberOfVolunteersRequired = activity.NumberOfVolunteersRequired,
+                    Tasks = activity.Tasks.Select(t => new TaskSummaryModel()
+                    {
+                        Id = t.Id,
+                        Name = t.Name,
+                        StartDateTime = t.StartDateTime,
+                        EndDateTime = t.EndDateTime,
+                        AssignedVolunteers = t.AssignedVolunteers.Select(assignedVolunteer => new VolunteerModel
+                        {
+                            UserId = assignedVolunteer.User.Id,
+                            UserName = assignedVolunteer.User.UserName,
+                            HasVolunteered = true
+                        }).ToList()
+                    }).OrderBy(t => t.StartDateTime).ThenBy(t => t.Name).ToList(),
+                };
+            }
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #473.

An email will now be sent to the campaign's primary contact, as defined in **Campaign.CampaignContacts**, when a user unenrolls from an activity.  The attached file contains an example of the email that is generated.

[email.txt](https://github.com/HTBox/allReady/files/99578/email.txt)
