### PR TITLE
Excluding locked campaigns from the results on the Organization page

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/OrganizationControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/OrganizationControllerTests.cs
@@ -1,0 +1,92 @@
+﻿using AllReady.Controllers;
+using AllReady.Features.Organizations;
+using AllReady.Models;
+using AllReady.ViewModels;
+using MediatR;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Mvc;
+using Moq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Controllers
+{
+    public class OrganizationControllerTests
+    {
+        [Fact]
+        public void ShowOrganization_ReturnsCorrectView()
+        {
+            OrganizationController controller;
+            var mockMediator = MockMediatorOrganizationDetailsQuery(out controller);
+
+            var result = controller.ShowOrganization(1);
+
+            Assert.NotNull(result);
+            Assert.IsType<ViewResult>(result.Result);
+
+            var finalResult = result.Result as ViewResult;
+
+            Assert.Equal("Organization", finalResult.ViewName);
+        }
+
+        [Fact]
+        public void ShowOrganization_ReturnsNotFoundForInvalidId()
+        {
+            OrganizationController controller;
+            var mockMediator = MockMediatorOrganizationDetailsQuery(out controller);
+
+            var result = controller.ShowOrganization(0).Result as HttpNotFoundResult;
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        public void ShowOrganization_ReturnsNotFoundForNullOrganization()
+        {
+            OrganizationController controller;
+            var mockMediator = MockMediatorOrganizationDetailsQueryNullResult(out controller);
+
+            var result = controller.ShowOrganization(1).Result as HttpNotFoundResult;
+
+            Assert.NotNull(result);
+        }
+
+        #region Helper Methods
+
+        private static Mock<IMediator> MockMediatorOrganizationDetailsQuery(out OrganizationController controller, OrganizationViewModel model = null)
+        {
+            var dataMock = new Mock<IAllReadyDataAccess>();
+
+            if (model == null) model = new OrganizationViewModel { Id = 1, Name = "Org 1" };
+
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationDetailsQueryAsync>())).Returns(() => Task.FromResult(model)).Verifiable();
+            controller = new OrganizationController(mockMediator.Object, dataMock.Object);
+            return mockMediator;
+        }
+
+        private static Mock<IMediator> MockMediatorOrganizationDetailsQueryNullResult(out OrganizationController controller)
+        {
+            var dataMock = new Mock<IAllReadyDataAccess>();            
+
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationDetailsQueryAsync>())).Returns(() => Task.FromResult((OrganizationViewModel)null)).Verifiable();
+            controller = new OrganizationController(mockMediator.Object, dataMock.Object);
+            return mockMediator;
+        }
+
+        private static Mock<ActionContext> MockActionContextWithUser(ClaimsPrincipal principle)
+        {
+            var mockHttpContext = new Mock<HttpContext>();
+            mockHttpContext.Setup(mock => mock.User)
+                .Returns(() => principle);
+            var mockContext = new Mock<ActionContext>();
+
+            mockContext.Object.HttpContext = mockHttpContext.Object;
+            return mockContext;
+        }
+
+        #endregion
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Organizations/OrganizationDetailsQueryHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Organizations/OrganizationDetailsQueryHandlerAsyncTests.cs
@@ -1,0 +1,52 @@
+﻿using AllReady.Features.Organizations;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Features.Organizations
+{
+    public class OrganizationDetailsQueryHandlerAsyncTests : InMemoryContextTest
+    {
+        [Fact]
+        public async Task CorrectOrganizationReturnedWhenIdInMessage()
+        {
+            var handler = new OrganizationDetailsQueryHandlerAsync(Context);
+            var result = await handler.Handle(new OrganizationDetailsQueryAsync { Id = 1 });
+
+            Assert.NotNull(result);
+            Assert.Equal("Org 1", result.Name);
+        }
+
+        [Fact]
+        public async Task LockedCampaignsAreNotIncludedInTheResults()
+        {
+            var handler = new OrganizationDetailsQueryHandlerAsync(Context);
+            var result = await handler.Handle(new OrganizationDetailsQueryAsync { Id = 1 });
+
+            Assert.NotNull(result);
+            Assert.Equal(3, result.Campaigns.Count);
+        }
+
+        [Fact]
+        public async Task NullReturnedWhenSkillIdDoesNotExists()
+        {
+            var handler = new OrganizationDetailsQueryHandlerAsync(Context);
+            var result = await handler.Handle(new OrganizationDetailsQueryAsync { Id = 100 });
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public async Task NullReturnedWhenSkillIdNotInMessage()
+        {
+            var handler = new OrganizationDetailsQueryHandlerAsync(Context);
+            var result = await handler.Handle(new OrganizationDetailsQueryAsync());
+
+            Assert.Null(result);
+        }
+
+        protected override void LoadTestData()
+        {
+            OrganizationHandlerTestHelper.LoadOrganizationHandlerTestData(Context);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Organizations/OrganizationHandlerTestHelper.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Organizations/OrganizationHandlerTestHelper.cs
@@ -1,0 +1,22 @@
+﻿using AllReady.Models;
+
+namespace AllReady.UnitTest.Features.Organizations
+{
+    public static class OrganizationHandlerTestHelper
+    {
+        public static void LoadOrganizationHandlerTestData(AllReadyContext context)
+        {
+            // Organizations
+            context.Organizations.Add(new Organization { Id = 1, Name = "Org 1" });
+            context.Organizations.Add(new Organization { Id = 2, Name = "Org 2" });
+
+            // Campaigns
+            context.Campaigns.Add(new Campaign { Name = "Campaign 1", ManagingOrganizationId = 1 });
+            context.Campaigns.Add(new Campaign { Name = "Campaign 2", ManagingOrganizationId = 1 });
+            context.Campaigns.Add(new Campaign { Name = "Locked Campaign", ManagingOrganizationId = 1, Locked = true });
+            context.Campaigns.Add(new Campaign { Name = "Unlocked Campaign", ManagingOrganizationId = 1, Locked = false });
+
+            context.SaveChanges();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Organizations/OrganizationDetailsQueryAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Organizations/OrganizationDetailsQueryAsync.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.ViewModels;
+using MediatR;
+
+namespace AllReady.Features.Organizations
+{
+    public class OrganizationDetailsQueryAsync : IAsyncRequest<OrganizationViewModel>
+    {
+        public int Id { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Organizations/OrganizationDetailsQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Organizations/OrganizationDetailsQueryHandlerAsync.cs
@@ -1,0 +1,36 @@
+﻿using AllReady.Models;
+using AllReady.ViewModels;
+using MediatR;
+using Microsoft.Data.Entity;
+using System;
+using System.Threading.Tasks;
+
+namespace AllReady.Features.Organizations
+{
+    public class OrganizationDetailsQueryHandlerAsync : IAsyncRequestHandler<OrganizationDetailsQueryAsync, OrganizationViewModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public OrganizationDetailsQueryHandlerAsync(AllReadyContext context)
+        {
+            if (context == null)
+                throw new ArgumentNullException(nameof(context));
+
+            _context = context;
+        }
+
+        public async Task<OrganizationViewModel> Handle(OrganizationDetailsQueryAsync message)
+        {
+            var result = await _context.Organizations.AsNoTracking()
+                .Include(t => t.Campaigns)
+                .SingleOrDefaultAsync(t => t.Id == message.Id);
+
+            if (result == null)
+                return null;
+
+            result.Campaigns.RemoveAll(c => c.Locked);
+
+            return new OrganizationViewModel(result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes issue #524 

- Moved the ShowOrganization action from direct use of context to the command/query pattern
- Implemented a handler which excluded locked campaigns in the OrganizationViewModel
- Added tests for the controller action and the handler