### PR TITLE
Assignee and Status in Admin Activity Task List

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ActivityDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ActivityDetailQueryHandler.cs
@@ -40,17 +40,29 @@ namespace AllReady.Areas.Admin.Features.Activities
                     NumberOfVolunteersRequired = activity.NumberOfVolunteersRequired,
                     IsLimitVolunteers = activity.IsLimitVolunteers,
                     IsAllowWaitList = activity.IsAllowWaitList,
+                    RequiredSkills = activity.RequiredSkills,
+                    ImageUrl = activity.ImageUrl,
                     Tasks = activity.Tasks.Select(t => new TaskSummaryModel()
                     {
                         Id = t.Id,
                         Name = t.Name,
                         StartDateTime = t.StartDateTime,
                         EndDateTime = t.EndDateTime,
+                        NumberOfVolunteersRequired = t.NumberOfVolunteersRequired,
+                        AssignedVolunteers = t.AssignedVolunteers?.Select(assignedVolunteer => new VolunteerModel
+                        {
+                            UserId = assignedVolunteer.User.Id,
+                            UserName = assignedVolunteer.User.UserName,
+                            HasVolunteered = true,
+                            Status = assignedVolunteer.Status,
+                            PreferredEmail = assignedVolunteer.PreferredEmail,
+                            PreferredPhoneNumber = assignedVolunteer.PreferredPhoneNumber,
+                            AdditionalInfo = assignedVolunteer.AdditionalInfo
+                        }).ToList()
                     }).OrderBy(t => t.StartDateTime).ThenBy(t => t.Name).ToList(),
-                    RequiredSkills = activity.RequiredSkills,
-                    ImageUrl = activity.ImageUrl
                 };
             }
+
             return result;
         }
 
@@ -59,7 +71,7 @@ namespace AllReady.Areas.Admin.Features.Activities
             return _context.Activities
                 .AsNoTracking()
                 .Include(a => a.Campaign).ThenInclude(c => c.ManagingOrganization)
-                .Include(a => a.Tasks)
+                .Include(a => a.Tasks).ThenInclude(t => t.AssignedVolunteers).ThenInclude(av => av.User)
                 .Include(a => a.RequiredSkills)
                 .Include(a => a.UsersSignedUp).ThenInclude(a => a.User)
                 .SingleOrDefault(a => a.Id == message.ActivityId);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/_List.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/_List.cshtml
@@ -35,7 +35,7 @@
                     else if (item.AssignedVolunteers.Count == 1)
                     {
                         <td>@item.AssignedVolunteers[0].UserName</td>
-                        @*<td>@(item.AssignedVolunteers[0].HasVolunteered ? "": "*")</td>*@
+                        <td>@(item.AssignedVolunteers[0]?.Status ?? "*")</td>
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #561 

Updated the query handler to include the related AssignedVolunteers and load the model appropriately as used in other areas of the application.

Updated the view to use the status when a single assignee is set.

I wasn't 100% clear on the expected logic for the HasVolunteered Boolean. For now I've followed it's use elsewhere and set to true when populating the model. If this use is incorrect I can amend.

It feels like it might be good to document some of the this with either XML comments or .md pages as well since some properties can be a little confusing in their expected usage - at least I found it so in this case!
