### PR TITLE
TaskApiController: adding unit tests and refactoring to mediator

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerTests.cs
@@ -88,15 +88,14 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
 
             var task = Context.Tasks.First();
             var user = Context.Users.First();
-            var command = new TaskStatusChangeCommand
+            var command = new TaskStatusChangeCommandAsync
             {
                 TaskId = task.Id,
                 UserId = user.Id,
                 TaskStatus = TaskStatus.Accepted
             };
-
-            var handler = new TaskStatusChangeHandler(Context, mediator.Object);
-            await handler.Handle(command);
+            var handler = new TaskStatusChangeHandlerAsync(Context, mediator.Object);
+            var result = handler.Handle(command);
 
             var taskSignup = Context.TaskSignups.First();
             mediator.Verify(b => b.PublishAsync(It.Is<TaskSignupStatusChanged>(notifyCommand => notifyCommand.SignupId == taskSignup.Id)), Times.Once());

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerTests.cs
@@ -95,7 +95,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
                 TaskStatus = TaskStatus.Accepted
             };
             var handler = new TaskStatusChangeHandlerAsync(Context, mediator.Object);
-            var result = handler.Handle(command);
+            await handler.Handle(command);
 
             var taskSignup = Context.TaskSignups.First();
             mediator.Verify(b => b.PublishAsync(It.Is<TaskSignupStatusChanged>(notifyCommand => notifyCommand.SignupId == taskSignup.Id)), Times.Once());

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ActivityApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ActivityApiControllerTests.cs
@@ -263,8 +263,8 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<ActivityByActivityIdQuery>())).Returns(activity);
 
-            var sut = new ActivityApiController(mediator.Object) { DateTimeUtcNow = () => utcNow }
-                .SetFakeUser(userId);
+            var sut = new ActivityApiController(mediator.Object) { DateTimeUtcNow = () => utcNow };
+            sut.SetFakeUser(userId);
             await sut.PutCheckin(It.IsAny<int>());
 
             mediator.Verify(x => x.SendAsync(It.Is<AddActivitySignupCommandAsync>(y => y.ActivitySignup == activitySignup)));
@@ -283,8 +283,8 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<ActivityByActivityIdQuery>())).Returns(activity);
 
-            var sut = new ActivityApiController(mediator.Object)
-                .SetFakeUser(userId);
+            var sut = new ActivityApiController(mediator.Object);
+            sut.SetFakeUser(userId);
 
             var expected = $"{{ Activity = {{ Name = {activity.Name}, Description = {activity.Description} }} }}";
 
@@ -303,8 +303,8 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<ActivityByActivityIdQuery>())).Returns(activity);
 
-            var sut = new ActivityApiController(mediator.Object)
-                .SetFakeUser(userId);
+            var sut = new ActivityApiController(mediator.Object);
+            sut.SetFakeUser(userId);
 
             var expected = $"{{ NeedsSignup = True, Activity = {{ Name = {activity.Name}, Description = {activity.Description} }} }}";
 
@@ -345,7 +345,7 @@ namespace AllReady.UnitTest.Controllers
             const string modelStateErrorMessage = "modelStateErrorMessage";
 
             var sut = new ActivityApiController(null);
-            sut.AddModelStateError(modelStateErrorMessage);
+            sut.AddModelStateErrorWithErrorMessage(modelStateErrorMessage);
 
             var jsonResult = (JsonResult)await sut.RegisterActivity(new ActivitySignupViewModel());
             var result = jsonResult.GetValueForProperty<List<string>>("errors");
@@ -413,8 +413,8 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.Send(It.IsAny<ActivitySignupByActivityIdAndUserIdQuery>()))
                 .Returns(new ActivitySignup { Activity = new Activity(), User = new ApplicationUser() });
 
-            var controller = new ActivityApiController(mediator.Object)
-                .SetFakeUser(userId);
+            var controller = new ActivityApiController(mediator.Object);
+            controller.SetFakeUser(userId);
 
             await controller.UnregisterActivity(activityId);
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ActivityApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ActivityApiControllerTests.cs
@@ -371,7 +371,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task RegisterActivityReturnsSuccess()
         {
             var sut = new ActivityApiController(Mock.Of<IMediator>());
-            var result = (object)await sut.RegisterActivity(new ActivitySignupViewModel());
+            var result = await sut.RegisterActivity(new ActivitySignupViewModel());
 
             Assert.True(result.ToString().Contains("success"));
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ActivityApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ActivityApiControllerTests.cs
@@ -493,4 +493,3 @@ namespace AllReady.UnitTest.Controllers
         }
     }
 }
-

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ActivityApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ActivityApiControllerTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Threading.Tasks;
 using AllReady.Controllers;
 using AllReady.Models;

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/DetermineIfATaskIsEditableTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/DetermineIfATaskIsEditableTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 
 namespace AllReady.UnitTest.Controllers
 {
-    public class ProvideTaskEditPermissionsTests
+    public class DetermineIfATaskIsEditableTests
     {
         [Fact]
         public void SiteAdminsCanEditAllReadyTasks()

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ProvideTaskEditPermissionsTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ProvideTaskEditPermissionsTests.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using AllReady.Controllers;
+using AllReady.Models;
+using Xunit;
+
+namespace AllReady.UnitTest.Controllers
+{
+    public class ProvideTaskEditPermissionsTests
+    {
+        [Fact]
+        public void SiteAdminsCanEditAllReadyTasks()
+        {
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, "1"),
+                new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), UserType.SiteAdmin))
+            }));
+
+            var sut = new ProvideTaskEditPermissions();
+            var result = sut.HasTaskEditPermissions(null, claimsPrincipal);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void OrgAdminsCanEditAllReadyTasks()
+        {
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, "1"),
+                new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), UserType.OrgAdmin))
+            }));
+
+            var sut = new ProvideTaskEditPermissions();
+            var result = sut.HasTaskEditPermissions(null, claimsPrincipal);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void AllReadyTaskThatHasInstanceOfActivityAndActivityHasInstanceOfOrganizerAndOrganizerIdEqualsUserIdIsEditable()
+        {
+            const string userId = "1";
+
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, "1"),
+                new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), UserType.BasicUser))
+            }));
+
+            var allReadyTask = new AllReadyTask { Activity = new Activity { Organizer = new ApplicationUser { Id = userId }}};
+
+            var sut = new ProvideTaskEditPermissions();
+            var result = sut.HasTaskEditPermissions(allReadyTask, claimsPrincipal);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void AllReadyTaskThatHasInstanceOfActivityAndActivityHasInstanceOfCampaignAndCampaignHasInstanceOfOrganizerAndOrganizerIdEqualsUserIdIsEditable()
+        {
+            const string userId = "1";
+
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, "1"),
+                new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), UserType.BasicUser))
+            }));
+
+            var allReadyTask = new AllReadyTask { Activity = new Activity { Campaign = new Campaign { Organizer = new ApplicationUser { Id = userId }}}};
+
+            var sut = new ProvideTaskEditPermissions();
+            var result = sut.HasTaskEditPermissions(allReadyTask, claimsPrincipal);
+
+            Assert.True(result);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ProvideTaskEditPermissionsTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ProvideTaskEditPermissionsTests.cs
@@ -19,8 +19,8 @@ namespace AllReady.UnitTest.Controllers
                 new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), UserType.SiteAdmin))
             }));
 
-            var sut = new ProvideTaskEditPermissions();
-            var result = sut.HasTaskEditPermissions(null, claimsPrincipal);
+            var sut = new DetermineIfATaskIsEditable();
+            var result = sut.IsEditableFor(null, claimsPrincipal);
 
             Assert.True(result);
         }
@@ -35,8 +35,8 @@ namespace AllReady.UnitTest.Controllers
                 new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), UserType.OrgAdmin))
             }));
 
-            var sut = new ProvideTaskEditPermissions();
-            var result = sut.HasTaskEditPermissions(null, claimsPrincipal);
+            var sut = new DetermineIfATaskIsEditable();
+            var result = sut.IsEditableFor(null, claimsPrincipal);
 
             Assert.True(result);
         }
@@ -55,8 +55,8 @@ namespace AllReady.UnitTest.Controllers
 
             var allReadyTask = new AllReadyTask { Activity = new Activity { Organizer = new ApplicationUser { Id = userId }}};
 
-            var sut = new ProvideTaskEditPermissions();
-            var result = sut.HasTaskEditPermissions(allReadyTask, claimsPrincipal);
+            var sut = new DetermineIfATaskIsEditable();
+            var result = sut.IsEditableFor(allReadyTask, claimsPrincipal);
 
             Assert.True(result);
         }
@@ -75,8 +75,8 @@ namespace AllReady.UnitTest.Controllers
 
             var allReadyTask = new AllReadyTask { Activity = new Activity { Campaign = new Campaign { Organizer = new ApplicationUser { Id = userId }}}};
 
-            var sut = new ProvideTaskEditPermissions();
-            var result = sut.HasTaskEditPermissions(allReadyTask, claimsPrincipal);
+            var sut = new DetermineIfATaskIsEditable();
+            var result = sut.IsEditableFor(allReadyTask, claimsPrincipal);
 
             Assert.True(result);
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ProvideTaskEditPermissionsTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ProvideTaskEditPermissionsTests.cs
@@ -20,7 +20,7 @@ namespace AllReady.UnitTest.Controllers
             }));
 
             var sut = new DetermineIfATaskIsEditable();
-            var result = sut.For(null, claimsPrincipal);
+            var result = sut.For(claimsPrincipal, null);
 
             Assert.True(result);
         }
@@ -36,7 +36,7 @@ namespace AllReady.UnitTest.Controllers
             }));
 
             var sut = new DetermineIfATaskIsEditable();
-            var result = sut.For(null, claimsPrincipal);
+            var result = sut.For(claimsPrincipal, null);
 
             Assert.True(result);
         }
@@ -56,7 +56,7 @@ namespace AllReady.UnitTest.Controllers
             var allReadyTask = new AllReadyTask { Activity = new Activity { Organizer = new ApplicationUser { Id = userId }}};
 
             var sut = new DetermineIfATaskIsEditable();
-            var result = sut.For(allReadyTask, claimsPrincipal);
+            var result = sut.For(claimsPrincipal, allReadyTask);
 
             Assert.True(result);
         }
@@ -76,7 +76,7 @@ namespace AllReady.UnitTest.Controllers
             var allReadyTask = new AllReadyTask { Activity = new Activity { Campaign = new Campaign { Organizer = new ApplicationUser { Id = userId }}}};
 
             var sut = new DetermineIfATaskIsEditable();
-            var result = sut.For(allReadyTask, claimsPrincipal);
+            var result = sut.For(claimsPrincipal, allReadyTask);
 
             Assert.True(result);
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ProvideTaskEditPermissionsTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ProvideTaskEditPermissionsTests.cs
@@ -20,7 +20,7 @@ namespace AllReady.UnitTest.Controllers
             }));
 
             var sut = new DetermineIfATaskIsEditable();
-            var result = sut.IsEditableFor(null, claimsPrincipal);
+            var result = sut.For(null, claimsPrincipal);
 
             Assert.True(result);
         }
@@ -36,7 +36,7 @@ namespace AllReady.UnitTest.Controllers
             }));
 
             var sut = new DetermineIfATaskIsEditable();
-            var result = sut.IsEditableFor(null, claimsPrincipal);
+            var result = sut.For(null, claimsPrincipal);
 
             Assert.True(result);
         }
@@ -56,7 +56,7 @@ namespace AllReady.UnitTest.Controllers
             var allReadyTask = new AllReadyTask { Activity = new Activity { Organizer = new ApplicationUser { Id = userId }}};
 
             var sut = new DetermineIfATaskIsEditable();
-            var result = sut.IsEditableFor(allReadyTask, claimsPrincipal);
+            var result = sut.For(allReadyTask, claimsPrincipal);
 
             Assert.True(result);
         }
@@ -76,7 +76,7 @@ namespace AllReady.UnitTest.Controllers
             var allReadyTask = new AllReadyTask { Activity = new Activity { Campaign = new Campaign { Organizer = new ApplicationUser { Id = userId }}}};
 
             var sut = new DetermineIfATaskIsEditable();
-            var result = sut.IsEditableFor(allReadyTask, claimsPrincipal);
+            var result = sut.For(allReadyTask, claimsPrincipal);
 
             Assert.True(result);
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNet.Authorization;
 using Microsoft.AspNet.Mvc;
 using Moq;
 using Xunit;
+using DeleteTaskCommandAsync = AllReady.Features.Tasks.DeleteTaskCommandAsync;
 using TaskStatus = AllReady.Areas.Admin.Features.Tasks.TaskStatus;
 
 namespace AllReady.UnitTest.Controllers

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -20,6 +20,7 @@ namespace AllReady.UnitTest.Controllers
 {
     public class TaskApiControllerTests
     {
+        #region Post
         [Fact]
         public async Task PostReturnsHttpUnauthorizedWhenUserDoesNotHaveTheAuthorizationToEditTheTaskOrTheTaskIsNotInAnEditableState()
         {
@@ -67,7 +68,7 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public async Task PostInvokesAddTaskAsyncWithCorrectModel()
+        public async Task PostSendsAddTaskCommandAsyncWithCorrectData()
         {
             var model = new TaskViewModel { ActivityId = 1, Id = 1 };
             var allReadyTask = new AllReadyTask();
@@ -84,7 +85,7 @@ namespace AllReady.UnitTest.Controllers
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
             await sut.Post(model);
 
-            dataAccess.Verify(x => x.AddTaskAsync(allReadyTask), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.Is<AddTaskCommandAsync>(y => y.AllReadyTask == allReadyTask)), Times.Once);
         }
 
         [Fact]
@@ -143,8 +144,9 @@ namespace AllReady.UnitTest.Controllers
             var attribute = sut.GetAttributesOn(x => x.Post(It.IsAny<TaskViewModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
+        #endregion
 
-        //Put
+        #region Put
         [Fact]
         public async Task PutSendsTaskByTaskIdQueryWithCorrectTaskId()
         {
@@ -184,7 +186,7 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public async Task PutInvokesUpdateTaskAsyncWithCorrectAllReadyTask()
+        public async Task PutSendsUpdateTaskCommandAsyncWithCorrectAllReadyTask()
         {
             var allReadyTask = new AllReadyTask();
             var model = new TaskViewModel { Name = "name", Description = "description", StartDateTime = DateTime.UtcNow, EndDateTime = DateTime.UtcNow };
@@ -195,12 +197,10 @@ namespace AllReady.UnitTest.Controllers
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
             determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
-            var dataAccess = new Mock<IAllReadyDataAccess>();
-
-            var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
+            var sut = new TaskApiController(null, mediator.Object, determineIfATaskIsEditable.Object);
             await sut.Put(It.IsAny<int>(), model);
 
-            dataAccess.Verify(x => x.UpdateTaskAsync(allReadyTask), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.Is<UpdateTaskCommandAsync>(y => y.AllReadyTask == allReadyTask)), Times.Once);
         }
 
         [Fact]
@@ -215,9 +215,7 @@ namespace AllReady.UnitTest.Controllers
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
             determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
-            var dataAccess = new Mock<IAllReadyDataAccess>();
-
-            var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
+            var sut = new TaskApiController(null, mediator.Object, determineIfATaskIsEditable.Object);
             var result = await sut.Put(It.IsAny<int>(), model) as HttpStatusCodeResult;
 
             Assert.IsType<HttpStatusCodeResult>(result);
@@ -232,8 +230,9 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "{id}");
         }
+        #endregion
 
-        //Delete
+        #region Delete
         [Fact]
         public async Task DeleteSendsTaskByTaskIdQueryWithCorrectTaskId()
         {
@@ -271,7 +270,7 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public async Task DeleteInvokesDeleteTaskAsyncWithCorrectTaskId()
+        public async Task DeleteSendsDeleteTaskCommandAsyncWithCorrectTaskId()
         {
             var allReadyTask = new AllReadyTask { Id = 1 };
 
@@ -281,12 +280,10 @@ namespace AllReady.UnitTest.Controllers
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
             determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
-            var dataAccess = new Mock<IAllReadyDataAccess>();
-
-            var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
+            var sut = new TaskApiController(null, mediator.Object, determineIfATaskIsEditable.Object);
             await sut.Delete(It.IsAny<int>());
 
-            dataAccess.Verify(x => x.DeleteTaskAsync(allReadyTask.Id), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.Is<DeleteTaskCommandAsync>(y => y.TaskId == allReadyTask.Id)));
         }
 
         [Fact]
@@ -297,8 +294,9 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "{id}");
         }
+        #endregion
 
-        //RegisterTask
+        #region RegisterTask
         [Fact]
         public async Task RegisterTaskReturnsHttpBadRequestWhenModelIsNull()
         {
@@ -419,7 +417,9 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
             Assert.Equal(attribute.ContentTypes.Select(x => x.MediaType).First(), "application/json");
         }
+        #endregion
 
+        #region UnregisterTask
         [Fact]
         public async Task UnregisterTaskSendsTaskUnenrollCommandAsyncWithCorrectTaskIdAndUserId()
         {
@@ -503,7 +503,9 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "{id}/signup");
         }
+        #endregion
 
+        #region ChangeStatus
         [Fact]
         public async Task ChangeStatusInvokesSendAsyncWithCorrectTaskStatusChangeCommand()
         {
@@ -604,6 +606,7 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "changestatus");
         }
+        #endregion
 
         [Fact]
         public void ControllerHasRouteAtttributeWithTheCorrectRoute()

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -19,6 +19,30 @@ namespace AllReady.UnitTest.Controllers
     public class TaskApiControllerTests
     {
         //Post
+        [Fact]
+        public void PutHasValidateAntiForgeryTokenAttribute()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+        [Fact]
+        public void PutHasHttpPostAttribute()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        //[Fact]
+        //public void ChangeStatusHasRouteAttributeWithCorrectTemplate()
+        //{
+        //    var sut = new TaskApiController(null, null);
+        //    var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<RouteAttribute>().SingleOrDefault();
+        //    Assert.NotNull(attribute);
+        //    Assert.Equal(attribute.Template, "changestatus");
+        //}
+
         //Put
         //Delete
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -312,7 +312,7 @@ namespace AllReady.UnitTest.Controllers
             const string modelStateErrorMessage = "modelStateErrorMessage";
 
             var sut = new TaskApiController(null, null, null);
-            sut.AddModelStateError(modelStateErrorMessage);
+            sut.AddModelStateErrorWithErrorMessage(modelStateErrorMessage);
 
             var jsonResult = await sut.RegisterTask(new ActivitySignupViewModel()) as JsonResult;
             var result = jsonResult.GetValueForProperty<List<string>>("errors");
@@ -429,8 +429,9 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult()));
 
-            var sut = new TaskApiController(null, mediator.Object, null)
-                .SetFakeUser(userId);
+            var sut = new TaskApiController(null, mediator.Object, null);
+            sut.SetFakeUser(userId);
+
             await sut.UnregisterTask(taskId);
 
             mediator.Verify(x => x.SendAsync(It.Is<TaskUnenrollCommand>(y => y.TaskId == taskId && y.UserId == userId)));

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -128,6 +128,22 @@ namespace AllReady.UnitTest.Controllers
             Assert.Equal(result.StatusCode, 201);
         }
 
+        [Fact]
+        public void PostHasHttpPostAttribute()
+        {
+            var sut = new TaskApiController(null, null, null);
+            var attribute = sut.GetAttributesOn(x => x.Post(It.IsAny<TaskViewModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void PostHasValidateAntiForgeryTokenAttribute()
+        {
+            var sut = new TaskApiController(null, null, null);
+            var attribute = sut.GetAttributesOn(x => x.Post(It.IsAny<TaskViewModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
         //Put
         [Fact]
         public async Task PutSendsTaskByTaskIdQueryWithCorrectTaskId()
@@ -208,6 +224,15 @@ namespace AllReady.UnitTest.Controllers
             Assert.Equal(result.StatusCode, 204);
         }
 
+        [Fact]
+        public void PutHasHttpPutAttributeWithCorrectTemplate()
+        {
+            var sut = new TaskApiController(null, null, null);
+            var attribute = sut.GetAttributesOn(x => x.Put(It.IsAny<int>(), It.IsAny<TaskViewModel>())).OfType<HttpPutAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Template, "{id}");
+        }
+
         //Delete
         [Fact]
         public async Task DeleteSendsTaskByTaskIdQueryWithCorrectTaskId()
@@ -262,6 +287,15 @@ namespace AllReady.UnitTest.Controllers
             await sut.Delete(It.IsAny<int>());
 
             dataAccess.Verify(x => x.DeleteTaskAsync(allReadyTask.Id), Times.Once);
+        }
+
+        [Fact]
+        public void DeleteHasHttpDeleteAttributeWithCorrectTemplate()
+        {
+            var sut = new TaskApiController(null, null, null);
+            var attribute = sut.GetAttributesOn(x => x.Delete(It.IsAny<int>())).OfType<HttpDeleteAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Template, "{id}");
         }
 
         //RegisterTask

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Controllers;
+using AllReady.UnitTest.Extensions;
+using Microsoft.AspNet.Mvc;
+using Xunit;
+
+namespace AllReady.UnitTest.Controllers
+{
+    public class TaskApiControllerTests
+    {
+        //Post
+        //Put
+        //Delete
+
+        //these do not use HasEditTaskPermissions
+        //RegisterTask
+        //UnregisterTask
+        //ChangeStatus
+
+        [Fact]
+        public void ControllerHasRouteAtttributeWithTheCorrectRoute()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributes().OfType<RouteAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Template, "api/task");
+        }
+
+        [Fact]
+        public void ControllerHasProducesAtttributeWithTheCorrectContentType()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributes().OfType<ProducesAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.ContentTypes.Select(x => x.MediaType).First(), "application/json");
+        }
+
+        //method attributes
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -427,7 +427,7 @@ namespace AllReady.UnitTest.Controllers
             const int taskId = 1;
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult()));
+            mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).ReturnsAsync(new TaskUnenrollResult());
 
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetFakeUser(userId);
@@ -443,7 +443,7 @@ namespace AllReady.UnitTest.Controllers
             const string status = "status";
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult { Status = status }));
+            mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).ReturnsAsync(new TaskUnenrollResult { Status = status });
 
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
@@ -460,7 +460,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task UnregisterTaskReturnsNullForTaskWhenResultTaskIsNull()
         {
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult()));
+            mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).ReturnsAsync(new TaskUnenrollResult());
 
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
@@ -476,7 +476,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task UnregisterTaskReturnsTaskViewModelWhenResultTaskIsNotNull()
         {
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult { Task = new AllReadyTask() }));
+            mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).ReturnsAsync(new TaskUnenrollResult { Task = new AllReadyTask() });
 
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -26,7 +26,7 @@ namespace AllReady.UnitTest.Controllers
             dataAccess.Setup(x => x.GetActivity(It.IsAny<int>())).Returns(new Activity());
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(false);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(false);
 
             var sut = new TaskApiController(dataAccess.Object, null, determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel { ActivityId = 1 });
@@ -44,7 +44,7 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.Send(It.IsAny<TaskByTaskIdQuery>())).Returns(new AllReadyTask());
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel { ActivityId = 1 });
@@ -56,7 +56,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task PostReturnsBadRequestObjectResultWithCorrectErrorMessageWhenActivityIsNull()
         { 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
             var sut = new TaskApiController(Mock.Of<IAllReadyDataAccess>(), Mock.Of<IMediator>(), determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel()) as BadRequestObjectResult;
@@ -78,7 +78,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
             await sut.Post(model);
@@ -98,7 +98,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
 
             var provider = new Mock<IDetermineIfATaskIsEditable>();
-            provider.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            provider.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, provider.Object);
             await sut.Post(model);
@@ -118,7 +118,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
 
             var provider = new Mock<IDetermineIfATaskIsEditable>();
-            provider.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            provider.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, provider.Object);
             var result = await sut.Post(model) as HttpStatusCodeResult;
@@ -128,6 +128,7 @@ namespace AllReady.UnitTest.Controllers
         }
 
         //Put
+
         //Delete
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -133,7 +133,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task RegisterTaskReturnsHttpBadRequestWhenModelIsNull()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var result = await sut.RegisterTask(null);
 
             Assert.IsType<BadRequestResult>(result);
@@ -144,7 +144,7 @@ namespace AllReady.UnitTest.Controllers
         {
             const string modelStateErrorMessage = "modelStateErrorMessage";
 
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             sut.AddModelStateError(modelStateErrorMessage);
 
             var jsonResult = await sut.RegisterTask(new ActivitySignupViewModel()) as JsonResult;
@@ -162,7 +162,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model))).Returns(Task.FromResult(new TaskSignupResult()));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             await sut.RegisterTask(model);
 
             mediator.Verify(x => x.SendAsync(It.Is<TaskSignupCommand>(command => command.TaskSignupModel.Equals(model))));
@@ -176,7 +176,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model))).Returns(Task.FromResult(new TaskSignupResult { Status = taskSignUpResultStatus }));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
 
             var jsonResult = await sut.RegisterTask(model) as JsonResult;
             var result = jsonResult.GetValueForProperty<string>("Status");
@@ -191,7 +191,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model))).Returns(Task.FromResult(new TaskSignupResult()));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             
             var jsonResult = await sut.RegisterTask(model) as JsonResult;
             var result = jsonResult.GetValueForProperty<string>("Task");
@@ -206,7 +206,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model))).Returns(Task.FromResult(new TaskSignupResult { Task = new AllReadyTask() }));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             var jsonResult = await sut.RegisterTask(model) as JsonResult;
             var result = jsonResult.GetValueForProperty<TaskViewModel>("Task");
 
@@ -217,7 +217,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void RegisterTaskHasValidateAntiForgeryTokenAttrbiute()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.RegisterTask(It.IsAny<ActivitySignupViewModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -225,7 +225,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void RegisterTaskHasHttpPostAttributeWithCorrectTemplate()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.RegisterTask(It.IsAny<ActivitySignupViewModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
 
             Assert.NotNull(attribute);
@@ -235,7 +235,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void RegisterTaskHasAuthorizeAttrbiute()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.RegisterTask(It.IsAny<ActivitySignupViewModel>())).OfType<AuthorizeAttribute>().SingleOrDefault();
 
             Assert.NotNull(attribute);
@@ -244,7 +244,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void RegisterTaskHasHasProducesAtttributeWithTheCorrectContentType()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.RegisterTask(It.IsAny<ActivitySignupViewModel>())).OfType<ProducesAttribute>().SingleOrDefault();
 
             Assert.NotNull(attribute);
@@ -260,7 +260,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult()));
 
-            var sut = new TaskApiController(null, mediator.Object)
+            var sut = new TaskApiController(null, mediator.Object, null)
                 .SetFakeUser(userId);
             await sut.UnregisterTask(taskId);
 
@@ -275,7 +275,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult { Status = status }));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
             var jsonResult = await sut.UnregisterTask(It.IsAny<int>()) as JsonResult;
@@ -292,7 +292,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult()));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
             var jsonResult = await sut.UnregisterTask(It.IsAny<int>()) as JsonResult;
@@ -308,7 +308,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskUnenrollCommand>())).Returns(Task.FromResult(new TaskSignupResult { Task = new AllReadyTask() }));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
             
             var jsonResult = await sut.UnregisterTask(It.IsAny<int>()) as JsonResult;
@@ -321,7 +321,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void UnregisterTaskHasAuthorizeAttrbiute()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.UnregisterTask(It.IsAny<int>())).OfType<AuthorizeAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -329,7 +329,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void UnregisterTaskHasHttpDeleteAttributeWithCorrectTemplate()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.UnregisterTask(It.IsAny<int>())).OfType<HttpDeleteAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "{id}/signup");
@@ -343,7 +343,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskStatusChangeCommandAsync>())).Returns(() => Task.FromResult(new TaskChangeResult()));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             await sut.ChangeStatus(model);
 
             mediator.Verify(x => x.SendAsync(It.Is<TaskStatusChangeCommandAsync>(y => y.TaskId == model.TaskId && 
@@ -360,7 +360,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskStatusChangeCommandAsync>())).Returns(() => Task.FromResult(new TaskChangeResult { Status = status }));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
             var jsonResult = await sut.ChangeStatus(new TaskChangeModel()) as JsonResult;
@@ -377,7 +377,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskStatusChangeCommandAsync>())).Returns(() => Task.FromResult(new TaskChangeResult { Status = "status" }));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
             var jsonResult = await sut.ChangeStatus(new TaskChangeModel()) as JsonResult;
@@ -393,7 +393,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskStatusChangeCommandAsync>())).Returns(() => Task.FromResult(new TaskChangeResult { Task = new AllReadyTask() }));
 
-            var sut = new TaskApiController(null, mediator.Object);
+            var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
             var jsonResult = await sut.ChangeStatus(new TaskChangeModel()) as JsonResult;
@@ -406,7 +406,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void ChangeStatusHasHttpPostAttribute()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -414,7 +414,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void ChangeStatusHasAuthorizeAttribute()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<AuthorizeAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -422,7 +422,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void ChangeStatusHasValidateAntiForgeryTokenAttribute()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -430,7 +430,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void ChangeStatusHasRouteAttributeWithCorrectTemplate()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<RouteAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "changestatus");
@@ -439,7 +439,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void ControllerHasRouteAtttributeWithTheCorrectRoute()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributes().OfType<RouteAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "api/task");
@@ -448,7 +448,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void ControllerHasProducesAtttributeWithTheCorrectContentType()
         {
-            var sut = new TaskApiController(null, null);
+            var sut = new TaskApiController(null, null, null);
             var attribute = sut.GetAttributes().OfType<ProducesAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.ContentTypes.Select(x => x.MediaType).First(), "application/json");

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -4,7 +4,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using AllReady.Controllers;
 using AllReady.UnitTest.Extensions;
+using AllReady.ViewModels;
+using Microsoft.AspNet.Authorization;
 using Microsoft.AspNet.Mvc;
+using Moq;
 using Xunit;
 
 namespace AllReady.UnitTest.Controllers
@@ -17,6 +20,40 @@ namespace AllReady.UnitTest.Controllers
 
         //these do not use HasEditTaskPermissions
         //RegisterTask
+        [Fact]
+        public void RegisterTaskHasValidateAntiForgeryTokenAttrbiute()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.RegisterTask(It.IsAny<ActivitySignupViewModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void RegisterTaskHasHttpPostAttributeWithCorrectTemplate()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.RegisterTask(It.IsAny<ActivitySignupViewModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Template, "signup");
+        }
+
+        [Fact]
+        public void RegisterTaskHasAuthorizeAttrbiute()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.RegisterTask(It.IsAny<ActivitySignupViewModel>())).OfType<AuthorizeAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void RegisterTaskHasHasProducesAtttributeWithTheCorrectContentType()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.RegisterTask(It.IsAny<ActivitySignupViewModel>())).OfType<ProducesAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.ContentTypes.Select(x => x.MediaType).First(), "application/json");
+        }
+
         //UnregisterTask
         //ChangeStatus
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -27,7 +27,7 @@ namespace AllReady.UnitTest.Controllers
             dataAccess.Setup(x => x.GetActivity(It.IsAny<int>())).Returns(new Activity());
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(false);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(false);
 
             var sut = new TaskApiController(dataAccess.Object, null, determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel { ActivityId = 1 });
@@ -45,7 +45,7 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.Send(It.IsAny<TaskByTaskIdQuery>())).Returns(new AllReadyTask());
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel { ActivityId = 1 });
@@ -57,7 +57,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task PostReturnsBadRequestObjectResultWithCorrectErrorMessageWhenActivityIsNull()
         { 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
             var sut = new TaskApiController(Mock.Of<IAllReadyDataAccess>(), Mock.Of<IMediator>(), determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel()) as BadRequestObjectResult;
@@ -79,7 +79,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
             await sut.Post(model);
@@ -99,7 +99,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
 
             var provider = new Mock<IDetermineIfATaskIsEditable>();
-            provider.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            provider.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, provider.Object);
             await sut.Post(model);
@@ -119,7 +119,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
 
             var provider = new Mock<IDetermineIfATaskIsEditable>();
-            provider.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            provider.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, provider.Object);
             var result = await sut.Post(model) as HttpStatusCodeResult;
@@ -159,7 +159,7 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.Send(It.IsAny<TaskByTaskIdQuery>())).Returns(new AllReadyTask());
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(false);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(false);
 
             var sut = new TaskApiController(null, mediator.Object, determineIfATaskIsEditable.Object);
             var result = await sut.Put(taskId, It.IsAny<TaskViewModel>());
@@ -177,7 +177,7 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.Send(It.IsAny<TaskByTaskIdQuery>())).Returns(allReadyTask);
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
             var dataAccess = new Mock<IAllReadyDataAccess>();
 
@@ -197,7 +197,7 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.Send(It.IsAny<TaskByTaskIdQuery>())).Returns(allReadyTask);
 
             var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
-            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
 
             var dataAccess = new Mock<IAllReadyDataAccess>();
 
@@ -209,7 +209,62 @@ namespace AllReady.UnitTest.Controllers
         }
 
         //Delete
+        [Fact]
+        public async Task DeleteSendsTaskByTaskIdQueryWithCorrectTaskId()
+        {
+            const int taskId = 1;
 
+            var mediator = new Mock<IMediator>();
+            var sut = new TaskApiController(null, mediator.Object, null);
+            await sut.Delete(taskId);
+
+            mediator.Verify(x => x.Send(It.Is<TaskByTaskIdQuery>(y => y.TaskId == taskId)));
+        }
+
+        [Fact]
+        public async Task DeleteReturnsBadRequestResultWhenCannotFindTaskByTaskId()
+        {
+            var sut = new TaskApiController(null, Mock.Of<IMediator>(), null);
+            var result = await sut.Delete(It.IsAny<int>());
+
+            Assert.IsType<BadRequestResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteReturnsHttpUnauthorizedResultWhenAUserDoesNotHavePermissionToEditTheTaskOrTheTaskIsNotEditable()
+        {
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.Send(It.IsAny<TaskByTaskIdQuery>())).Returns(new AllReadyTask());
+
+            var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(false);
+
+            var sut = new TaskApiController(null, mediator.Object, determineIfATaskIsEditable.Object);
+            var result = await sut.Delete(It.IsAny<int>());
+
+            Assert.IsType<HttpUnauthorizedResult>(result);
+        }
+
+        [Fact]
+        public async Task DeleteInvokesDeleteTaskAsyncWithCorrectTaskId()
+        {
+            var allReadyTask = new AllReadyTask { Id = 1 };
+
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.Send(It.IsAny<TaskByTaskIdQuery>())).Returns(allReadyTask);
+
+            var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
+            determineIfATaskIsEditable.Setup(x => x.For(It.IsAny<ClaimsPrincipal>(), It.IsAny<AllReadyTask>())).Returns(true);
+
+            var dataAccess = new Mock<IAllReadyDataAccess>();
+
+            var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
+            await sut.Delete(It.IsAny<int>());
+
+            dataAccess.Verify(x => x.DeleteTaskAsync(allReadyTask.Id), Times.Once);
+        }
+
+        //RegisterTask
         [Fact]
         public async Task RegisterTaskReturnsHttpBadRequestWhenModelIsNull()
         {

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -25,10 +25,10 @@ namespace AllReady.UnitTest.Controllers
             var dataAccess = new Mock<IAllReadyDataAccess>();
             dataAccess.Setup(x => x.GetActivity(It.IsAny<int>())).Returns(new Activity());
 
-            var provider = new Mock<IProvideTaskEditPermissions>();
-            provider.Setup(x => x.HasTaskEditPermissions(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(false);
+            var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
+            determineIfATaskIsEditable.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(false);
 
-            var sut = new TaskApiController(dataAccess.Object, null, provider.Object);
+            var sut = new TaskApiController(dataAccess.Object, null, determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel { ActivityId = 1 });
 
             Assert.IsType<HttpUnauthorizedResult>(result);
@@ -43,10 +43,10 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<TaskByTaskIdQuery>())).Returns(new AllReadyTask());
 
-            var provider = new Mock<IProvideTaskEditPermissions>();
-            provider.Setup(x => x.HasTaskEditPermissions(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
+            determineIfATaskIsEditable.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
-            var sut = new TaskApiController(dataAccess.Object, mediator.Object, provider.Object);
+            var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel { ActivityId = 1 });
 
             Assert.IsType<BadRequestResult>(result);
@@ -55,10 +55,10 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task PostReturnsBadRequestObjectResultWithCorrectErrorMessageWhenActivityIsNull()
         { 
-            var provider = new Mock<IProvideTaskEditPermissions>();
-            provider.Setup(x => x.HasTaskEditPermissions(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
+            determineIfATaskIsEditable.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
-            var sut = new TaskApiController(Mock.Of<IAllReadyDataAccess>(), Mock.Of<IMediator>(), provider.Object);
+            var sut = new TaskApiController(Mock.Of<IAllReadyDataAccess>(), Mock.Of<IMediator>(), determineIfATaskIsEditable.Object);
             var result = await sut.Post(new TaskViewModel()) as BadRequestObjectResult;
 
             Assert.IsType<BadRequestObjectResult>(result);
@@ -77,10 +77,10 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
 
-            var provider = new Mock<IProvideTaskEditPermissions>();
-            provider.Setup(x => x.HasTaskEditPermissions(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            var determineIfATaskIsEditable = new Mock<IDetermineIfATaskIsEditable>();
+            determineIfATaskIsEditable.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
-            var sut = new TaskApiController(dataAccess.Object, mediator.Object, provider.Object);
+            var sut = new TaskApiController(dataAccess.Object, mediator.Object, determineIfATaskIsEditable.Object);
             await sut.Post(model);
 
             dataAccess.Verify(x => x.AddTaskAsync(allReadyTask), Times.Once);
@@ -97,8 +97,8 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
 
-            var provider = new Mock<IProvideTaskEditPermissions>();
-            provider.Setup(x => x.HasTaskEditPermissions(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            var provider = new Mock<IDetermineIfATaskIsEditable>();
+            provider.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, provider.Object);
             await sut.Post(model);
@@ -117,8 +117,8 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
 
-            var provider = new Mock<IProvideTaskEditPermissions>();
-            provider.Setup(x => x.HasTaskEditPermissions(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
+            var provider = new Mock<IDetermineIfATaskIsEditable>();
+            provider.Setup(x => x.IsEditableFor(It.IsAny<AllReadyTask>(), It.IsAny<ClaimsPrincipal>())).Returns(true);
 
             var sut = new TaskApiController(dataAccess.Object, mediator.Object, provider.Object);
             var result = await sut.Post(model) as HttpStatusCodeResult;

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -448,7 +448,7 @@ namespace AllReady.UnitTest.Controllers
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
-            var jsonResult = await sut.UnregisterTask(It.IsAny<int>()) as JsonResult;
+            var jsonResult = await sut.UnregisterTask(It.IsAny<int>());
             var result = jsonResult.GetValueForProperty<string>("Status");
 
             Assert.IsType<JsonResult>(jsonResult);
@@ -465,7 +465,7 @@ namespace AllReady.UnitTest.Controllers
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
-            var jsonResult = await sut.UnregisterTask(It.IsAny<int>()) as JsonResult;
+            var jsonResult = await sut.UnregisterTask(It.IsAny<int>());
             var result = jsonResult.GetValueForProperty<string>("Task");
 
             Assert.IsType<JsonResult>(jsonResult);
@@ -481,7 +481,7 @@ namespace AllReady.UnitTest.Controllers
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
             
-            var jsonResult = await sut.UnregisterTask(It.IsAny<int>()) as JsonResult;
+            var jsonResult = await sut.UnregisterTask(It.IsAny<int>());
             var result = jsonResult.GetValueForProperty<TaskViewModel>("Task");
 
             Assert.IsType<JsonResult>(jsonResult);
@@ -535,7 +535,7 @@ namespace AllReady.UnitTest.Controllers
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
-            var jsonResult = await sut.ChangeStatus(new TaskChangeModel()) as JsonResult;
+            var jsonResult = await sut.ChangeStatus(new TaskChangeModel());
             var result = jsonResult.GetValueForProperty<string>("Status");
 
             Assert.IsType<JsonResult>(jsonResult);
@@ -552,7 +552,7 @@ namespace AllReady.UnitTest.Controllers
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
-            var jsonResult = await sut.ChangeStatus(new TaskChangeModel()) as JsonResult;
+            var jsonResult = await sut.ChangeStatus(new TaskChangeModel());
             var result = jsonResult.GetValueForProperty<string>("Task");
 
             Assert.IsType<JsonResult>(jsonResult);
@@ -568,7 +568,7 @@ namespace AllReady.UnitTest.Controllers
             var sut = new TaskApiController(null, mediator.Object, null);
             sut.SetDefaultHttpContext();
 
-            var jsonResult = await sut.ChangeStatus(new TaskChangeModel()) as JsonResult;
+            var jsonResult = await sut.ChangeStatus(new TaskChangeModel());
             var result = jsonResult.GetValueForProperty<TaskViewModel>("Task");
 
             Assert.IsType<JsonResult>(jsonResult);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Tasks;
@@ -23,7 +22,6 @@ namespace AllReady.UnitTest.Controllers
         //Put
         //Delete
 
-        //RegisterTask
         [Fact]
         public async Task RegisterTaskReturnsHttpBadRequestWhenModelIsNull()
         {
@@ -87,12 +85,10 @@ namespace AllReady.UnitTest.Controllers
 
             var sut = new TaskApiController(null, mediator.Object);
             
-            //var result = await sut.RegisterTask(model);
             var jsonResult = await sut.RegisterTask(model) as JsonResult;
             var result = jsonResult.GetValueForProperty<string>("Task");
 
             Assert.Null(result);
-            //Assert.Equal(result.ToString(), "{ Status = , Task =  }");
         }
 
         [Fact]
@@ -147,7 +143,6 @@ namespace AllReady.UnitTest.Controllers
             Assert.Equal(attribute.ContentTypes.Select(x => x.MediaType).First(), "application/json");
         }
 
-        //UnregisterTask
         [Fact]
         public async Task UnregisterTaskSendsTaskUnenrollCommandAsyncWithCorrectTaskIdAndUserId()
         {
@@ -232,7 +227,6 @@ namespace AllReady.UnitTest.Controllers
             Assert.Equal(attribute.Template, "{id}/signup");
         }
 
-        //ChangeStatus
         [Fact]
         public async Task ChangeStatusInvokesSendAsyncWithCorrectTaskStatusChangeCommand()
         {
@@ -299,6 +293,39 @@ namespace AllReady.UnitTest.Controllers
 
             Assert.IsType<JsonResult>(jsonResult);
             Assert.IsType<TaskViewModel>(result);
+        }
+
+        [Fact]
+        public void ChangeStatusHasHttpPostAttribute()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void ChangeStatusHasAuthorizeAttribute()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<AuthorizeAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void ChangeStatusHasValidateAntiForgeryTokenAttribute()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void ChangeStatusHasRouteAttributeWithCorrectTemplate()
+        {
+            var sut = new TaskApiController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.ChangeStatus(It.IsAny<TaskChangeModel>())).OfType<RouteAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Template, "changestatus");
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/DataAccess/AllReadyDataAccessEF7Tests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/DataAccess/AllReadyDataAccessEF7Tests.cs
@@ -86,7 +86,7 @@ namespace AllReady.UnitTest.DataAccess
         }
 
         [Fact]
-        public async void DeleteActivityAndTaskSignupsAsyncRemovesTaskSignup()
+        public async Task DeleteActivityAndTaskSignupsAsyncRemovesTaskSignup()
         {
             const int activitySignupId = 5;
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
@@ -40,7 +40,7 @@ namespace AllReady.UnitTest.Extensions
             claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
             {
                 new Claim(ClaimTypes.NameIdentifier, "1"),
-                new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), userType))
+                new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof(UserType), userType))
             }));
 
             Mock.Get(controller.HttpContext).SetupGet(httpContext => httpContext.User).Returns(claimsPrincipal);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Security.Claims;
+using AllReady.Models;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Http.Internal;
 using Microsoft.AspNet.Mvc;
@@ -26,6 +28,40 @@ namespace AllReady.UnitTest.Extensions
 
             var claimsPrincipal = new ClaimsPrincipal();
             claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.NameIdentifier, userId) }));
+
+            Mock.Get(controller.HttpContext).SetupGet(httpContext => httpContext.User).Returns(claimsPrincipal);
+
+            return controller;
+        }
+
+        public static T SetFakeUserType<T>(this T controller, UserType userType) where T : Controller
+        {
+            if (controller.ActionContext.HttpContext == null)
+                controller.SetFakeHttpContext();
+
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, "1"),
+                new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), userType))
+            }));
+
+            Mock.Get(controller.HttpContext).SetupGet(httpContext => httpContext.User).Returns(claimsPrincipal);
+
+            return controller;
+        }
+
+        public static T SetFakeUserAndUserType<T>(this T controller, string userId, UserType userType) where T : Controller
+        {
+            if (controller.ActionContext.HttpContext == null)
+                controller.SetFakeHttpContext();
+
+            var claimsPrincipal = new ClaimsPrincipal();
+            claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId),
+                new Claim(AllReady.Security.ClaimTypes.UserType, Enum.GetName(typeof (UserType), userType))
+            }));
 
             Mock.Get(controller.HttpContext).SetupGet(httpContext => httpContext.User).Returns(claimsPrincipal);
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
@@ -22,7 +22,7 @@ namespace AllReady.UnitTest.Extensions
             Mock.Get(controller.Request).SetupGet(httpRequest => httpRequest.Scheme).Returns(requestScheme);
         }
 
-        public static T SetFakeUser<T>(this T controller, string userId) where T : Controller
+        public static void SetFakeUser(this Controller controller, string userId)
         {
             SetFakeHttpContextIfNotAlreadySet(controller);
 
@@ -30,11 +30,9 @@ namespace AllReady.UnitTest.Extensions
             claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.NameIdentifier, userId) }));
 
             Mock.Get(controller.HttpContext).SetupGet(httpContext => httpContext.User).Returns(claimsPrincipal);
-
-            return controller;
         }
 
-        public static T SetFakeUserType<T>(this T controller, UserType userType) where T : Controller
+        public static void SetFakeUserType(this Controller controller, UserType userType)
         {
             if (controller.ActionContext.HttpContext == null)
                 controller.SetFakeHttpContext();
@@ -47,11 +45,9 @@ namespace AllReady.UnitTest.Extensions
             }));
 
             Mock.Get(controller.HttpContext).SetupGet(httpContext => httpContext.User).Returns(claimsPrincipal);
-
-            return controller;
         }
 
-        public static T SetFakeUserAndUserType<T>(this T controller, string userId, UserType userType) where T : Controller
+        public static void SetFakeUserAndUserType(this Controller controller, string userId, UserType userType)
         {
             if (controller.ActionContext.HttpContext == null)
                 controller.SetFakeHttpContext();
@@ -64,11 +60,9 @@ namespace AllReady.UnitTest.Extensions
             }));
 
             Mock.Get(controller.HttpContext).SetupGet(httpContext => httpContext.User).Returns(claimsPrincipal);
-
-            return controller;
         }
 
-        public static void AddModelStateError(this Controller controller, string errorMessage)
+        public static void AddModelStateErrorWithErrorMessage(this Controller controller, string errorMessage)
         {
             controller.ViewData.ModelState.AddModelError("Error", errorMessage);
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
@@ -34,8 +34,7 @@ namespace AllReady.UnitTest.Extensions
 
         public static void SetFakeUserType(this Controller controller, UserType userType)
         {
-            if (controller.ActionContext.HttpContext == null)
-                controller.SetFakeHttpContext();
+            SetFakeHttpContextIfNotAlreadySet(controller);
 
             var claimsPrincipal = new ClaimsPrincipal();
             claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
@@ -49,8 +48,7 @@ namespace AllReady.UnitTest.Extensions
 
         public static void SetFakeUserAndUserType(this Controller controller, string userId, UserType userType)
         {
-            if (controller.ActionContext.HttpContext == null)
-                controller.SetFakeHttpContext();
+            SetFakeHttpContextIfNotAlreadySet(controller);
 
             var claimsPrincipal = new ClaimsPrincipal();
             claimsPrincipal.AddIdentity(new ClaimsIdentity(new List<Claim>
@@ -110,7 +108,7 @@ namespace AllReady.UnitTest.Extensions
         private static void SetFakeHttpContextIfNotAlreadySet(Controller controller)
         {
             if (controller.ActionContext.HttpContext == null)
-                controller.SetFakeHttpContext();
+                controller.ActionContext.HttpContext = SetFakeHttpContext();
         }
 
         private static void SetFakeHttpContext(this Controller controller)

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Extensions/ControllerTestHelpers.cs
@@ -108,13 +108,7 @@ namespace AllReady.UnitTest.Extensions
         private static void SetFakeHttpContextIfNotAlreadySet(Controller controller)
         {
             if (controller.ActionContext.HttpContext == null)
-                controller.ActionContext.HttpContext = SetFakeHttpContext();
-        }
-
-        private static void SetFakeHttpContext(this Controller controller)
-        {
-            var httpContext = FakeHttpContext();
-            controller.ActionContext.HttpContext = httpContext;
+                controller.ActionContext.HttpContext = FakeHttpContext();
         }
 
         private static HttpContext FakeHttpContext()

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Tasks/AddTaskCommandHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Tasks/AddTaskCommandHandlerAsyncTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using AllReady.Features.Tasks;
+using AllReady.Models;
+using Moq;
+using Xunit;
+
+namespace AllReady.UnitTest.Features.Tasks
+{
+    public class AddTaskCommandHandlerAsyncTests
+    {
+        [Fact]
+        public async Task HandleInvokesAddTaskAsyncWithCorrectData()
+        {
+            var message = new AddTaskCommandAsync { AllReadyTask = new AllReadyTask() };
+            var dataAccess = new Mock<IAllReadyDataAccess>();
+            var sut = new AddTaskCommandHandlerAsync(dataAccess.Object);
+            await sut.Handle(message);
+
+            dataAccess.Verify(x => x.AddTaskAsync(message.AllReadyTask), Times.Once);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Tasks/UpdateTaskCommandHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Tasks/UpdateTaskCommandHandlerAsyncTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using AllReady.Features.Tasks;
+using AllReady.Models;
+using Moq;
+using Xunit;
+
+namespace AllReady.UnitTest.Features.Tasks
+{
+    public class UpdateTaskCommandHandlerAsyncTests
+    {
+        [Fact]
+        public async Task HandleInvokesUpdateTaskAsyncWithCorrectData()
+        {
+            var message = new UpdateTaskCommandAsync { AllReadyTask = new AllReadyTask() };
+            var dataAccess = new Mock<IAllReadyDataAccess>();
+
+            var sut = new UpdateTaskCommandHandlerAsync(dataAccess.Object);
+            await sut.Handle(message);
+
+            dataAccess.Verify(x => x.UpdateTaskAsync(message.AllReadyTask), Times.Once);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Tasks/SignupStatusChangeTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Tasks/SignupStatusChangeTests.cs
@@ -97,7 +97,7 @@ namespace AllReady.UnitTest.Tasks
             await handler.Handle(command);
 
             var taskSignup = Context.TaskSignups.First();
-            mediator.Verify(b => b.Publish(It.Is<TaskSignupStatusChanged>(notifyCommand => notifyCommand.SignupId == taskSignup.Id)), Times.Once());
+            mediator.Verify(b => b.PublishAsync(It.Is<TaskSignupStatusChanged>(notifyCommand => notifyCommand.SignupId == taskSignup.Id)), Times.Once());
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Tasks/SignupStatusChangeTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Tasks/SignupStatusChangeTests.cs
@@ -1,0 +1,103 @@
+﻿using AllReady.Areas.Admin.Features.Tasks;
+using AllReady.Features.Notifications;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Tasks
+{
+    public class SignupStatusChangeTests : InMemoryContextTest
+    {
+        protected override void LoadTestData()
+        {
+            var context = ServiceProvider.GetService<AllReadyContext>();
+            var htb = new Organization()
+            {
+                Name = "Humanitarian Toolbox",
+                LogoUrl = "http://www.htbox.org/upload/home/ht-hero.png",
+                WebUrl = "http://www.htbox.org",
+                Campaigns = new List<Campaign>()
+            };
+
+            var firePrev = new Campaign()
+            {
+                Name = "Neighborhood Fire Prevention Days",
+                ManagingOrganization = htb
+            };
+
+            var queenAnne = new Activity()
+            {
+                Id = 1,
+                Name = "Queen Anne Fire Prevention Day",
+                Campaign = firePrev,
+                CampaignId = firePrev.Id,
+                StartDateTime = new DateTime(2015, 7, 4, 10, 0, 0).ToUniversalTime(),
+                EndDateTime = new DateTime(2015, 12, 31, 15, 0, 0).ToUniversalTime(),
+                Location = new Location { Id = 1 },
+                RequiredSkills = new List<ActivitySkill>(),
+            };
+
+            var username1 = $"blah@1.com";
+
+            var user1 = new ApplicationUser { UserName = username1, Email = username1, EmailConfirmed = true };
+            context.Users.Add(user1);
+
+            htb.Campaigns.Add(firePrev);
+            context.Organizations.Add(htb);
+            context.Activities.Add(queenAnne);
+
+            var activitySignups = new List<ActivitySignup>
+            {
+                new ActivitySignup { Activity = queenAnne, User = user1, SignupDateTime = DateTime.UtcNow }
+            };
+
+            context.ActivitySignup.AddRange(activitySignups);
+
+            var newTask = new AllReadyTask()
+            {
+                Activity = queenAnne,
+                Description = "Description of a very important task",
+                Name = "Task # 1",
+                EndDateTime = DateTime.Now.AddDays(5),
+                StartDateTime = DateTime.Now.AddDays(3),
+                Organization = htb
+            };
+
+            newTask.AssignedVolunteers.Add(new TaskSignup()
+            {
+                Task = newTask,
+                User = user1
+            });
+
+            context.Tasks.Add(newTask);
+
+            context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task VolunteerAcceptsTask()
+        {
+            var mediator = new Mock<IMediator>();
+
+            var task = Context.Tasks.First();
+            var user = Context.Users.First();
+            var command = new TaskStatusChangeCommandAsync
+            {
+                TaskId = task.Id,
+                UserId = user.Id,
+                TaskStatus = AllReady.Areas.Admin.Features.Tasks.TaskStatus.Accepted
+            };
+            var handler = new TaskStatusChangeHandlerAsync(Context, mediator.Object);
+            await handler.Handle(command);
+
+            var taskSignup = Context.TaskSignups.First();
+            mediator.Verify(b => b.Publish(It.Is<TaskSignupStatusChanged>(notifyCommand => notifyCommand.SignupId == taskSignup.Id)), Times.Once());
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Tasks/TaskByTaskIdQueryHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Tasks/TaskByTaskIdQueryHandlerTests.cs
@@ -1,0 +1,22 @@
+﻿using AllReady.Features.Tasks;
+using AllReady.Models;
+using Moq;
+using Xunit;
+
+namespace AllReady.UnitTest.Tasks
+{
+    public class TaskByTaskIdQueryHandlerTests
+    { 
+        [Fact]
+        public void WhenHandlingTaskByTaskIdQueryGetTaskIsInvokedWithCorrectTaskId()
+        {
+            var message = new TaskByTaskIdQuery { TaskId = 1 };
+
+            var dataAccess = new Mock<IAllReadyDataAccess>();
+            var sut = new TaskByTaskIdQueryHandler(dataAccess.Object);
+            sut.Handle(message);
+
+            dataAccess.Verify(x => x.GetTask(message.TaskId), Times.Once);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskStatusChangeCommandAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskStatusChangeCommandAsync.cs
@@ -2,7 +2,7 @@
 
 namespace AllReady.Areas.Admin.Features.Tasks
 {
-    public class TaskStatusChangeCommand : IAsyncRequest<TaskChangeResult>
+    public class TaskStatusChangeCommandAsync : IAsyncRequest<TaskChangeResult>
     {
         public int TaskId { get; set; }
         public string UserId { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerAsync.cs
@@ -70,7 +70,7 @@ namespace AllReady.Areas.Admin.Features.Tasks
             return new TaskChangeResult { Status = "success", Task = task };
         }
 
-        private async Task<AllReadyTask> GetTask(TaskStatusChangeCommand message)
+        private async Task<AllReadyTask> GetTask(TaskStatusChangeCommandAsync message)
         {
             return await _context.Tasks
                 .Include(t => t.AssignedVolunteers).ThenInclude(ts => ts.User)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerAsync.cs
@@ -8,18 +8,18 @@ using Microsoft.Data.Entity;
 
 namespace AllReady.Areas.Admin.Features.Tasks
 {
-    public class TaskStatusChangeHandler : IAsyncRequestHandler<TaskStatusChangeCommand, TaskChangeResult>
+    public class TaskStatusChangeHandlerAsync : IAsyncRequestHandler<TaskStatusChangeCommandAsync, TaskChangeResult>
     {
         private AllReadyContext _context;
         private IMediator _mediator;
 
-        public TaskStatusChangeHandler(AllReadyContext context, IMediator mediator)
+        public TaskStatusChangeHandlerAsync(AllReadyContext context, IMediator mediator)
         {
             _context = context;
             _mediator = mediator;
         }
 
-        public async Task<TaskChangeResult> Handle(TaskStatusChangeCommand message)
+        public async Task<TaskChangeResult> Handle(TaskStatusChangeCommandAsync message)
         {
             var task = await GetTask(message).ConfigureAwait(false);
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/ActivityApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ActivityApiController.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.AspNet.Authorization;
-using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Mvc;
 using AllReady.Models;
-using AllReady.Services;
 using AllReady.ViewModels;
 using System;
 using System.Collections.Generic;
@@ -137,7 +135,6 @@ namespace AllReady.Controllers
             }
 
             await _mediator.SendAsync(new ActivitySignupCommand { ActivitySignup = signupModel });
-
 
             return new {Status = "success"};
         }

--- a/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
@@ -96,13 +96,6 @@ namespace AllReady.Controllers
         public async Task<IActionResult> ChangeStatus(int activityId, int taskId, string userId, TaskStatus status, string statusDesc)
         {
             if (userId == null)
-                return HttpBadRequest();
-        [HttpGet]
-        [Route("/Activity/ChangeStatus")]
-        [Authorize]
-        public async Task<IActionResult> ChangeStatus(int activityId, int taskId, string userId, TaskStatus status, string statusDesc)
-        {
-            if (userId == null)
             {
                 return HttpBadRequest();
             }

--- a/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
@@ -84,8 +84,8 @@ namespace AllReady.Controllers
                 await _mediator.SendAsync(new ActivitySignupCommand { ActivitySignup = signupModel });
             }
             
-            //TODO: handle invalid activity signup info (phone, email) in a useful way
-            //  would be best to handle it in KO on the client side (prevent clicking Volunteer)
+                //TODO: handle invalid activity signup info (phone, email) in a useful way
+                //  would be best to handle it in KO on the client side (prevent clicking Volunteer)
 
             return RedirectToAction(nameof(ShowActivity), new { id = signupModel.ActivityId });
         }
@@ -102,7 +102,7 @@ namespace AllReady.Controllers
 
             await _mediator.SendAsync(new TaskStatusChangeCommand { TaskStatus = status, TaskId = taskId, UserId = userId, TaskStatusDescription = statusDesc });
 
-            return RedirectToAction(nameof(ShowActivity), new { id = activityId });
-        }
+        //    return RedirectToAction(nameof(ShowActivity), new { id = activityId });
+        //}
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ActivityController.cs
@@ -96,13 +96,20 @@ namespace AllReady.Controllers
         public async Task<IActionResult> ChangeStatus(int activityId, int taskId, string userId, TaskStatus status, string statusDesc)
         {
             if (userId == null)
+                return HttpBadRequest();
+        [HttpGet]
+        [Route("/Activity/ChangeStatus")]
+        [Authorize]
+        public async Task<IActionResult> ChangeStatus(int activityId, int taskId, string userId, TaskStatus status, string statusDesc)
+        {
+            if (userId == null)
             {
                 return HttpBadRequest();
             }
 
-            await _mediator.SendAsync(new TaskStatusChangeCommand { TaskStatus = status, TaskId = taskId, UserId = userId, TaskStatusDescription = statusDesc });
+            await _mediator.SendAsync(new TaskStatusChangeCommandAsync { TaskStatus = status, TaskId = taskId, UserId = userId, TaskStatusDescription = statusDesc });
 
-        //    return RedirectToAction(nameof(ShowActivity), new { id = activityId });
-        //}
+            return RedirectToAction(nameof(ShowActivity), new { id = activityId });
+        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -98,7 +98,9 @@ namespace AllReady.Controllers
 
             var result = await _mediator.SendAsync(new TaskSignupCommand { TaskSignupModel = signupModel });
 
-            return new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, signupModel.UserId) };
+            return new { result.Status, Task = result.Task == null ? 
+                null : 
+                new TaskViewModel(result.Task, signupModel.UserId) };
         }
 
         [HttpDelete("{id}/signup")]
@@ -106,8 +108,8 @@ namespace AllReady.Controllers
         public async Task<object> UnregisterTask(int id)
         {
             var userId = User.GetUserId();
-            var result = await _mediator.SendAsync(new TaskUnenrollCommand() { TaskId = id, UserId = userId});
-            return new { result.Status, Task = (result.Task == null) ? null : new TaskViewModel(result.Task, userId) };
+            var result = await _mediator.SendAsync(new TaskUnenrollCommand { TaskId = id, UserId = userId });
+            return new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, userId) };
         }
 
         [HttpPost]

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -105,11 +105,12 @@ namespace AllReady.Controllers
 
         [HttpDelete("{id}/signup")]
         [Authorize]
-        public async Task<object> UnregisterTask(int id)
+        public async Task<ActionResult> UnregisterTask(int id)
         {
             var userId = User.GetUserId();
             var result = await _mediator.SendAsync(new TaskUnenrollCommand { TaskId = id, UserId = userId });
-            return new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, userId) };
+
+            return Json(new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, userId) });
         }
 
         [HttpPost]

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -96,9 +96,9 @@ namespace AllReady.Controllers
                 return Json(new { errors = ModelState.GetErrorMessages() });
             }
 
-            var result = await _mediator.SendAsync(new TaskSignupCommand() { TaskSignupModel = signupModel });
+            var result = await _mediator.SendAsync(new TaskSignupCommand { TaskSignupModel = signupModel });
 
-            return new { result.Status, Task = (result.Task == null) ? null : new TaskViewModel(result.Task, signupModel.UserId)};
+            return new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, signupModel.UserId) };
         }
 
         [HttpDelete("{id}/signup")]

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -1,28 +1,17 @@
-﻿using Microsoft.AspNet.Identity;
-using Microsoft.AspNet.Mvc;
-
+﻿using Microsoft.AspNet.Mvc;
 using AllReady.Security;
 using AllReady.Models;
 using AllReady.ViewModels;
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Tasks;
 using AllReady.Extensions;
-using AllReady.Features.Activity;
-using AllReady.Features.Notifications;
 using AllReady.Features.Tasks;
 using MediatR;
 using Microsoft.AspNet.Authorization;
-using TaskStatus = AllReady.Areas.Admin.Features.Tasks.TaskStatus;
 
 namespace AllReady.Controllers
 {
-
     [Route("api/task")]
     [Produces("application/json")]
     public class TaskApiController : Controller
@@ -30,79 +19,27 @@ namespace AllReady.Controllers
         private readonly IAllReadyDataAccess _allReadyDataAccess;
         private readonly IMediator _mediator;
 
-
         public TaskApiController(IAllReadyDataAccess allReadyDataAccess, IMediator mediator)
         {
             _allReadyDataAccess = allReadyDataAccess;
             _mediator = mediator;
         }
 
-        private bool HasTaskEditPermissions(AllReadyTask task)
-        {
-            var userId = User.GetUserId();
-            if (User.IsUserType(UserType.SiteAdmin))
-            {
-                return true;
-            }
-
-            if (User.IsUserType(UserType.OrgAdmin))
-            {
-                //TODO: Modify to check that user is organization admin for organization of task
-                return true;
-            }
-
-            if (task.Activity?.Organizer != null && task.Activity.Organizer.Id == userId)
-            {
-                return true;
-            }
-
-            if (task.Activity?.Campaign != null && task.Activity.Campaign.Organizer != null && task.Activity.Campaign.Organizer.Id == userId)
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private bool HasTaskSignupEditPermissions(AllReadyTask task)
-        {
-            if (HasTaskEditPermissions(task))
-            {
-                return true;
-            }
-            else
-            {
-                var userId = User.GetUserId();                
-                if (task.AssignedVolunteers?.FirstOrDefault(x => x.User.Id == userId) != null)
-                {
-                    return true;
-                }
-                else { return false; }
-            }
-        }
-
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async void Post([FromBody]TaskViewModel task)
         {
-            bool hasPermissions = HasTaskEditPermissions(task.ToModel(_allReadyDataAccess));
+            var hasPermissions = HasTaskEditPermissions(task.ToModel(_allReadyDataAccess));
             if (!hasPermissions)
-            {
                 HttpUnauthorized();
-            }
 
-            bool alreadyExists = _allReadyDataAccess.GetTask(task.Id) != null;
-
+            var alreadyExists = _allReadyDataAccess.GetTask(task.Id) != null;
             if (alreadyExists)
-            {
                 HttpBadRequest();
-            }
 
             var model = task.ToModel(_allReadyDataAccess);
             if (model == null)
-            {
                 HttpBadRequest("Should have found a matching activity Id");
-            }
 
             await _allReadyDataAccess.AddTaskAsync(model);
         }
@@ -112,16 +49,12 @@ namespace AllReady.Controllers
         {
             var task = _allReadyDataAccess.GetTask(id);
 
-            bool hasPermissions = HasTaskEditPermissions(task);
+            var hasPermissions = HasTaskEditPermissions(task);
             if (!hasPermissions)
-            {
                 HttpUnauthorized();
-            }
 
             if (task == null)
-            {
                 HttpBadRequest();
-            }
 
             // Changing all the potential properties that the VM could have modified.
             task.Name = value.Name;
@@ -139,11 +72,10 @@ namespace AllReady.Controllers
 
             if (matchingTask != null)
             {
-                bool hasPermissions = HasTaskEditPermissions(matchingTask);
+                var hasPermissions = HasTaskEditPermissions(matchingTask);
                 if (!hasPermissions)
-                {
                     HttpUnauthorized();
-                }
+
                 await _allReadyDataAccess.DeleteTaskAsync(matchingTask.Id);
             }
         }
@@ -155,9 +87,7 @@ namespace AllReady.Controllers
         public async Task<object> RegisterTask(ActivitySignupViewModel signupModel)
         {
             if (signupModel == null)
-            {
                 return HttpBadRequest();
-            }
 
             if (!ModelState.IsValid)
             {
@@ -167,7 +97,8 @@ namespace AllReady.Controllers
             }
 
             var result = await _mediator.SendAsync(new TaskSignupCommand() { TaskSignupModel = signupModel });
-            return new {Status = result.Status, Task = (result.Task == null) ? null : new TaskViewModel(result.Task, signupModel.UserId)};
+
+            return new { result.Status, Task = (result.Task == null) ? null : new TaskViewModel(result.Task, signupModel.UserId)};
         }
 
         [HttpDelete("{id}/signup")]
@@ -176,7 +107,7 @@ namespace AllReady.Controllers
         {
             var userId = User.GetUserId();
             var result = await _mediator.SendAsync(new TaskUnenrollCommand() { TaskId = id, UserId = userId});
-            return new { Status = result.Status, Task = (result.Task == null) ? null : new TaskViewModel(result.Task, userId) };
+            return new { result.Status, Task = (result.Task == null) ? null : new TaskViewModel(result.Task, userId) };
         }
 
         [HttpPost]

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -10,6 +10,7 @@ using AllReady.Extensions;
 using AllReady.Features.Tasks;
 using MediatR;
 using Microsoft.AspNet.Authorization;
+using DeleteTaskCommandAsync = AllReady.Features.Tasks.DeleteTaskCommandAsync;
 
 namespace AllReady.Controllers
 {

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -109,17 +109,15 @@ namespace AllReady.Controllers
             }
 
             var result = await _mediator.SendAsync(new TaskSignupCommand { TaskSignupModel = signupModel });
-
             return Json(new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, signupModel.UserId) });
         }
 
         [HttpDelete("{id}/signup")]
         [Authorize]
-        public async Task<ActionResult> UnregisterTask(int id)
+        public async Task<JsonResult> UnregisterTask(int id)
         {
             var userId = User.GetUserId();
             var result = await _mediator.SendAsync(new TaskUnenrollCommand { TaskId = id, UserId = userId });
-
             return Json(new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, userId) });
         }
 
@@ -127,10 +125,9 @@ namespace AllReady.Controllers
         [ValidateAntiForgeryToken]
         [Route("changestatus")]
         [Authorize]
-        public async Task<ActionResult> ChangeStatus(TaskChangeModel model)
+        public async Task<JsonResult> ChangeStatus(TaskChangeModel model)
         {
             var result = await _mediator.SendAsync(new TaskStatusChangeCommandAsync { TaskStatus = model.Status, TaskId = model.TaskId, UserId = model.UserId, TaskStatusDescription = model.StatusDescription });
-
             return Json(new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, model.UserId) });
         }
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -21,12 +21,6 @@ namespace AllReady.Controllers
         private readonly IMediator _mediator;
         private readonly IProvideTaskEditPermissions _taskEditPermissionsProvider;
 
-        public TaskApiController(IAllReadyDataAccess allReadyDataAccess, IMediator mediator)
-        {
-            _allReadyDataAccess = allReadyDataAccess;
-            _mediator = mediator;
-        }
-
         public TaskApiController(IAllReadyDataAccess allReadyDataAccess, IMediator mediator, IProvideTaskEditPermissions taskEditPermissionsProvider)
         {
             _allReadyDataAccess = allReadyDataAccess;

--- a/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Task.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/AllReadyDataAccessEF7.Task.cs
@@ -53,7 +53,8 @@ namespace AllReady.Models
                 _dbContext.Add(task);
                 return _dbContext.SaveChangesAsync();
             }
-            else throw new InvalidOperationException("Added task that already has Id");
+
+            throw new InvalidOperationException("Added task that already has Id");
         }
 
         Task IAllReadyDataAccess.DeleteTaskAsync(int taskId)

--- a/AllReadyApp/Web-App/AllReady/DataAccess/IAllReadyDataAccess.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/IAllReadyDataAccess.cs
@@ -89,6 +89,7 @@ namespace AllReady.Models
         Task DeleteTaskAsync(int taskId);
 
         Task UpdateTaskAsync(AllReadyTask value);
+
         IEnumerable<TaskSignup> GetTasksAssignedToUser(int activityId, string userId);
 
         #endregion

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/AddTaskCommandAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/AddTaskCommandAsync.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Features.Tasks
+{
+    public class AddTaskCommandAsync : IAsyncRequest
+    {
+        public AllReadyTask AllReadyTask { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/AddTaskCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/AddTaskCommandHandlerAsync.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Features.Tasks
+{
+    public class AddTaskCommandHandlerAsync : AsyncRequestHandler<AddTaskCommandAsync>
+    {
+        private readonly IAllReadyDataAccess dataAccess;
+
+        public AddTaskCommandHandlerAsync(IAllReadyDataAccess dataAccess)
+        {
+            this.dataAccess = dataAccess;
+        }
+
+        protected override async Task HandleCore(AddTaskCommandAsync message)
+        {
+            await dataAccess.AddTaskAsync(message.AllReadyTask);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/DeleteTaskCommandAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/DeleteTaskCommandAsync.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Tasks
+{
+    public class DeleteTaskCommandAsync : IAsyncRequest
+    {
+        public int TaskId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/DeleteTaskCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/DeleteTaskCommandHandlerAsync.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using RestSharp;
+
+namespace AllReady.Features.Tasks
+{
+    public class DeleteTaskCommandHandlerAsync : AsyncRequestHandler<DeleteTaskCommandAsync>
+    {
+        private readonly IAllReadyDataAccess dataAccess;
+
+        public DeleteTaskCommandHandlerAsync(IAllReadyDataAccess dataAccess)
+        {
+            this.dataAccess = dataAccess;
+        }
+
+        protected override async Task HandleCore(DeleteTaskCommandAsync message)
+        {
+            await dataAccess.DeleteTaskAsync(message.TaskId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/TaskByTaskIdQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/TaskByTaskIdQuery.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Features.Tasks
+{
+    public class TaskByTaskIdQuery : IRequest<AllReadyTask>
+    {
+        public int TaskId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/TaskByTaskIdQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/TaskByTaskIdQueryHandler.cs
@@ -1,0 +1,20 @@
+﻿using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Features.Tasks
+{
+    public class TaskByTaskIdQueryHandler : IRequestHandler<TaskByTaskIdQuery, AllReadyTask>
+    {
+        private readonly IAllReadyDataAccess dataAccess;
+
+        public TaskByTaskIdQueryHandler(IAllReadyDataAccess dataAccess)
+        {
+            this.dataAccess = dataAccess;
+        }
+
+        public AllReadyTask Handle(TaskByTaskIdQuery message)
+        {
+            return dataAccess.GetTask(message.TaskId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/UpdateTaskCommandAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/UpdateTaskCommandAsync.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Features.Tasks
+{
+    public class UpdateTaskCommandAsync : IAsyncRequest
+    {
+        public AllReadyTask AllReadyTask { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/UpdateTaskCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/UpdateTaskCommandHandlerAsync.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Features.Tasks
+{
+    public class UpdateTaskCommandHandlerAsync : AsyncRequestHandler<UpdateTaskCommandAsync>
+    {
+        private readonly IAllReadyDataAccess dataAccess;
+
+        public UpdateTaskCommandHandlerAsync(IAllReadyDataAccess dataAccess)
+        {
+            this.dataAccess = dataAccess;
+        }
+
+        protected override async Task HandleCore(UpdateTaskCommandAsync message)
+        {
+            await dataAccess.UpdateTaskAsync(message.AllReadyTask);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using AllReady.Controllers;
 using AllReady.Models;
 using AllReady.Security;
 using AllReady.Services;
@@ -112,6 +113,7 @@ namespace AllReady
             services.AddTransient<IEmailSender, AuthMessageSender>();
             services.AddTransient<ISmsSender, AuthMessageSender>();
             services.AddTransient<IAllReadyDataAccess, AllReadyDataAccessEF7>();
+            services.AddTransient<IProvideTaskEditPermissions, ProvideTaskEditPermissions>();
             services.AddSingleton<IImageService, ImageService>();
             //services.AddSingleton<GeoService>();
             services.AddTransient<SampleDataGenerator>();

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -113,7 +113,7 @@ namespace AllReady
             services.AddTransient<IEmailSender, AuthMessageSender>();
             services.AddTransient<ISmsSender, AuthMessageSender>();
             services.AddTransient<IAllReadyDataAccess, AllReadyDataAccessEF7>();
-            services.AddTransient<IProvideTaskEditPermissions, ProvideTaskEditPermissions>();
+            services.AddTransient<IDetermineIfATaskIsEditable, DetermineIfATaskIsEditable>();
             services.AddSingleton<IImageService, ImageService>();
             //services.AddSingleton<GeoService>();
             services.AddTransient<SampleDataGenerator>();

--- a/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
@@ -12,7 +12,7 @@ namespace AllReady.ViewModels
         {
         }
 
-        public TaskViewModel(AllReadyTask task, string userId=null)
+        public TaskViewModel(AllReadyTask task, string userId = null)
         {
             Id = task.Id;
             Name = task.Name;
@@ -180,8 +180,8 @@ namespace AllReady.ViewModels
             dbtask.Id = taskViewModel.Id;
             dbtask.Description = taskViewModel.Description;
             dbtask.Activity = activity;
-            dbtask.EndDateTime = taskViewModel.EndDateTime.HasValue ? taskViewModel.EndDateTime.Value.UtcDateTime : new Nullable<DateTime>();
-            dbtask.StartDateTime = taskViewModel.EndDateTime.HasValue ? taskViewModel.StartDateTime.Value.UtcDateTime : new Nullable<DateTime>();
+            dbtask.EndDateTime = taskViewModel.EndDateTime.HasValue ? taskViewModel.EndDateTime.Value.UtcDateTime : new DateTime?();
+            dbtask.StartDateTime = taskViewModel.EndDateTime.HasValue ? taskViewModel.StartDateTime.Value.UtcDateTime : new DateTime?();
             dbtask.Name = taskViewModel.Name;
             dbtask.RequiredSkills = dbtask.RequiredSkills ?? new List<TaskSkill>();
             taskViewModel.RequiredSkills = taskViewModel.RequiredSkills ?? new List<int>();

--- a/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
@@ -83,7 +83,6 @@ namespace AllReady.ViewModels
 
         }
 
-
         public int Id { get; set; }
         public bool IsNew { get; set; }
 
@@ -147,7 +146,6 @@ namespace AllReady.ViewModels
         {
             IsUserSignedUpForTask = isUserSignedupForTask;
         }
-
     }
 
     public static class TaskViewModelExtensions
@@ -211,7 +209,6 @@ namespace AllReady.ViewModels
             }
             // end workaround
 
-
             if (taskViewModel.AssignedVolunteers != null && taskViewModel.AssignedVolunteers.Count > 0)
             {
                 var taskUsersList = taskViewModel.AssignedVolunteers.Select(tvm => new TaskSignup
@@ -241,13 +238,11 @@ namespace AllReady.ViewModels
             }
 
             return dbtask;
-
         }
 
         public static IEnumerable<AllReadyTask> ToModel(this IEnumerable<TaskViewModel> tasks, IAllReadyDataAccess dataContext)
         {
             return tasks.Select(task => task.ToModel(dataContext));
         }
-
     }
 }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
@@ -18,20 +18,15 @@ namespace AllReady.ViewModels
             Name = task.Name;
             Description = task.Description;
 
-
             if (task.StartDateTime.HasValue)
             {
-                DateTime startDateWithUtcKind = DateTime.SpecifyKind(
-                    DateTime.Parse(task.StartDateTime.Value.ToString()),
-                    DateTimeKind.Utc);
+                var startDateWithUtcKind = DateTime.SpecifyKind(DateTime.Parse(task.StartDateTime.Value.ToString()), DateTimeKind.Utc);
                 StartDateTime = new DateTimeOffset(startDateWithUtcKind);
             }
 
             if (task.EndDateTime.HasValue)
             {
-                DateTime endDateWithUtcKind = DateTime.SpecifyKind(
-                    DateTime.Parse(task.EndDateTime.Value.ToString()),
-                    DateTimeKind.Utc);
+                var endDateWithUtcKind = DateTime.SpecifyKind(DateTime.Parse(task.EndDateTime.Value.ToString()), DateTimeKind.Utc);
                 EndDateTime = new DateTimeOffset(endDateWithUtcKind);
             }
 
@@ -60,19 +55,21 @@ namespace AllReady.ViewModels
                 {
                     IsUserSignedUpForTask = task.AssignedVolunteers.Any(au => au.User.Id == userId);
                 }
-                this.AssignedVolunteers = new List<TaskSignupViewModel>();
+
+                AssignedVolunteers = new List<TaskSignupViewModel>();
+
                 if (IsUserSignedUpForTask)
                 {                    
                     foreach (var t in task.AssignedVolunteers.Where(au => au.User.Id == userId))
                     {
-                        this.AssignedVolunteers.Add(new TaskSignupViewModel(t));
+                        AssignedVolunteers.Add(new TaskSignupViewModel(t));
                     }
                 }
             }
 
             if (task.RequiredSkills != null)
             {
-                this.RequiredSkills = task.RequiredSkills.Select(t => t.SkillId);
+                RequiredSkills = task.RequiredSkills.Select(t => t.SkillId);
                 RequiredSkillObjects = task.RequiredSkills?.Select(t => t.Skill).ToList();
             }
 
@@ -167,7 +164,7 @@ namespace AllReady.ViewModels
             if (activity == null)
                 return null;
 
-            bool newTask = true;
+            var newTask = true;
             AllReadyTask dbtask;
 
             if (taskViewModel.Id == 0)


### PR DESCRIPTION
Fixes #604

A couple notes:

First, I added an abstraction called `IDetermineIfATaskIsEditable` that is injected into TaskApiController via constructor injection. The implementation is in the `DetermineIfATaskIsEditable` class. The goal here was to encapsulate, the code that previously was in TaskApiController's `private bool HasTaskEditPermissions(AllReadyTask task)` method.

Breaking this out into a separate class allowed me to unit test whether a user has permissions to edit the task or if the AllReadyTask is in an editable state. 

That freed the Post, Put and Delete methods from having to worry about the setup and outcome of this check, as well as I only had to write the unit test for "is editable" once instead of every time I had to write a unit test against any of these three methods in the controller.

Second, as much as I wanted to, I could not remove the injection of IAllReadyDataAccess from TaskApiController's constructor, even moving 100% to mediator.

The reason is this call in the fist line of the Post method:
`task.ToModel(_allReadyDataAccess);`

'ToModel' does a BUNCH of work turning the TaskViewModel into an AllReadyTask, including making database queires via IAllReadyDataAccess. There are also a larege number of other things going on in here, so much so, that I would say someone needs to take a look at this code, and either start to decompose it, or change some of these rules to live somehwere else. I don't know enough about the app to make those calls.

Two good steps would be:
- removing the injected IAllReadyDataAccess
- writing unit tests around this view model class

that could start the ball rolling.