### PR TITLE
Email after volunteering or unenrolling

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Notifications/GetUserUnenrollsNotificationModel.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Notifications/GetUserUnenrollsNotificationModel.cs
@@ -109,8 +109,8 @@ namespace AllReady.UnitTest.Notifications
         public void ModelCanBeCreatedFomExistingActivity()
         {
             var context = ServiceProvider.GetService<AllReadyContext>();
-            var query = new UserUnenrollsNotificationQuery { ActivityId = 1 };
-            var handler = new UserUnenrollsNotificationQueryHandler(context);
+            var query = new ActivityDetailForNotificationQuery { ActivityId = 1 };
+            var handler = new ActivityDetailForNotificationQueryHandler(context);
             var result = handler.Handle(query);
             Assert.NotNull(result);
             Assert.True(_queenAnne.UsersSignedUp.Count == result.UsersSignedUp.Count, "Count of signed up users does not match");
@@ -123,8 +123,8 @@ namespace AllReady.UnitTest.Notifications
         public void ActivityDoesNotExist()
         {
             var context = ServiceProvider.GetService<AllReadyContext>();
-            var query = new UserUnenrollsNotificationQuery { ActivityId = 999 };
-            var handler = new UserUnenrollsNotificationQueryHandler(context);
+            var query = new ActivityDetailForNotificationQuery { ActivityId = 999 };
+            var handler = new ActivityDetailForNotificationQueryHandler(context);
             var result = handler.Handle(query);
             Assert.Null(result);
         }

--- a/AllReadyApp/Web-App/AllReady/Controllers/ActivityApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ActivityApiController.cs
@@ -178,7 +178,7 @@ namespace AllReady.Controllers
                 return HttpNotFound();
             }
 
-            //Notify admins 
+            //Notify admins & volunteer
             _bus.Publish(new UserUnenrolls {ActivityId = signedUp.Activity.Id, UserId = signedUp.User.Id});
 
             await _allReadyDataAccess.DeleteActivitySignupAsync(signedUp.Id);

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/ActivityDetailForNotificationModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/ActivityDetailForNotificationModel.cs
@@ -4,7 +4,7 @@ using AllReady.Models;
 
 namespace AllReady.Features.Notifications
 {
-    public class UserUnenrollsNotificationModel
+    public class ActivityDetailForNotificationModel
     {
         public int ActivityId { get; set; }
         public string CampaignName { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/ActivityDetailForNotificationQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/ActivityDetailForNotificationQuery.cs
@@ -2,7 +2,7 @@
 
 namespace AllReady.Features.Notifications
 {
-    public class UserUnenrollsNotificationQuery : IRequest<UserUnenrollsNotificationModel>
+    public class ActivityDetailForNotificationQuery : IRequest<ActivityDetailForNotificationModel>
     {
         public int ActivityId { get; set; }
     }

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/ActivityDetailForNotificationQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/ActivityDetailForNotificationQueryHandler.cs
@@ -7,18 +7,18 @@ using Microsoft.Data.Entity;
 
 namespace AllReady.Features.Notifications
 {
-    public class UserUnenrollsNotificationQueryHandler : IRequestHandler<UserUnenrollsNotificationQuery, UserUnenrollsNotificationModel>
+    public class ActivityDetailForNotificationQueryHandler : IRequestHandler<ActivityDetailForNotificationQuery, ActivityDetailForNotificationModel>
     {
         private AllReadyContext _context;
 
-        public UserUnenrollsNotificationQueryHandler(AllReadyContext context)
+        public ActivityDetailForNotificationQueryHandler(AllReadyContext context)
         {
             _context = context;
         }
 
-        public UserUnenrollsNotificationModel Handle(UserUnenrollsNotificationQuery message)
+        public ActivityDetailForNotificationModel Handle(ActivityDetailForNotificationQuery message)
         {
-            UserUnenrollsNotificationModel result = null;
+            ActivityDetailForNotificationModel result = null;
 
             var activity = _context.Activities
                 .AsNoTracking()
@@ -30,7 +30,7 @@ namespace AllReady.Features.Notifications
 
             if (activity != null)
             {
-                result = new UserUnenrollsNotificationModel
+                result = new ActivityDetailForNotificationModel
                 {
                     ActivityId = activity.Id,
                     CampaignName = activity.Campaign.Name,

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForUserUnenrolls.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForUserUnenrolls.cs
@@ -23,7 +23,7 @@ namespace AllReady.Features.Notifications
 
         public void Handle(UserUnenrolls notification)
         {
-            var model = _bus.Send(new UserUnenrollsNotificationQuery {ActivityId = notification.ActivityId});
+            var model = _bus.Send(new ActivityDetailForNotificationQuery {ActivityId = notification.ActivityId});
             var campaignContact = model.CampaignContacts.SingleOrDefault(tc => tc.ContactType == (int)ContactTypes.Primary);
 
             if (string.IsNullOrWhiteSpace(campaignContact?.Contact.Email)) return;

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForActivitySignup.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForActivitySignup.cs
@@ -26,8 +26,13 @@ namespace AllReady.Features.Notifications
             var model = _bus.Send(new ActivityDetailForNotificationQuery {ActivityId = notification.ActivityId});
 
             var signup = model.UsersSignedUp?.FirstOrDefault(s => s.User.Id == notification.UserId);
+            if (signup == null) return;
 
-            if (string.IsNullOrWhiteSpace(signup?.PreferredEmail)) return;
+            var emailRecipient = !string.IsNullOrWhiteSpace(signup.PreferredEmail)
+                ? signup.PreferredEmail
+                : signup.User?.Email;
+
+            if (string.IsNullOrWhiteSpace(emailRecipient)) return;
 
             var activityLink = $"View activity: {_options.Value.SiteBaseUrl}Admin/Activity/Details/{model.ActivityId}";
             var subject = "allReady Activity Enrollment Confirmation";
@@ -46,7 +51,7 @@ namespace AllReady.Features.Notifications
                 {
                     EmailMessage = message.ToString(),
                     HtmlMessage = message.ToString(),
-                    EmailRecipients = new List<string> { signup.PreferredEmail},
+                    EmailRecipients = new List<string> { emailRecipient},
                     Subject = subject
                 }
             };

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForActivitySignup.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForActivitySignup.cs
@@ -25,7 +25,7 @@ namespace AllReady.Features.Notifications
         {
             var model = _bus.Send(new ActivityDetailForNotificationQuery {ActivityId = notification.ActivityId});
 
-            var signup = model.UsersSignedUp.FirstOrDefault(s => s.User.Id == notification.UserId);
+            var signup = model.UsersSignedUp?.FirstOrDefault(s => s.User.Id == notification.UserId);
 
             if (string.IsNullOrWhiteSpace(signup?.PreferredEmail)) return;
 

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForActivitySignup.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForActivitySignup.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AllReady.Areas.Admin.Features.Activities;
+using AllReady.Features.Login;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Extensions.OptionsModel;
+
+namespace AllReady.Features.Notifications
+{
+    public class NotifyVolunteerForActivitySignup : INotificationHandler<VolunteerInformationAdded>
+    {
+        private readonly IMediator _bus;
+        private readonly IOptions<GeneralSettings> _options;
+
+        public NotifyVolunteerForActivitySignup(IMediator bus, IOptions<GeneralSettings> options)
+        {
+            _bus = bus;
+            _options = options;
+        }
+
+        public void Handle(VolunteerInformationAdded notification)
+        {
+            var model = _bus.Send(new ActivityDetailForNotificationQuery {ActivityId = notification.ActivityId});
+
+            var signup = model.UsersSignedUp.FirstOrDefault(s => s.User.Id == notification.UserId);
+
+            if (signup == null || !signup.User.EmailConfirmed) return;
+
+            var activityLink = $"View activity: {_options.Value.SiteBaseUrl}Admin/Activity/Details/{model.ActivityId}";
+            var subject = "allReady Activity Enrollment Confirmation";
+
+            var message = new StringBuilder();
+            message.AppendLine($"This is to confirm that you have volunteered to participate in the following activity:");
+            message.AppendLine();
+            message.AppendLine($"   Campaign: {model.CampaignName}");
+            message.AppendLine($"   Activity: {model.ActivityName} ({activityLink})");
+            message.AppendLine();
+            message.AppendLine($"Thanks for volunteering. Your help is appreciated.");
+
+            var command = new NotifyVolunteersCommand
+            {
+                ViewModel = new NotifyVolunteersViewModel
+                {
+                    EmailMessage = message.ToString(),
+                    HtmlMessage = message.ToString(),
+                    EmailRecipients = new List<string> { signup.User.Email },
+                    Subject = subject
+                }
+            };
+            _bus.Send(command);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForActivitySignup.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForActivitySignup.cs
@@ -27,7 +27,7 @@ namespace AllReady.Features.Notifications
 
             var signup = model.UsersSignedUp.FirstOrDefault(s => s.User.Id == notification.UserId);
 
-            if (signup == null || !signup.User.EmailConfirmed) return;
+            if (string.IsNullOrWhiteSpace(signup?.PreferredEmail)) return;
 
             var activityLink = $"View activity: {_options.Value.SiteBaseUrl}Admin/Activity/Details/{model.ActivityId}";
             var subject = "allReady Activity Enrollment Confirmation";
@@ -46,7 +46,7 @@ namespace AllReady.Features.Notifications
                 {
                     EmailMessage = message.ToString(),
                     HtmlMessage = message.ToString(),
-                    EmailRecipients = new List<string> { signup.User.Email },
+                    EmailRecipients = new List<string> { signup.PreferredEmail},
                     Subject = subject
                 }
             };

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForUserUnenrolls.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForUserUnenrolls.cs
@@ -26,8 +26,12 @@ namespace AllReady.Features.Notifications
             var model = _bus.Send(new ActivityDetailForNotificationQuery {ActivityId = notification.ActivityId});
 
             var signup = model.UsersSignedUp?.FirstOrDefault(s => s.User.Id == notification.UserId);
+            if (signup == null) return;
 
-            if (string.IsNullOrWhiteSpace(signup?.PreferredEmail)) return;
+            var emailRecipient = !string.IsNullOrWhiteSpace(signup.PreferredEmail)
+                ? signup.PreferredEmail
+                : signup.User?.Email;
+            if (string.IsNullOrWhiteSpace(emailRecipient)) return;
 
             var activityLink = $"View activity: {_options.Value.SiteBaseUrl}Admin/Activity/Details/{model.ActivityId}";
             var subject = "allReady Activity Unenrollment Confirmation";
@@ -46,7 +50,7 @@ namespace AllReady.Features.Notifications
                 {
                     EmailMessage = message.ToString(),
                     HtmlMessage = message.ToString(),
-                    EmailRecipients = new List<string> { signup.PreferredEmail },
+                    EmailRecipients = new List<string> { emailRecipient },
                     Subject = subject
                 }
             };

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForUserUnenrolls.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForUserUnenrolls.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using AllReady.Areas.Admin.Features.Activities;
+using AllReady.Features.Login;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Extensions.OptionsModel;
+
+namespace AllReady.Features.Notifications
+{
+    public class NotifyVolunteerForUserUnenrolls : INotificationHandler<UserUnenrolls>
+    {
+        private readonly IMediator _bus;
+        private readonly IOptions<GeneralSettings> _options;
+
+        public NotifyVolunteerForUserUnenrolls(IMediator bus, IOptions<GeneralSettings> options)
+        {
+            _bus = bus;
+            _options = options;
+        }
+
+        public void Handle(UserUnenrolls notification)
+        {
+            var model = _bus.Send(new ActivityDetailForNotificationQuery {ActivityId = notification.ActivityId});
+
+            var signup = model.UsersSignedUp.FirstOrDefault(s => s.User.Id == notification.UserId);
+
+            if (signup == null || !signup.User.EmailConfirmed) return;
+
+            var activityLink = $"View activity: {_options.Value.SiteBaseUrl}Admin/Activity/Details/{model.ActivityId}";
+            var subject = "allReady Activity Unenrollment Confirmation";
+
+            var message = new StringBuilder();
+            message.AppendLine($"This is to confirm that you have elected to unenroll from the following activity:");
+            message.AppendLine();
+            message.AppendLine($"   Campaign: {model.CampaignName}");
+            message.AppendLine($"   Activity: {model.ActivityName} ({activityLink})");
+            message.AppendLine();
+            message.AppendLine($"Thanks for letting us know that you will not be participating.");
+
+            var command = new NotifyVolunteersCommand
+            {
+                ViewModel = new NotifyVolunteersViewModel
+                {
+                    EmailMessage = message.ToString(),
+                    HtmlMessage = message.ToString(),
+                    EmailRecipients = new List<string> { signup.User.Email },
+                    Subject = subject
+                }
+            };
+            _bus.Send(command);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForUserUnenrolls.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForUserUnenrolls.cs
@@ -25,7 +25,7 @@ namespace AllReady.Features.Notifications
         {
             var model = _bus.Send(new ActivityDetailForNotificationQuery {ActivityId = notification.ActivityId});
 
-            var signup = model.UsersSignedUp.FirstOrDefault(s => s.User.Id == notification.UserId);
+            var signup = model.UsersSignedUp?.FirstOrDefault(s => s.User.Id == notification.UserId);
 
             if (string.IsNullOrWhiteSpace(signup?.PreferredEmail)) return;
 

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForUserUnenrolls.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyVolunteerForUserUnenrolls.cs
@@ -27,7 +27,7 @@ namespace AllReady.Features.Notifications
 
             var signup = model.UsersSignedUp.FirstOrDefault(s => s.User.Id == notification.UserId);
 
-            if (signup == null || !signup.User.EmailConfirmed) return;
+            if (string.IsNullOrWhiteSpace(signup?.PreferredEmail)) return;
 
             var activityLink = $"View activity: {_options.Value.SiteBaseUrl}Admin/Activity/Details/{model.ActivityId}";
             var subject = "allReady Activity Unenrollment Confirmation";
@@ -46,7 +46,7 @@ namespace AllReady.Features.Notifications
                 {
                     EmailMessage = message.ToString(),
                     HtmlMessage = message.ToString(),
-                    EmailRecipients = new List<string> { signup.User.Email },
+                    EmailRecipients = new List<string> { signup.PreferredEmail },
                     Subject = subject
                 }
             };


### PR DESCRIPTION
Fixes #372

Confirmation emails will now be sent to the volunteer upon signing up for or unenrolling from an activity.

Note, as discussed in the issue comments, this PR does not provide for allowing user to opt out of receiving these emails.