### PR TITLE
Scenario V1: Volunteer Edit Profile

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -48,22 +48,7 @@ namespace AllReady.Controllers
                 : "";
 
             var user = GetCurrentUser();
-            var model = new IndexViewModel
-            {
-                HasPassword = await _userManager.HasPasswordAsync(user),
-                EmailAddress = user.Email,
-                IsEmailAddressConfirmed = user.EmailConfirmed,
-                IsPhoneNumberConfirmed = user.PhoneNumberConfirmed,
-                PhoneNumber = await _userManager.GetPhoneNumberAsync(user),
-                TwoFactor = await _userManager.GetTwoFactorEnabledAsync(user),
-                Logins = await _userManager.GetLoginsAsync(user),
-                BrowserRemembered = await _signInManager.IsTwoFactorClientRememberedAsync(user),
-                AssociatedSkills = user.AssociatedSkills,
-                TimeZoneId = user.TimeZoneId,
-                Name = user.Name,
-                ProposedNewEmailAddress = user.PendingNewEmail
-            };
-            return View(model);
+            return View(await user.ToViewModel(_userManager, _signInManager));
         }
 
         // POST: /Manage/Index
@@ -71,11 +56,16 @@ namespace AllReady.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Index(IndexViewModel model)
         {
+            var user = GetCurrentUser();
+
             if (!ModelState.IsValid)
             {
-                return View(model);
+                var viewModelWithInputs = await user.ToViewModel(_userManager, _signInManager);
+                viewModelWithInputs.Name = model.Name;
+                viewModelWithInputs.TimeZoneId = model.TimeZoneId;
+                viewModelWithInputs.AssociatedSkills = model.AssociatedSkills;
+                return View(viewModelWithInputs);
             }
-            var user = GetCurrentUser();
             var shouldRefreshSignin = false;
             if (!string.IsNullOrEmpty(model.Name))
             {

--- a/AllReadyApp/Web-App/AllReady/ViewModels/ManageViewModels.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/ManageViewModels.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.ComponentModel.DataAnnotations;
+using AllReady.ViewModels;
 using Microsoft.AspNet.Http.Authentication;
 using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Mvc.Rendering;
@@ -11,6 +12,13 @@ namespace AllReady.Models
 {
     public class IndexViewModel
     {
+        public IndexViewModel()
+        {
+            Logins = new List<UserLoginInfo>();
+            AssociatedSkills = new List<UserSkill>();
+        }
+
+        [Required]
         public string Name { get; set; }
 
         [Display(Name = "Email Address")]
@@ -38,6 +46,29 @@ namespace AllReady.Models
         public string TimeZoneId { get; set; }
 
         public string ProposedNewEmailAddress { get; set; }
+    }
+
+    public static class IndexViewModelExtensions
+    {
+        public static async Task<IndexViewModel> ToViewModel(this ApplicationUser user, UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager)
+        {
+            var result = new IndexViewModel
+            {
+                HasPassword = await userManager.HasPasswordAsync(user),
+                EmailAddress = user.Email,
+                IsEmailAddressConfirmed = user.EmailConfirmed,
+                IsPhoneNumberConfirmed = user.PhoneNumberConfirmed,
+                PhoneNumber = await userManager.GetPhoneNumberAsync(user),
+                TwoFactor = await userManager.GetTwoFactorEnabledAsync(user),
+                Logins = await userManager.GetLoginsAsync(user),
+                BrowserRemembered = await signInManager.IsTwoFactorClientRememberedAsync(user),
+                AssociatedSkills = user.AssociatedSkills,
+                TimeZoneId = user.TimeZoneId,
+                Name = user.Name,
+                ProposedNewEmailAddress = user.PendingNewEmail
+            };
+            return result;
+        }
     }
 
     public class ManageLoginsViewModel


### PR DESCRIPTION
Fixes #501 

This PR addresses making the "Name" property "Required" on profile add/edit as stipulated on the following requirement:
- [ ] **Volunteer can enter/edit name as required field**

The remaining requirements of this issue appear to be handled in the existing code:
- [x]  Name appears as supplied at top next to Hello instead of email address
- [x]  Volunteer can enter/edit phone number
- [x]  App performs verification via SMS on phone number
- [x]  Volunteer can update password (if using site account)
- [x]  Skills - Volunteer can self report skills by adding/removing skills from list
- [x]  Skills - Skills list contains skills user supplied on this screen as well as any identified when they volunteer