### PR TITLE
Optimize async code for RemoveUserProfileIncompleteClaimCommandHandler and ApplicationUserQueryHandler

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Login/ApplicationUserQueryTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Login/ApplicationUserQueryTests.cs
@@ -1,14 +1,10 @@
-﻿using AllReady.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+﻿using System.Threading.Tasks;
 using AllReady.Features.Login;
+using AllReady.Models;
 using AllReady.UnitTest.Features.Campaigns;
 using Xunit;
 
-namespace AllReady.UnitTest.Login
+namespace AllReady.UnitTest.Features.Login
 {
     public class ApplicationUserQueryTests : InMemoryContextTest
     {

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Login/RemoveUserProfileIncompleteClaimCommandHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Login/RemoveUserProfileIncompleteClaimCommandHandlerTests.cs
@@ -1,15 +1,16 @@
-﻿using AllReady.Models;
-using System.Linq;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Features.Login;
-using Xunit;
-using Microsoft.AspNet.Identity.EntityFramework;
+using AllReady.Models;
 using AllReady.Security;
+using Microsoft.AspNet.Identity.EntityFramework;
+using Xunit;
 using System.Threading.Tasks;
 using AllReady.UnitTest.Features.Campaigns;
 
-namespace AllReady.UnitTest.Login
+namespace AllReady.UnitTest.Features.Login
 {
-    public class RemoveUserIncompleteProfileClaimCommandTests : InMemoryContextTest
+    public class RemoveUserProfileIncompleteClaimCommandHandlerTests : InMemoryContextTest
     {
         private ApplicationUser _user1;
         private ApplicationUser _user2;
@@ -23,16 +24,20 @@ namespace AllReady.UnitTest.Login
             _user2 = new ApplicationUser { UserName = username2, Email = username2, EmailConfirmed = true, NormalizedUserName = username2.ToUpperInvariant() };
             Context.Users.Add(_user1);
             Context.Users.Add(_user2);
-            var claimForUser1 = new IdentityUserClaim<string>();
-            claimForUser1.UserId = _user1.Id;
-            claimForUser1.ClaimType = ClaimTypes.ProfileIncomplete;
-            claimForUser1.ClaimValue = "NewUser";
+            var claimForUser1 = new IdentityUserClaim<string>
+            {
+                UserId = _user1.Id,
+                ClaimType = ClaimTypes.ProfileIncomplete,
+                ClaimValue = "NewUser"
+            };
             Context.UserClaims.Add(claimForUser1);
 
-            var claimForUser2 = new IdentityUserClaim<string>();
-            claimForUser2.UserId = _user2.Id;
-            claimForUser2.ClaimType = "SomeOtherClaim";
-            claimForUser2.ClaimValue = "Blah";
+            var claimForUser2 = new IdentityUserClaim<string>
+            {
+                UserId = _user2.Id,
+                ClaimType = "SomeOtherClaim",
+                ClaimValue = "Blah"
+            };
             Context.UserClaims.Add(claimForUser2);
 
             Context.SaveChanges();
@@ -59,7 +64,6 @@ namespace AllReady.UnitTest.Login
 
             var matchingClaimForUser2 = Context.UserClaims.Where(u => u.UserId == _user2.Id && u.ClaimType == "SomeOtherClaim");
             Assert.Single(matchingClaimForUser2);
-
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Login/RemoveUserProfileIncompleteClaimCommandHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Login/RemoveUserProfileIncompleteClaimCommandHandlerTests.cs
@@ -5,8 +5,6 @@ using AllReady.Models;
 using AllReady.Security;
 using Microsoft.AspNet.Identity.EntityFramework;
 using Xunit;
-using System.Threading.Tasks;
-using AllReady.UnitTest.Features.Campaigns;
 
 namespace AllReady.UnitTest.Features.Login
 {

--- a/AllReadyApp/Web-App/AllReady/Features/Login/ApplicationUserQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Login/ApplicationUserQueryHandler.cs
@@ -21,7 +21,8 @@ namespace AllReady.Features.Login
                 .AsNoTracking()
                 .Include(a => a.Claims)
                 .Include(a => a.Roles)
-                .SingleOrDefaultAsync(a => a.NormalizedUserName == normalizedUserName);
+                .SingleOrDefaultAsync(a => a.NormalizedUserName == normalizedUserName)
+                .ConfigureAwait(false);
              return user;
         }
     }

--- a/AllReadyApp/Web-App/AllReady/Features/Login/RemoveUserProfileIncompleteClaimCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Login/RemoveUserProfileIncompleteClaimCommandHandler.cs
@@ -14,14 +14,14 @@ namespace AllReady.Features.Login
             _context = context;
         }
 
-        protected async override System.Threading.Tasks.Task HandleCore(RemoveUserProfileIncompleteClaimCommand message)
+        protected override async Task HandleCore(RemoveUserProfileIncompleteClaimCommand message)
         {
             //Going directly to the database here to remove the claim instead of using the UserManager because the user isn't always logged in (eg. when confirming email address)
-            var existingClaim = await _context.UserClaims.SingleOrDefaultAsync(u => u.UserId == message.UserId && u.ClaimType == Security.ClaimTypes.ProfileIncomplete);
+            var existingClaim = await _context.UserClaims.SingleOrDefaultAsync(u => u.UserId == message.UserId && u.ClaimType == Security.ClaimTypes.ProfileIncomplete).ConfigureAwait(false);
             if (existingClaim != null)
             {
                 _context.Remove(existingClaim);
-                await _context.SaveChangesAsync();
+                await _context.SaveChangesAsync().ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Fixes #651

- Optimize async code for RemoveUserProfileIncompleteClaimCommandHandler and ApplicationUserQueryHandler
- rename tests after what they're testing
- align unit test namespaces/folders for both tests and hanlders