### PR TITLE
Feature 212 display geo info

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/ViewModels/CampaignViewModelShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/ViewModels/CampaignViewModelShould.cs
@@ -1,0 +1,64 @@
+﻿using AllReady.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.ViewModels
+{
+    public class CampaignViewModelShould
+    {
+        [Fact]
+        public void ReturnCityAndStateWhenBothArePresent()
+        {
+            // arrange
+            var model = new CampaignViewModel();
+
+            // act
+            model.Location = new Models.Location
+            {
+                City = "HappyTown",
+                State = "Utopia"
+            };
+
+            // assert
+            Assert.Equal("HappyTown, Utopia", model.LocationSummary);
+
+        }
+
+        [Fact]
+        public void ReturnCityWhenStateNotPresent()
+        {
+            // arrange
+            var model = new CampaignViewModel();
+
+            // act
+            model.Location = new Models.Location
+            {
+                City = "HappyTown"
+            };
+
+            // assert
+            Assert.Equal("HappyTown", model.LocationSummary);
+
+        }
+
+        [Fact]
+        public void ReturnStateWhenCityNotPresent()
+        {
+            // arrange
+            var model = new CampaignViewModel();
+
+            // act
+            model.Location = new Models.Location
+            {
+                State = "Utopia"
+            };
+
+            // assert
+            Assert.Equal("Utopia", model.LocationSummary);
+
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/ViewModels/LocationViewModelShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/ViewModels/LocationViewModelShould.cs
@@ -1,0 +1,48 @@
+﻿using AllReady.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.ViewModels
+{
+    public class LocationViewModelShould
+    {
+        [Fact]
+        public void ReturnCityAndStateWhenBothArePresent()
+        {
+            // arrange
+            var model = new LocationViewModel{
+                City = "HappyTown",
+                State = "Utopia"
+            };
+
+            // assert
+            Assert.Equal("HappyTown, Utopia", model.Summary);
+
+        }
+
+        [Fact]
+        public void ReturnCityWhenStateNotPresent()
+        {
+            // arrange
+            var model = new LocationViewModel { City = "HappyTown" };
+
+            // assert
+            Assert.Equal("HappyTown", model.Summary);
+
+        }
+
+        [Fact]
+        public void ReturnStateWhenCityNotPresent()
+        {
+            // arrange
+            var model = new LocationViewModel { State = "Utopia" };
+
+            // assert
+            Assert.Equal("Utopia", model.Summary);
+
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Campaign.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Campaign.cs
@@ -24,6 +24,8 @@ namespace AllReady.Models
                 .Include(x => x.ManagingOrganization)
                 .Include(x => x.CampaignImpact)
                 .Include(x => x.Activities)
+                .ThenInclude(a => a.Location)
+                .Include(x => x.Location)
                 .Include(x => x.ParticipatingOrganizations)
                 .SingleOrDefault(x => x.Id == campaignId);
         }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/CampaignViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/CampaignViewModel.cs
@@ -29,8 +29,8 @@ namespace AllReady.ViewModels
             Activities = campaign.Activities != null ? campaign.Activities.ToViewModel() : Enumerable.Empty<ActivityViewModel>();
             CampaignImpact = campaign.CampaignImpact;
             ImageUrl = campaign.ImageUrl;
-
             HasPrivacyPolicy = !string.IsNullOrEmpty(campaign.ManagingOrganization?.PrivacyPolicy);
+            Location = campaign.Location;
         }
 
         public int Id { get; set; }
@@ -42,6 +42,8 @@ namespace AllReady.ViewModels
         public string FullDescription { get; set; }
 
         public string ImageUrl { get; set; }
+
+        public Location Location { get; set; }
 
         public int ManagingOrganizationId { get; set; }
 

--- a/AllReadyApp/Web-App/AllReady/ViewModels/CampaignViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/CampaignViewModel.cs
@@ -45,6 +45,21 @@ namespace AllReady.ViewModels
 
         public Location Location { get; set; }
 
+        public string LocationSummary
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(Location?.City) && !string.IsNullOrEmpty(Location?.State))
+                    return $"{Location.City}, {Location.State}";
+                if (!string.IsNullOrEmpty(Location?.City))
+                    return $"{Location.City}";
+                if (!string.IsNullOrEmpty(Location?.State))
+                    return $"{Location.State}";
+
+                return string.Empty;
+            }
+        }
+
         public int ManagingOrganizationId { get; set; }
 
         public string ManagingOrganizationName { get; set; }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/LocationViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/LocationViewModel.cs
@@ -25,5 +25,19 @@ namespace AllReady.ViewModels
         public string State { get; set; }
         public PostalCodeGeo PostalCode { get; set; }
         public string Country { get; set; }
+
+        public string Summary {
+            get
+            {
+                if (!string.IsNullOrEmpty(City) && !string.IsNullOrEmpty(State))
+                    return $"{City}, {State}";
+                if (!string.IsNullOrEmpty(City))
+                    return $"{City}";
+                if (!string.IsNullOrEmpty(State))
+                    return $"{State}";
+
+                return string.Empty;
+            }
+        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Views/Campaign/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Campaign/Details.cshtml
@@ -26,6 +26,7 @@
             <time value="Model.StartDate" format="D"></time> - <time value="Model.EndDate" format="D"></time>
             <em><time-zone-name time-zone-id="@Model.TimeZoneId"></time-zone-name></em>
         </p>
+        <p>@Model.LocationSummary</p>
     </div>
 </div>
 
@@ -106,6 +107,7 @@
                 <tr>
                     <th><span title="Name of the activity">Title</span></th>
                     <th><span title="Description of the activity">Description</span></th>
+                    <th><span title="Activity Location">Location</span></th>
                     <th><span title="Date of the activity">Dates</span></th>
                 </tr>
                 <!-- ko foreach: activities.filtered -->
@@ -115,6 +117,9 @@
                     </td>
                     <td>
                         <span data-bind="text: Description"></span>
+                    </td>
+                    <td>
+                        <span data-bind="text: Location ? Location.Summary : '' "></span>
                     </td>
                     <td>
                         <span data-bind="text: displayDate()"></span>

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/campaign.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/campaign.js
@@ -39,7 +39,8 @@ function ResourcesViewModel(category)
             var start = moment(this.StartDateTime).utcOffset(this.StartDateTime).format("dddd, MMMM Do YYYY");
             var end = moment(this.EndDateTime).utcOffset(this.EndDateTime).format("dddd, MMMM Do YYYY");
             return start + ' - ' + end;
-        }
+        };
+        
         return this;
     }
     function CampaignViewModel(activities) {


### PR DESCRIPTION
The campaign details page now shows the location of the campaign and of each of the activities.

![image](https://cloud.githubusercontent.com/assets/1197383/13549248/55dc9c86-e2c7-11e5-836e-b5f12e48a2e3.png)

 - Extended the view models
 - Added tests  for VMs
 - Included the location data in the data context

This controller is still using the data access repository, but changing to queries/handlers was outside the scope of this change.

I think that these VMs could be refactored as well as they are being reused a fair bit and many of the properties (and subqueries used to fetch them) are not even being used. This should be addressed in the switch to queries/handlers.

Closes #212