### PR TITLE
Add "ActivityType" property to "Activity" model to support new Activity workflows

### DIFF
--- a/AllReadyApp/AllReady.IntegrationTest/Pages.fs
+++ b/AllReadyApp/AllReady.IntegrationTest/Pages.fs
@@ -92,15 +92,16 @@ module AdminActivityCreate =
         VolunteersRequired:int
         StartDate:string
         EndDate:string
-
+        ActivityType: int
     }
 
     let DefaultActivityDetails = {
         Name = ""
         Description = ""
-        VolunteersRequired = 0
+        VolunteersRequired = 1
         StartDate = ""
         EndDate = ""
+        ActivityType = 1
     }
 
     let PopulateActivityDetails details =
@@ -109,6 +110,7 @@ module AdminActivityCreate =
         "#NumberOfVolunteersRequired" << details.VolunteersRequired.ToString()
         "#StartDateTime" << details.StartDate
         "#EndDateTime" << details.EndDate
+        "#ActivityType" << details.ActivityType.ToString()
 
     let private createBtn = "Create"
 

--- a/AllReadyApp/AllReady.IntegrationTest/Pages.fs
+++ b/AllReadyApp/AllReady.IntegrationTest/Pages.fs
@@ -85,6 +85,7 @@ module AdminOrganizationCreate =
         click "Save"
 
 
+
 module AdminActivityCreate =
     type ActivityDetails = {
         Name:string

--- a/AllReadyApp/AllReady.IntegrationTest/Pages.fs
+++ b/AllReadyApp/AllReady.IntegrationTest/Pages.fs
@@ -113,7 +113,7 @@ module AdminActivityCreate =
         "#EndDateTime" << details.EndDate
         "#ActivityType" << details.ActivityType.ToString()
 
-    let private createBtn = "Create"
+    let private createBtn = ".submit-form"
 
     let Create _ =
         click createBtn

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ActivityAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ActivityAdminController.cs
@@ -63,6 +63,7 @@ namespace AllReady.Areas.Admin.Controllers
                 return HttpUnauthorized();
             }
 
+
             var activity = new ActivityDetailModel
             {
                 CampaignId = campaign.Id,
@@ -135,6 +136,7 @@ namespace AllReady.Areas.Admin.Controllers
         public IActionResult Edit(int id)
         {
             ActivityDetailModel activity = _bus.Send(new ActivityDetailQuery { ActivityId = id });
+
             if (activity == null)
             {
                 return HttpNotFound();

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ActivityDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ActivityDetailQueryHandler.cs
@@ -32,6 +32,7 @@ namespace AllReady.Areas.Admin.Features.Activities
                 result = new ActivityDetailModel
                 {
                     Id = activity.Id,
+                    ActivityType = activity.ActivityType,
                     CampaignName = activity.Campaign.Name,
                     CampaignId = activity.Campaign.Id,
                     OrganizationId = activity.Campaign.ManagingOrganizationId,

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/EditActivityCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/EditActivityCommandHandler.cs
@@ -29,6 +29,7 @@ namespace AllReady.Areas.Admin.Features.Activities
 
             activity.Name = message.Activity.Name;
             activity.Description = message.Activity.Description;
+            activity.ActivityType = message.Activity.ActivityType;
 
             TimeZoneInfo timeZone = TimeZoneInfo.FindSystemTimeZoneById(message.Activity.TimeZoneId);
             var startDateTimeOffset = timeZone.GetUtcOffset(message.Activity.StartDateTime);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ActivitySummaryModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ActivitySummaryModel.cs
@@ -37,6 +37,7 @@ namespace AllReady.Areas.Admin.Models
         [Display(Name = "Browse for image")]
         public string FileUpload { get; set; }
 
+        [Range(1, int.MaxValue, ErrorMessage = "'Volunteers Required' must be greater than 0")]
         [Display(Name = "Volunteers Required")]
         public int NumberOfVolunteersRequired { get; set; }
         

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ActivitySummaryModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ActivitySummaryModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
+using AllReady.Models;
 
 namespace AllReady.Areas.Admin.Models
 {
@@ -12,6 +13,12 @@ namespace AllReady.Areas.Admin.Models
 
         [Required]
         public string Name { get; set; }
+
+        [Required]
+        [Range(1, 99, ErrorMessage = "A valid 'Activity Type' is required")]
+        [Display(Name = "Activity Type")]
+        public ActivityTypes ActivityType { get; set; }
+
         public string Description { get; set; }
 
         [Display(Name = "Campaign")]

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Edit.cshtml
@@ -151,7 +151,7 @@
 
     <div class="row">
         <div class="col-md-12">
-            <button type="submit" value="@actionTitle" class="btn btn-default" data-bind="enable: requiredSkills.isValid">@actionTitle</button>
+            <button type="submit" value="@actionTitle" class="btn btn-default submit-form" data-bind="enable: requiredSkills.isValid">@actionTitle</button>
             <a href="@cancelUrl" class="btn btn-default">Cancel</a>        
         </div>
     </div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Edit.cshtml
@@ -1,3 +1,5 @@
+@using System.Threading.Tasks
+@using AllReady.Services
 @model  AllReady.Areas.Admin.Models.ActivityDetailModel
 @inject AllReady.Services.ISelectListService SelectListService
 
@@ -69,6 +71,15 @@
                 </div>
             </div>
             <div class="form-group">
+                <label asp-for="ActivityType" class="control-label col-md-2"></label>
+                <div class="col-md-10">
+                    <select asp-for="ActivityType" asp-items="Html.GetEnumSelectList<ActivityTypes>()" class="form-control">
+                        <option value="0">-- Select --</option>
+                    </select>
+                    <span asp-validation-for="ActivityType" class="text-danger"></span>
+                </div>
+            </div>
+            <div class="form-group">
                 <label asp-for="NumberOfVolunteersRequired" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="NumberOfVolunteersRequired" class="form-control" />
@@ -79,7 +90,7 @@
                 <label asp-for="StartDateTime" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="StartDateTime" class="form-control datetimepicker" />
-                    <time-zone-name time-zone-id="@Model.TimeZoneId" class="text-muted"></time-zone-name>
+                    <time-zone-name time-zone-id="@Model.TimeZoneId" class="text-muted"></time-zone-name><br />
                     <span asp-validation-for="StartDateTime" class="text-danger"></span>
                 </div>
             </div>
@@ -87,7 +98,7 @@
                 <label asp-for="EndDateTime" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="EndDateTime" class="form-control datetimepicker" />
-                    <time-zone-name time-zone-id="@Model.TimeZoneId" class="text-muted"></time-zone-name>
+                    <time-zone-name time-zone-id="@Model.TimeZoneId" class="text-muted"></time-zone-name><br />
                     <span asp-validation-for="EndDateTime" class="text-danger"></span>
                 </div>
             </div>

--- a/AllReadyApp/Web-App/AllReady/Migrations/20160203182757_ActivityType.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20160203182757_ActivityType.Designer.cs
@@ -1,0 +1,689 @@
+using System;
+using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Migrations;
+using AllReady.Models;
+
+namespace AllReady.Migrations
+{
+    [DbContext(typeof(AllReadyContext))]
+    [Migration("20160203182757_ActivityType")]
+    partial class ActivityType
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "7.0.0-rc1-16348")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("AllReady.Models.Activity", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("ActivityType");
+
+                    b.Property<int>("CampaignId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ActivitySignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("ActivityId");
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<DateTime?>("CheckinDateTime");
+
+                    b.Property<string>("PreferredEmail");
+
+                    b.Property<string>("PreferredPhoneNumber");
+
+                    b.Property<DateTime>("SignupDateTime");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ActivitySkill", b =>
+                {
+                    b.Property<int>("ActivityId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("ActivityId", "SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("ActivityId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset?>("EndDateTime");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<DateTimeOffset?>("StartDateTime");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PendingNewEmail");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasAnnotation("Relational:Name", "EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .HasAnnotation("Relational:Name", "UserNameIndex");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUsers");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignImpactId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<string>("FullDescription");
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<int>("ManagingOrganizationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.Property<int>("CampaignId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.HasKey("CampaignId", "ContactId", "ContactType");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignImpact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CurrentImpactLevel");
+
+                    b.Property<bool>("Display");
+
+                    b.Property<int>("ImpactType");
+
+                    b.Property<int>("NumericImpactGoal");
+
+                    b.Property<string>("TextualImpactGoal");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignId");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ClosestLocation", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<double>("Distance");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Contact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Location", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address1");
+
+                    b.Property<string>("Address2");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("Country");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<string>("PostalCodePostalCode");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("LogoUrl");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("WebUrl");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.Property<int>("OrganizationId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.HasKey("OrganizationId", "ContactId", "ContactType");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeo", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeoCoordinate", b =>
+                {
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.HasKey("Latitude", "Longitude");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Resource", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("CategoryTag");
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("MediaUrl");
+
+                    b.Property<string>("Name");
+
+                    b.Property<DateTime>("PublishDateBegin");
+
+                    b.Property<DateTime>("PublishDateEnd");
+
+                    b.Property<string>("ResourceUrl");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int?>("OwningOrganizationId");
+
+                    b.Property<int?>("ParentSkillId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Status");
+
+                    b.Property<DateTime>("StatusDateTimeUtc");
+
+                    b.Property<string>("StatusDescription");
+
+                    b.Property<int?>("TaskId");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.Property<int>("TaskId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("TaskId", "SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("UserId", "SkillId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRole", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Name")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .HasAnnotation("Relational:Name", "RoleNameIndex");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetRoles");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("RoleId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetRoleClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider");
+
+                    b.Property<string>("ProviderKey");
+
+                    b.Property<string>("ProviderDisplayName");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserLogins");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<string>("RoleId");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserRoles");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Activity", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ActivitySignup", b =>
+                {
+                    b.HasOne("AllReady.Models.Activity")
+                        .WithMany()
+                        .HasForeignKey("ActivityId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ActivitySkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Activity")
+                        .WithMany()
+                        .HasForeignKey("ActivityId");
+
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.HasOne("AllReady.Models.Activity")
+                        .WithMany()
+                        .HasForeignKey("ActivityId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.HasOne("AllReady.Models.CampaignImpact")
+                        .WithMany()
+                        .HasForeignKey("CampaignImpactId");
+
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("ManagingOrganizationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Location", b =>
+                {
+                    b.HasOne("AllReady.Models.PostalCodeGeo")
+                        .WithMany()
+                        .HasForeignKey("PostalCodePostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OwningOrganizationId");
+
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("ParentSkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.HasOne("AllReady.Models.AllReadyTask")
+                        .WithMany()
+                        .HasForeignKey("TaskId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+
+                    b.HasOne("AllReady.Models.AllReadyTask")
+                        .WithMany()
+                        .HasForeignKey("TaskId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNet.Identity.EntityFramework.IdentityRole")
+                        .WithMany()
+                        .HasForeignKey("RoleId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNet.Identity.EntityFramework.IdentityRole")
+                        .WithMany()
+                        .HasForeignKey("RoleId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20160203182757_ActivityType.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20160203182757_ActivityType.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using AllReady.Models;
+using Microsoft.Data.Entity.Migrations;
+
+namespace AllReady.Migrations
+{
+    public partial class ActivityType : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(name: "FK_Activity_Campaign_CampaignId", table: "Activity");
+            migrationBuilder.DropForeignKey(name: "FK_ActivitySkill_Activity_ActivityId", table: "ActivitySkill");
+            migrationBuilder.DropForeignKey(name: "FK_ActivitySkill_Skill_SkillId", table: "ActivitySkill");
+            migrationBuilder.DropForeignKey(name: "FK_Campaign_Organization_ManagingOrganizationId", table: "Campaign");
+            migrationBuilder.DropForeignKey(name: "FK_CampaignContact_Campaign_CampaignId", table: "CampaignContact");
+            migrationBuilder.DropForeignKey(name: "FK_CampaignContact_Contact_ContactId", table: "CampaignContact");
+            migrationBuilder.DropForeignKey(name: "FK_OrganizationContact_Contact_ContactId", table: "OrganizationContact");
+            migrationBuilder.DropForeignKey(name: "FK_OrganizationContact_Organization_OrganizationId", table: "OrganizationContact");
+            migrationBuilder.DropForeignKey(name: "FK_TaskSkill_Skill_SkillId", table: "TaskSkill");
+            migrationBuilder.DropForeignKey(name: "FK_TaskSkill_AllReadyTask_TaskId", table: "TaskSkill");
+            migrationBuilder.DropForeignKey(name: "FK_UserSkill_Skill_SkillId", table: "UserSkill");
+            migrationBuilder.DropForeignKey(name: "FK_UserSkill_ApplicationUser_UserId", table: "UserSkill");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityRoleClaim<string>_IdentityRole_RoleId", table: "AspNetRoleClaims");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserClaim<string>_ApplicationUser_UserId", table: "AspNetUserClaims");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserLogin<string>_ApplicationUser_UserId", table: "AspNetUserLogins");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserRole<string>_IdentityRole_RoleId", table: "AspNetUserRoles");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserRole<string>_ApplicationUser_UserId", table: "AspNetUserRoles");
+            migrationBuilder.AddColumn<int>(
+                name: "ActivityType",
+                table: "Activity",
+                nullable: false,
+                defaultValue: Models.ActivityTypes.ActivityManaged);
+            migrationBuilder.AddForeignKey(
+                name: "FK_Activity_Campaign_CampaignId",
+                table: "Activity",
+                column: "CampaignId",
+                principalTable: "Campaign",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivitySkill_Activity_ActivityId",
+                table: "ActivitySkill",
+                column: "ActivityId",
+                principalTable: "Activity",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivitySkill_Skill_SkillId",
+                table: "ActivitySkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_Campaign_Organization_ManagingOrganizationId",
+                table: "Campaign",
+                column: "ManagingOrganizationId",
+                principalTable: "Organization",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_CampaignContact_Campaign_CampaignId",
+                table: "CampaignContact",
+                column: "CampaignId",
+                principalTable: "Campaign",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_CampaignContact_Contact_ContactId",
+                table: "CampaignContact",
+                column: "ContactId",
+                principalTable: "Contact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationContact_Contact_ContactId",
+                table: "OrganizationContact",
+                column: "ContactId",
+                principalTable: "Contact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationContact_Organization_OrganizationId",
+                table: "OrganizationContact",
+                column: "OrganizationId",
+                principalTable: "Organization",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_TaskSkill_Skill_SkillId",
+                table: "TaskSkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_TaskSkill_AllReadyTask_TaskId",
+                table: "TaskSkill",
+                column: "TaskId",
+                principalTable: "AllReadyTask",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSkill_Skill_SkillId",
+                table: "UserSkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSkill_ApplicationUser_UserId",
+                table: "UserSkill",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityRoleClaim<string>_IdentityRole_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserClaim<string>_ApplicationUser_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserLogin<string>_ApplicationUser_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserRole<string>_IdentityRole_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserRole<string>_ApplicationUser_UserId",
+                table: "AspNetUserRoles",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(name: "FK_Activity_Campaign_CampaignId", table: "Activity");
+            migrationBuilder.DropForeignKey(name: "FK_ActivitySkill_Activity_ActivityId", table: "ActivitySkill");
+            migrationBuilder.DropForeignKey(name: "FK_ActivitySkill_Skill_SkillId", table: "ActivitySkill");
+            migrationBuilder.DropForeignKey(name: "FK_Campaign_Organization_ManagingOrganizationId", table: "Campaign");
+            migrationBuilder.DropForeignKey(name: "FK_CampaignContact_Campaign_CampaignId", table: "CampaignContact");
+            migrationBuilder.DropForeignKey(name: "FK_CampaignContact_Contact_ContactId", table: "CampaignContact");
+            migrationBuilder.DropForeignKey(name: "FK_OrganizationContact_Contact_ContactId", table: "OrganizationContact");
+            migrationBuilder.DropForeignKey(name: "FK_OrganizationContact_Organization_OrganizationId", table: "OrganizationContact");
+            migrationBuilder.DropForeignKey(name: "FK_TaskSkill_Skill_SkillId", table: "TaskSkill");
+            migrationBuilder.DropForeignKey(name: "FK_TaskSkill_AllReadyTask_TaskId", table: "TaskSkill");
+            migrationBuilder.DropForeignKey(name: "FK_UserSkill_Skill_SkillId", table: "UserSkill");
+            migrationBuilder.DropForeignKey(name: "FK_UserSkill_ApplicationUser_UserId", table: "UserSkill");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityRoleClaim<string>_IdentityRole_RoleId", table: "AspNetRoleClaims");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserClaim<string>_ApplicationUser_UserId", table: "AspNetUserClaims");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserLogin<string>_ApplicationUser_UserId", table: "AspNetUserLogins");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserRole<string>_IdentityRole_RoleId", table: "AspNetUserRoles");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserRole<string>_ApplicationUser_UserId", table: "AspNetUserRoles");
+            migrationBuilder.DropColumn(name: "ActivityType", table: "Activity");
+            migrationBuilder.AddForeignKey(
+                name: "FK_Activity_Campaign_CampaignId",
+                table: "Activity",
+                column: "CampaignId",
+                principalTable: "Campaign",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivitySkill_Activity_ActivityId",
+                table: "ActivitySkill",
+                column: "ActivityId",
+                principalTable: "Activity",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivitySkill_Skill_SkillId",
+                table: "ActivitySkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_Campaign_Organization_ManagingOrganizationId",
+                table: "Campaign",
+                column: "ManagingOrganizationId",
+                principalTable: "Organization",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_CampaignContact_Campaign_CampaignId",
+                table: "CampaignContact",
+                column: "CampaignId",
+                principalTable: "Campaign",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_CampaignContact_Contact_ContactId",
+                table: "CampaignContact",
+                column: "ContactId",
+                principalTable: "Contact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationContact_Contact_ContactId",
+                table: "OrganizationContact",
+                column: "ContactId",
+                principalTable: "Contact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationContact_Organization_OrganizationId",
+                table: "OrganizationContact",
+                column: "OrganizationId",
+                principalTable: "Organization",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_TaskSkill_Skill_SkillId",
+                table: "TaskSkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_TaskSkill_AllReadyTask_TaskId",
+                table: "TaskSkill",
+                column: "TaskId",
+                principalTable: "AllReadyTask",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSkill_Skill_SkillId",
+                table: "UserSkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSkill_ApplicationUser_UserId",
+                table: "UserSkill",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityRoleClaim<string>_IdentityRole_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserClaim<string>_ApplicationUser_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserLogin<string>_ApplicationUser_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserRole<string>_IdentityRole_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserRole<string>_ApplicationUser_UserId",
+                table: "AspNetUserRoles",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
@@ -21,6 +21,8 @@ namespace AllReady.Migrations
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd();
 
+                    b.Property<int>("ActivityType");
+
                     b.Property<int>("CampaignId");
 
                     b.Property<string>("Description");

--- a/AllReadyApp/Web-App/AllReady/Models/Activity.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Activity.cs
@@ -18,6 +18,9 @@ namespace AllReady.Models
 
         public string Description { get; set; }
 
+        [Display(Name = "Activity Type")]
+        public ActivityTypes ActivityType { get; set; }    
+        
         public int NumberOfVolunteersRequired { get; set; }
 
         [Display(Name = "Start date")]

--- a/AllReadyApp/Web-App/AllReady/Models/ActivityTypes.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/ActivityTypes.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace AllReady.Models
+{
+    public enum ActivityTypes
+    {
+        [Display(Name = "Activity Managed")]
+        ActivityManaged,
+
+        [Display(Name = "Task Managed")]
+        TaskManaged,
+
+        [Display(Name = "Deployment Managed")]
+        DeploymentManaged
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Models/ActivityTypes.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/ActivityTypes.cs
@@ -5,12 +5,12 @@ namespace AllReady.Models
     public enum ActivityTypes
     {
         [Display(Name = "Activity Managed")]
-        ActivityManaged,
+        ActivityManaged = 1,
 
         [Display(Name = "Task Managed")]
-        TaskManaged,
+        TaskManaged = 2,
 
         [Display(Name = "Deployment Managed")]
-        DeploymentManaged
+        DeploymentManaged = 3
     }
 }


### PR DESCRIPTION
Fixes #505.

## Note: This PR may need to be merged into a feature branch instead of Master

This PR  is a pre-requisite for issues #506, #507 & #508 and provides the following:
- [x] Add "ActivityTypes" enum with entries for the different activity types (ActivityManaged, TaskManaged, DeploymentManaged).  Note that per @tonysurma in #504 these names may be changed.
- [x] Add "ActivityType" property to "Activity" model
- [x] Create database migration script
- [x] Add "ActivityType" to  admin add/edit dialog for Activity 

If this were merged into "master" the only functionality change in the app visible to the user would be the "ActivityType" field appearing in the admin add/edit for Activity.  This property is not yet acted on by the rest of the app.  If this needs to be merged into a feature branch and I need to submit a different PR, please advise.