### PR TITLE
Show required Skills

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ActivityDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ActivityDetailQueryHandler.cs
@@ -1,14 +1,14 @@
-﻿using System.Linq;
-using AllReady.Areas.Admin.Models;
+﻿using AllReady.Areas.Admin.Models;
 using AllReady.Models;
 using MediatR;
 using Microsoft.Data.Entity;
+using System.Linq;
 
 namespace AllReady.Areas.Admin.Features.Activities
 {
     public class ActivityDetailQueryHandler : IRequestHandler<ActivityDetailQuery, ActivityDetailModel>
     {
-        private AllReadyContext _context;
+        private readonly AllReadyContext _context;
 
         public ActivityDetailQueryHandler(AllReadyContext context)
         {
@@ -72,7 +72,7 @@ namespace AllReady.Areas.Admin.Features.Activities
                 .AsNoTracking()
                 .Include(a => a.Campaign).ThenInclude(c => c.ManagingOrganization)
                 .Include(a => a.Tasks).ThenInclude(t => t.AssignedVolunteers).ThenInclude(av => av.User)
-                .Include(a => a.RequiredSkills)
+                .Include(a => a.RequiredSkills).ThenInclude(s => s.Skill).ThenInclude(s => s.ParentSkill)
                 .Include(a => a.UsersSignedUp).ThenInclude(a => a.User)
                 .SingleOrDefault(a => a.Id == message.ActivityId);
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskQueryHandlerAsync.cs
@@ -9,7 +9,7 @@ namespace AllReady.Areas.Admin.Features.Tasks
 {
     public class TaskQueryHandlerAsync : IAsyncRequestHandler<TaskQueryAsync, TaskSummaryModel>
     {
-        private AllReadyContext _context;
+        private readonly AllReadyContext _context;
 
         public TaskQueryHandlerAsync(AllReadyContext context)
         {
@@ -34,6 +34,7 @@ namespace AllReady.Areas.Admin.Features.Tasks
                 StartDateTime = task.StartDateTime,
                 EndDateTime = task.EndDateTime,
                 NumberOfVolunteersRequired = task.NumberOfVolunteersRequired,
+                RequiredSkills = task.RequiredSkills,
                 AssignedVolunteers = task.AssignedVolunteers.Select(av => new VolunteerModel { UserId = av.User.Id, UserName = av.User.UserName, HasVolunteered = true }).ToList(),
                 AllVolunteers = task.Activity.UsersSignedUp.Select(v => new VolunteerModel { UserId = v.User.Id, UserName = v.User.UserName, HasVolunteered = false }).ToList()
             };
@@ -53,6 +54,7 @@ namespace AllReady.Areas.Admin.Features.Tasks
                 .Include(t => t.Activity).ThenInclude(a => a.UsersSignedUp).ThenInclude(us => us.User)
                 .Include(t => t.Activity.Campaign)
                 .Include(t => t.AssignedVolunteers).ThenInclude(av => av.User)
+                .Include(s => s.RequiredSkills).ThenInclude(s => s.Skill).ThenInclude(s => s.ParentSkill).ThenInclude(s => s.ParentSkill)
                 .SingleOrDefaultAsync(t => t.Id == message.TaskId);
         }
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/TaskEditModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/TaskEditModel.cs
@@ -1,14 +1,7 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using AllReady.Models;
-
-namespace AllReady.Areas.Admin.Models
+﻿namespace AllReady.Areas.Admin.Models
 {
     public class TaskEditModel : TaskSummaryModel
     {
-        [Display(Name = "Required skills")]
-        public IList<TaskSkill> RequiredSkills { get; set; } = new List<TaskSkill>();
-
         public bool IgnoreTimeRangeWarning { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/TaskSummaryModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/TaskSummaryModel.cs
@@ -1,10 +1,13 @@
-﻿using System;
+﻿using AllReady.Models;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace AllReady.Areas.Admin.Models
 {
+    
+
     public class TaskSummaryModel
     {
         public int Id { get; set; }
@@ -35,6 +38,8 @@ namespace AllReady.Areas.Admin.Models
         public List<VolunteerModel> AssignedVolunteers { get; set; } = new List<VolunteerModel>();
 
         public List<VolunteerModel> AllVolunteers { get; set; } = new List<VolunteerModel>();
+
+        public List<TaskSkill> RequiredSkills { get; set; } = new List<TaskSkill>();
 
         public int AcceptedVolunteerCount => AssignedVolunteers?.Count(v => v.HasVolunteered) ?? 0;
         public int NumberOfVolunteersSignedUp => AssignedVolunteers.Count;

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Activity/Details.cshtml
@@ -19,27 +19,47 @@
     {
         <div data-bind="if: @Model.ImageUrl" class="col-sm-1">
             <h2></h2>
-            <img src="@Model.ImageUrl" class="img-responsive" />
+            <img src="@Model.ImageUrl" class="img-responsive"/>
         </div>
     }
     <div class="col-md-10">
-        <h2>@Model.Name <a asp-controller="Activity" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a> <a asp-controller="Activity" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a></h2>
+        <h2>
+            @Model.Name <a asp-controller="Activity" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a> <a asp-controller="Activity" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>
+        </h2>
         <p>@Model.Description</p>
-        <p><time value="Model.StartDateTime"></time> - <time value="Model.EndDateTime"></time> 
-        <em><time-zone-name time-zone-id="@Model.TimeZoneId"></time-zone-name></em></p>
+        <p><time value="Model.StartDateTime"></time> - <time value="Model.EndDateTime"></time>
+            <em><time-zone-name time-zone-id="@Model.TimeZoneId"></time-zone-name></em>
+        </p>
         @if (!string.IsNullOrEmpty(userTimeZoneId) && Model.TimeZoneId != userTimeZoneId)
-        { 
+        {
             <p>
                 <time value="Model.StartDateTime" target-time-zone-id="@userTimeZoneId"></time> - <time value="Model.EndDateTime" target-time-zone-id="@userTimeZoneId"></time>
                 <em><time-zone-name time-zone-id="@userTimeZoneId"></time-zone-name></em>
             </p>
-        }               
+        }
     </div>
 </div>
+@if (Model.RequiredSkills.Any())
+{
+    <div class="row">
+        <div class="col-md-12">
+            <h3>Required Skills</h3>
+            <ul>
+                @foreach (var requiredSkill in Model.RequiredSkills)
+                {
+                    <li><strong>@requiredSkill.Skill.HierarchicalName</strong></li>
+                }
+            </ul>
+        </div>
+    </div>
+}
 <div class="row">
     <div class="col-md-12">
         <h3>Volunteers @if (Model.NumberOfVolunteersRequired > 0)
-        { <span class="text-muted">(@Model.NumberOfVolunteersRequired Required)</span> } <button type="button" class="btn btn-primary" disabled="@(!Model.Volunteers.Any())" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button></h3>
+                       {
+                           <span class="text-muted">(@Model.NumberOfVolunteersRequired Required)</span>
+                       } <button type="button" class="btn btn-primary" disabled="@(!Model.Volunteers.Any())" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button>
+        </h3>
         @if (Model.Volunteers == null || Model.Volunteers.Count == 0)
         {
             <text>No volunteers yet. </text>
@@ -111,3 +131,4 @@
         });
     </script>
 }
+

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
@@ -36,10 +36,25 @@
             </p>
         }
 
-        <h4>
+        @if (Model.RequiredSkills.Any())
+        {
+            <div class="row">
+                <div class="col-md-12">
+                    <h3>Required Skills</h3>
+                    <ul>
+                        @foreach (var requiredSkill in Model.RequiredSkills)
+                {
+                            <li><strong>@requiredSkill.Skill.HierarchicalName</strong></li>
+                        }
+                    </ul>
+                </div>
+            </div>
+        }
+
+        <h3>
             Volunteers @if (Model.NumberOfVolunteersRequired > 0)
             { <span class="text-muted">(@Model.NumberOfVolunteersRequired Required)</span> }
-        </h4>
+        </h3>
         <ul class="nav nav-tabs">
             <li class="active"><a data-toggle="tab" href="#Assigned">Assigned Volunteers</a> </li>
             <li><a data-toggle="tab" href="#All">All Volunteers</a></li>
@@ -49,7 +64,7 @@
             <div id="Assigned" class="tab-pane fade in active">
                 <h3>Assigned Volunteers</h3>
                 @if (Model.AssignedVolunteers.Any())
-            {
+                {
                     <button type="button" class="btn btn-primary" disabled="@(!Model.AssignedVolunteers.Any())" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button>
                         <table class="table">
                             <tr>
@@ -58,7 +73,7 @@
                                 </th>
                             </tr>
                             @foreach (var volunteer in Model.AssignedVolunteers)
-                {
+                            {
                                 <tr>
                                     <td>@volunteer.UserName</td>
 

--- a/AllReadyApp/Web-App/AllReady/Models/Skill.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Skill.cs
@@ -11,9 +11,12 @@ namespace AllReady.Models
         public int? OwningOrganizationId { get; set; }
         [Display(Name = "Owning organization")]
         public Organization OwningOrganization { get; set; }
+
         public int? ParentSkillId { get; set; }
+
         [Display(Name = "Parent skill")]
         public virtual Skill ParentSkill { get; set; }
+
         public string HierarchicalName
         {
             get

--- a/AllReadyApp/Web-App/AllReady/Models/TaskSkill.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/TaskSkill.cs
@@ -7,6 +7,5 @@
 
         public int SkillId { get; set; }
         public virtual Skill Skill { get; set; }
-
     }
 }


### PR DESCRIPTION
I think it's there or thereabouts now. I've tried to keep the display order consistent between the activity and task details views, so the list of required skills will be shown above the summary of volunteers.

The required skills section will also be hidden if no required skills are set up yet, but that can easily be changed.

The Activity Details View:

![test activity - allready](https://cloud.githubusercontent.com/assets/588607/13951382/85815f58-f028-11e5-8384-7ba25f49c3d3.jpg)

The Task Details View:

![tasks details - allready](https://cloud.githubusercontent.com/assets/588607/13951386/8c999c1a-f028-11e5-82d8-35a7d9fd0a8d.jpg)

I'll squash the commits once everyone's happy with the changes, just to keep the commit history a bit cleaner. This will fix #559