### PR TITLE
Campaign dates should align

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Validators/CampaignSummaryModelValidatorShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Validators/CampaignSummaryModelValidatorShould.cs
@@ -32,6 +32,27 @@ namespace AllReady.UnitTest.Validators
             Assert.True(errors.ContainsKey("EndDate"));
         }
 
+        [Fact]
+        public async Task ReportErrorsWhenPostalCodeIsInvalid()
+        {
+            // arrange
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(m => m.SendAsync(It.IsAny<CheckValidPostcodeQueryAsync>())).ReturnsAsync(false);
+
+            var validator = new CampaignSummaryModelValidator(mediator.Object);
+            var model = new CampaignSummaryModel
+            {
+                Location = new LocationEditModel { PostalCode = "90210" }
+            };
+
+            // act
+            var errors = await validator.Validate(model);
+
+            // assert
+            mediator.Verify(m => m.SendAsync(It.IsAny<CheckValidPostcodeQueryAsync>()));
+            Assert.True(errors.ContainsKey("PostalCode"));
+
+        }
 
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Validators/CampaignSummaryModelValidatorShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Validators/CampaignSummaryModelValidatorShould.cs
@@ -1,0 +1,37 @@
+﻿using AllReady.Areas.Admin.Features.Campaigns;
+using AllReady.Areas.Admin.Models;
+using AllReady.Areas.Admin.Models.Validators;
+using MediatR;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Validators
+{
+    public class CampaignSummaryModelValidatorShould
+    {
+        [Fact]
+        public async Task ReportErrorsWhenDatesAreInvalid()
+        {
+            // arrage
+            var mediator = new Mock<IMediator>();
+            var validator = new CampaignSummaryModelValidator(mediator.Object);
+            var model = new CampaignSummaryModel
+            {
+                StartDate = new DateTimeOffset(new DateTime(2000, 1, 1)),
+                EndDate = new DateTimeOffset(new DateTime(1999, 1, 1))
+            };
+
+            // act
+            var errors = await validator.Validate(model);
+
+            // assert
+            Assert.True(errors.ContainsKey("EndDate"));
+        }
+
+
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/CampaignSummaryModelValidator.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/CampaignSummaryModelValidator.cs
@@ -1,0 +1,32 @@
+﻿using AllReady.Areas.Admin.Features.Campaigns;
+using AllReady.Models;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Models.Validators
+{
+    public class CampaignSummaryModelValidator
+    {
+        private IMediator _mediator;
+
+        public CampaignSummaryModelValidator(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        public async Task<Dictionary<string, string>> Validate (CampaignSummaryModel model)
+        {
+            var result = new Dictionary<string, string>();
+
+            if (model.EndDate < model.StartDate)
+            {
+                result.Add(nameof(model.EndDate), "The end date must fall after the start date.");
+            }
+
+            return result;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/CampaignSummaryModelValidator.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/CampaignSummaryModelValidator.cs
@@ -23,7 +23,7 @@ namespace AllReady.Areas.Admin.Models.Validators
 
             if (model.EndDate < model.StartDate)
             {
-                result.Add(nameof(model.EndDate), "The end date must fall after the start date.");
+                result.Add(nameof(model.EndDate), "The end date must fall on or after the start date.");
             }
 
             // Temporary code to avoid current database update error when the post code geo does not exist in the database.

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/CampaignSummaryModelValidator.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/CampaignSummaryModelValidator.cs
@@ -26,6 +26,7 @@ namespace AllReady.Areas.Admin.Models.Validators
                 result.Add(nameof(model.EndDate), "The end date must fall after the start date.");
             }
 
+            // Temporary code to avoid current database update error when the post code geo does not exist in the database.
             if (!string.IsNullOrEmpty(model.Location?.PostalCode))
             {
                 bool validPostcode = await _mediator.SendAsync(new CheckValidPostcodeQueryAsync

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/CampaignSummaryModelValidator.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/CampaignSummaryModelValidator.cs
@@ -26,6 +26,24 @@ namespace AllReady.Areas.Admin.Models.Validators
                 result.Add(nameof(model.EndDate), "The end date must fall after the start date.");
             }
 
+            if (!string.IsNullOrEmpty(model.Location?.PostalCode))
+            {
+                bool validPostcode = await _mediator.SendAsync(new CheckValidPostcodeQueryAsync
+                {
+                    Postcode = new PostalCodeGeo
+                    {
+                        City = model.Location.City,
+                        State = model.Location.State,
+                        PostalCode = model.Location.PostalCode
+                    }
+                });
+
+                if (!validPostcode)
+                {
+                    result.Add(nameof(model.Location.PostalCode), "The city, state and postal code combination is not valid");
+                }
+            }
+
             return result;
         }
     }


### PR DESCRIPTION
There are some complex validations that need to occur on the model (db lookup, multi-prop assertations). I wanted to use something like FluentValidation, but it's not ready for ASP.NET Core yet. This approach should do the trick.

 - Added validator
 - Moved validation from controller to validator
 - Fixed the validation for the start/end date

Closes #145