### PR TITLE
Workaround to Postal Code DB error

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/CampaignControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/CampaignControllerTests.cs
@@ -307,7 +307,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var tid = organizationId;
             var mockMediator = new Mock<IMediator>();
             mockMediator.Setup(mock => mock.Send(It.IsAny<CampaignSummaryQuery>()))
-                .Returns(() => new CampaignSummaryModel { OrganizationId = tid })
+                .Returns(() => new CampaignSummaryModel { OrganizationId = tid, Location = new LocationEditModel() })
                 .Verifiable();
             var mockImageService = new Mock<IImageService>();
             var controller = new CampaignController(

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CheckValidPostcodeQueryAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CheckValidPostcodeQueryAsync.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Campaigns
+{
+    public class CheckValidPostcodeQueryAsync : IAsyncRequest<bool>
+    {
+        public PostalCodeGeo Postcode { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CheckValidPostcodeQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CheckValidPostcodeQueryHandlerAsync.cs
@@ -1,0 +1,31 @@
+﻿using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Campaigns
+{
+    public class CheckValidPostcodeQueryHandlerAsync : IAsyncRequestHandler<CheckValidPostcodeQueryAsync, bool>
+    {
+        private AllReadyContext _context;
+        public CheckValidPostcodeQueryHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<bool> Handle(CheckValidPostcodeQueryAsync message)
+        {
+            var postcode = await _context.PostalCodes
+               .AsNoTracking()
+               .Where(p => p.City == message.Postcode.City)
+               .Where(p => p.State == message.Postcode.State)
+               .Where(p => p.PostalCode == message.Postcode.PostalCode)
+               .SingleOrDefaultAsync();
+
+            if(postcode == null) return false;
+
+            return true;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/LocationEditModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/LocationEditModel.cs
@@ -9,6 +9,7 @@ namespace AllReady.Areas.Admin.Models
         public string Address2 { get; set; }
         public string City { get; set; }
         public string State { get; set; }
+        [Display(Name = "Postal Code")]
         public string PostalCode { get; set; }
         public string Name { get; set; }
         [Phone]


### PR DESCRIPTION
Fixes #470 

This is an initial workaround to solve the immediate issue of a DB error being thrown up to the UI when trying to save a campaign with a postal code set.

Before saving the campaign I have added a check to validate if the city, state and postal code combination are valid (only triggered if the postal code is supplied in the form) which will return a model error to the user if the postal code is not found.