### PR TITLE
Adding create campaign button on the public Campaign page (visible to…

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Campaign/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Campaign/Index.cshtml
@@ -1,4 +1,6 @@
 ﻿@model IList<CampaignViewModel>
+@using AllReady.Security
+
 @{
     ViewData["Title"] = "All Registered Campaigns";
     @addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
@@ -41,6 +43,15 @@
                 </div>
             </div>
         </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
+        @if (User.IsUserType(UserType.OrgAdmin) || User.IsUserType(UserType.SiteAdmin))
+        {
+            <p><a asp-route-area="Admin" asp-route-controller="Campaign" asp-route-action="Create" class="btn btn-default">Create Campaign</a></p>
+        }
     </div>
 </div>
 


### PR DESCRIPTION
Resolves issue #503 

I have added a "Create Campaign" button on the public Campaign page (/Campaign). This button will be displayed if the current user is an org admin or a site admin.