### PR TITLE
ActivityAdminController refactoring

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ActivityAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ActivityAdminControllerTests.cs
@@ -533,12 +533,10 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         private static ActivityController GetActivityController(DateTimeOffset startDate, DateTimeOffset endDate)
         {
             var mediator = new Mock<IMediator>();
-            //var dataAccess = new Mock<IAllReadyDataAccess>();
             var imageService = new Mock<IImageService>();
 
             mediator.Setup(x => x.SendAsync(It.IsAny<CampaignSummaryQuery>())).ReturnsAsync(new CampaignSummaryModel { StartDate = startDate, EndDate = endDate });
 
-            //var sut = new ActivityController(dataAccess.Object, imageService.Object, mediator.Object);
             var sut = new ActivityController(imageService.Object, mediator.Object);
             sut.SetClaims(new List<Claim>
             {

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ActivityAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ActivityAdminControllerTests.cs
@@ -13,13 +13,103 @@ using MediatR;
 using Microsoft.AspNet.Mvc;
 using Moq;
 using Xunit;
+using System.Linq;
+using Microsoft.AspNet.Authorization;
 
 namespace AllReady.UnitTest.Areas.Admin.Controllers
 {
     public class ActivityAdminControllerTests
     {
+        //delete this line when all unit tests using it have been completed
+        private static readonly Task<int> TaskFromResultZero = Task.FromResult(0);
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DetailsSendsActivityDetailQueryAsyncWithCorrectActivityId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DetailsReturnsHttpNotFoundResultWhenActivityIsNull()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DetailsReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DetailsReturnsHttpUnauthorizedResultWhenActivityIsNotNullAndUserIsNotAnOrgAdmin()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DetailsReturnsCorrectViewModelWhenActivityIsNotNullAndUserIsOrgAdmin()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
         [Fact]
-        public async Task CreateReturnsEditView_When_ModelStateNotValid()
+        public void DetailsHasHttpGetAttribute()
+        {
+            var sut = new ActivityController(null, null);
+            var attribute = sut.GetAttributesOn(x => x.Details(It.IsAny<int>())).OfType<HttpGetAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void DetailsHasRouteAttributeWithCorrectRoute()
+        {
+            var sut = new ActivityController(null, null);
+            var routeAttribute = sut.GetAttributesOn(x => x.Details(It.IsAny<int>())).OfType<RouteAttribute>().SingleOrDefault();
+            Assert.NotNull(routeAttribute);
+            Assert.Equal(routeAttribute.Template, "Admin/Activity/Details/{id}");
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task CreateGetSendsCampaignSummaryQueryAsyncWithCorrectCampaignId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task CreateGetReturnsHttpUnauthorizedResultWhenCampaignIsNull()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task CreateGetReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task CreateGetReturnsCorrectViewAndViewModel()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void CreateGetHasRouteAttributeWithCorrectRoute()
+        {
+        }
+
+        [Fact]
+        public async Task CreatePostReturnsEditView_When_ModelStateNotValid()
         {
             var sut = GetActivityController();
             sut.ModelState.AddModelError("test", "test");
@@ -30,7 +120,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task CreateReturnsEditView_When_ActivityEndDateBeforeStartDate()
+        public async Task CreatePostReturnsEditView_When_ActivityEndDateBeforeStartDate()
         {
             var campaignStartDate = new DateTimeOffset(new DateTime(1900, 1, 1));
             var campaignEndDate = campaignStartDate.AddDays(4);
@@ -50,7 +140,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task CreateReturnsEditView_When_ActivityStartDateBeforeCampaignStartDate()
+        public async Task CreatePostReturnsEditView_When_ActivityStartDateBeforeCampaignStartDate()
         {
             var campaignStartDate = new DateTimeOffset(new DateTime(1900, 1, 1));
             var campaignEndDate = campaignStartDate.AddDays(4);
@@ -69,7 +159,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             Assert.Equal("Start date cannot be earlier than the campaign start date " + campaignStartDate.ToString("d"), errors[0]);
         }
         [Fact]
-        public async Task CreateReturnsEditView_When_ActivityEndDateAfterCampaignEndDate()
+        public async Task CreatePostReturnsEditView_When_ActivityEndDateAfterCampaignEndDate()
         {
             var campaignStartDate = new DateTimeOffset(new DateTime(1900, 1, 1));
             var campaignEndDate = campaignStartDate.AddDays(4);
@@ -94,7 +184,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         /// </summary>
         /// <returns></returns>
         //[Fact]
-        //public async Task CreateReturnsEditView_When_ModelStateNotValid_And_ImageIsNotNull()
+        //public async Task CreatePostReturnsEditView_When_ModelStateNotValid_And_ImageIsNotNull()
         //{
         //    var sut = GetActivityController();
         //    var activityModel = new ActivityDetailModel();
@@ -104,6 +194,337 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         //    Assert.Equal("Edit", result.ViewName);
         //}
 
+        [Fact(Skip = "NotImplemented")]
+        public void CreatePostHasHttpPostAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void CreatePostHasValidateAntiForgeryTokenAttrbiute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void CreatePostHasRouteAttrbiuteWithCorrectRoute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void EditGetSendsActivityDetailQueryAsyncWithCorrectActivityId()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void EditGetReturnsHttpNotFoundResultWhenActivityIsNull()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void EditGetReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void EditGetReturnsCorrectViewModel()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostReturnsBadRequestResultWhenActivityIsNull()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostSendsManagingOrganizationIdByActivityIdQueryWithCorrectActivityId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdminUser()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostSendsCampaignSummaryQueryAsyncWithTheCorrectCampaignId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostAddsValidationErrorsToModelStateErrorsWhenValidationFails()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostInvokesUploadActivityImageAsyncWithTheCorrectParametersWhenModelStateIsValidAndFileUploadIsNotNullAndFileUploadIsAnAcceptableImageContentType()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostAddsCorrectKeyAndValueToModelStateErrorsWhenModelStateIsValidAndFileUploadIsNotNullAndFileUploadIsNotAnAcceptableImageContentType()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostReturnsCorrectViewModelWhenModelStateIsValidAndFileUploadIsNotNullAndFileUploadIsNotAnAcceptableImageContentType()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostSendsEditActivityCommandAsyncWithCorrectActivityWhenModelStateIsValid()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostRedirectsToCorrectActionAndControllerWithCorrectRouteValuesWhenModelStateIsValid()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task EditPostReturnsCorrectViewModelWhenModelStateIsNotValid()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void EditPostHasHttpPostAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void EditPostHasValidateAntiForgeryTokenAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteSendsActivityDetailQueryAsyncWithCorrectActivityId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteReturnsHttpNotFoundResultWhenActivityIsNull()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteReturnsCorrectViewModel()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void DeleteHasActionNameAttributeWithCorrectName()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteConfirmedSendsActivityDetailQueryAsyncWithCorrectActivityId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteConfirmedReturnsHttpNotFoundResultWhenActivityIsNull()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteConfirmedReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteConfirmedSendsDeleteActivityCommandAsyncWithCorrectActivityId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task DeleteConfirmedRedirectToCorrectActionAndControllerWithCorrectRouteValues()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void DeleteConfirmedHasHttpPostAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void DeleteConfirmedHasActionNameAttributeWithCorrectName()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void DeleteConfirmedHasValidateAntiForgeryTokenAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void AssignSendsActivityByActivityIdQueryWithCorrectActivityId()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void AssignReturnsHttpNotFoundResultWhenActivityIsNull()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void AssignReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void AssignReturnsCorrectViewModel()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void AssignHasHttpGetAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task MessageAllVolunteersReturnsBadRequestObjectResultWhenModelStateIsInvalid()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task MessageAllVolunteersSendsActivityDetailQueryAsyncWithCorrectActivityId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task MessageAllVolunteersReturnsHttpNotFoundResultWhenActivityIsNull()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task MessageAllVolunteersReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task MessageAllVolunteersSendsMessageActivityVolunteersCommandAsyncWithCorrectData()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task MessageAllVolunteersReturnsHttpOkResult()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void MessageAllVolunteersHasHttpPostAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void MessageAllVolunteersHasValidateAntiForgeryTokenAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task PostActivityFileSendsActivityByActivityIdQueryWithCorrectActivityId()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task PostActivityFileSendsUpdateActivityAsyncWithCorrectData()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task PostActivityFileRedirectsToCorrectRoute()
+        {
+            // delete this line when starting work on this unit test
+            await TaskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void PostActivityFileHasHttpPostAttribute()
+        {
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public void PostActivityFileHasValidateAntiForgeryTokenAttribute()
+        {
+        }
+
+        [Fact]
+        public void ControllerHasAreaAtttributeWithTheCorrectAreaName()
+        {
+            var sut = new ActivityController(null, null);
+            var attribute = sut.GetAttributes().OfType<AreaAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.RouteValue, "Admin");
+        }
+
+        [Fact]
+        public void ControllerHasAreaAuthorizeAttributeWithCorrectPolicy()
+        {
+            var sut = new ActivityController(null, null);
+            var attribute = sut.GetAttributes().OfType<AuthorizeAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Policy, "OrgAdmin");
+        }
+
         private static ActivityController GetActivityController()
         {
             return GetActivityController(new DateTimeOffset(), new DateTimeOffset());
@@ -112,12 +533,13 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         private static ActivityController GetActivityController(DateTimeOffset startDate, DateTimeOffset endDate)
         {
             var mediator = new Mock<IMediator>();
-            var dataAccess = new Mock<IAllReadyDataAccess>();
+            //var dataAccess = new Mock<IAllReadyDataAccess>();
             var imageService = new Mock<IImageService>();
 
             mediator.Setup(x => x.SendAsync(It.IsAny<CampaignSummaryQuery>())).ReturnsAsync(new CampaignSummaryModel { StartDate = startDate, EndDate = endDate });
 
-            var sut = new ActivityController(dataAccess.Object, imageService.Object, mediator.Object);
+            //var sut = new ActivityController(dataAccess.Object, imageService.Object, mediator.Object);
+            var sut = new ActivityController(imageService.Object, mediator.Object);
             sut.SetClaims(new List<Claim>
             {
                 new Claim(AllReady.Security.ClaimTypes.UserType, UserType.SiteAdmin.ToString()),

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/OrganizationApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/OrganizationApiControllerTests.cs
@@ -76,7 +76,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public void ControllerHasAreaAtttributeWithTheCorrectRouteValue()
+        public void ControllerHasAreaAtttributeWithTheCorrectAreaName()
         {
             var sut = new OrganizationApiController(null);
             var attribute = sut.GetAttributes().OfType<AreaAttribute>().SingleOrDefault();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/ActivityDetailQueryHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/ActivityDetailQueryHandlerTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Activities;
 using AllReady.Models;
-using AllReady.UnitTest.Features.Campaigns;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
@@ -14,8 +14,8 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
         {
             var context = ServiceProvider.GetService<AllReadyContext>();
 
-            PostalCodeGeo seattlePostalCode = new PostalCodeGeo() { City = "Seattle", PostalCode = "98117", State = "WA" };
-            Location seattle = new Location()
+            var seattlePostalCode = new PostalCodeGeo { City = "Seattle", PostalCode = "98117", State = "WA" };
+            var seattle = new Location
             {
                 Id = 1,
                 Address1 = "123 Main Street",
@@ -29,7 +29,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
             };
          
 
-            Organization htb = new Organization()
+            var htb = new Organization
             {
                 Name = "Humanitarian Toolbox",
                 LogoUrl = "http://www.htbox.org/upload/home/ht-hero.png",
@@ -55,6 +55,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
                 Location = new Location { Id = 1 },
                 RequiredSkills = new List<ActivitySkill>()
             };
+
             context.PostalCodes.Add(seattlePostalCode);
             context.Locations.Add(seattle);
             context.Organizations.Add(htb);
@@ -63,32 +64,33 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
         }
 
         [Fact]
-        public void ActivityExists()
+        public async Task ActivityExists()
         {
             var context = ServiceProvider.GetService<AllReadyContext>();
             var query = new ActivityDetailQuery { ActivityId = 1 };
             var handler = new ActivityDetailQueryHandler(context);
-            var result = handler.Handle(query);
+            var result = await handler.Handle(query);
             Assert.NotNull(result);
         }
 
         [Fact]
-        public void ActivityDoesNotExist()
+        public async Task ActivityDoesNotExist()
         {
             var context = ServiceProvider.GetService<AllReadyContext>();
             var query = new ActivityDetailQuery();
             var handler = new ActivityDetailQueryHandler(context);
-            var result = handler.Handle(query);
+            var result = await handler.Handle(query);
             Assert.Null(result);
         }
 
         [Fact]
-        public void ActivityIncludesAllLocationInformation()
+        public async Task ActivityIncludesAllLocationInformation()
         {
             var context = ServiceProvider.GetService<AllReadyContext>();
-            var query = new ActivityDetailQuery() { ActivityId = 1 };
+            var query = new ActivityDetailQuery { ActivityId = 1 };
             var handler = new ActivityDetailQueryHandler(context);
-            var result = handler.Handle(query);
+            var result = await handler.Handle(query);
+
             Assert.NotNull(result.Location);
             Assert.NotNull(result.Location?.Id);
             Assert.NotNull(result.Location?.Address1);
@@ -99,7 +101,5 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
             Assert.NotNull(result.Location?.PhoneNumber);
             Assert.NotNull(result.Location?.Country);
         }
-
-
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/EditActivity.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/EditActivity.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Activities;
 using AllReady.Areas.Admin.Models;
 using AllReady.Models;
@@ -12,7 +13,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
     public class EditActivity : TestBase
     {
         [Fact]
-        public void ActivityDoesNotExist()
+        public async Task ActivityDoesNotExist()
         {
             var context = ServiceProvider.GetService<AllReadyContext>();
 
@@ -45,7 +46,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
 
             var query = new EditActivityCommand { Activity = vm };
             var handler = new EditActivityCommandHandler(context);
-            var result = handler.Handle(query);
+            var result = await handler.Handle(query);
             Assert.True(result > 0);
 
             var data = context.Activities.Count(_ => _.Id == result);
@@ -53,7 +54,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
         }
 
         [Fact]
-        public void ExistingActivity()
+        public async Task ExistingActivity()
         {
             var context = ServiceProvider.GetService<AllReadyContext>();
 
@@ -114,7 +115,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
             };
             var query = new EditActivityCommand { Activity = vm };
             var handler = new EditActivityCommandHandler(context);
-            var result = handler.Handle(query);
+            var result = await handler.Handle(query);
             Assert.Equal(100, result); // should get back the activity id
 
             var data = context.Activities.Single(_ => _.Id == result);
@@ -136,10 +137,11 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
         }
 
         [Fact]
-        public void ExistingActivityUpdateLocation()
+        public async Task ExistingActivityUpdateLocation()
         {
-            PostalCodeGeo seattlePostalCode = new PostalCodeGeo() { City = "Seattle", PostalCode = "98117", State = "WA" };
-            Location seattle = new Location()
+            var seattlePostalCode = new PostalCodeGeo { City = "Seattle", PostalCode = "98117", State = "WA" };
+
+            var seattle = new Location
             {
                 Id = 1,
                 Address1 = "123 Main Street",
@@ -153,7 +155,8 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
             };
 
             var context = ServiceProvider.GetService<AllReadyContext>();
-            Organization htb = new Organization()
+
+            var htb = new Organization
             {
                 Id = 123,
                 Name = "Humanitarian Toolbox",
@@ -161,7 +164,8 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
                 WebUrl = "http://www.htbox.org",
                 Campaigns = new List<Campaign>()
             };
-            Campaign firePrev = new Campaign()
+
+            var firePrev = new Campaign
             {
                 Id = 1,
                 Name = "Neighborhood Fire Prevention Days",
@@ -169,7 +173,8 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
                 TimeZoneId = "Central Standard Time"
             };
             htb.Campaigns.Add(firePrev);
-            Activity queenAnne = new Activity()
+
+            var queenAnne = new Activity
             {
                 Id = 100,
                 Name = "Queen Anne Fire Prevention Day",
@@ -185,11 +190,11 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
             context.Activities.Add(queenAnne);
             context.SaveChanges();
 
-            var NEW_LOCATION = LocationExtensions.ToEditModel(new Location()
+            var NEW_LOCATION = LocationExtensions.ToEditModel(new Location
             {
                 Address1 = "123 new address",
                 Address2 = "new suite",
-                PostalCode = new PostalCodeGeo() { City = "Bellevue", PostalCode = "98004", State = "WA" },
+                PostalCode = new PostalCodeGeo { City = "Bellevue", PostalCode = "98004", State = "WA" },
                 City = "Bellevue",
                 State = "WA",
                 Country = "USA",
@@ -218,7 +223,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
 
             var query = new EditActivityCommand { Activity = locationEdit };
             var handler = new EditActivityCommandHandler(context);
-            var result = handler.Handle(query);
+            var result = await handler.Handle(query);
             Assert.Equal(100, result); // should get back the activity id
 
             var data = context.Activities.Single(a => a.Id == result);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/EditingActivity.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/EditingActivity.cs
@@ -1,7 +1,7 @@
+using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Activities;
 using AllReady.Areas.Admin.Models;
 using AllReady.Models;
-using AllReady.UnitTest.Features.Campaigns;
 using Xunit;
 
 namespace AllReady.UnitTest.Areas.Admin.Features.Activities
@@ -17,10 +17,10 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Activities
         }
 
         [Fact]
-        public void ModelIsCreated()
+        public async Task ModelIsCreated()
         {
             var sut = new EditActivityCommandHandler(Context);
-            var actual = sut.Handle(new EditActivityCommand {Activity = new ActivityDetailModel {CampaignId = 1, Id = 1, TimeZoneId = "Central Standard Time"}});
+            var actual = await sut.Handle(new EditActivityCommand {Activity = new ActivityDetailModel {CampaignId = 1, Id = 1, TimeZoneId = "Central Standard Time"}});
             Assert.Equal(1, actual);
         }
     }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/ManagingOrganizationIdByActivityIdQueryHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/ManagingOrganizationIdByActivityIdQueryHandlerTests.cs
@@ -1,0 +1,21 @@
+﻿using AllReady.Areas.Admin.Features.Activities;
+using AllReady.Models;
+using Moq;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.Activities
+{
+    public class ManagingOrganizationIdByActivityIdQueryHandlerTests
+    {
+        [Fact]
+        public void ManagingOrganizationIdByActivityIdQueryHandlerInvokesGetManagingOrganizationIdWithCorrectActivityId()
+        {
+            var message = new ManagingOrganizationIdByActivityIdQuery { ActivityId = 1 };
+            var dataAccess = new Mock<IAllReadyDataAccess>();
+            var sut = new ManagingOrganizationIdByActivityIdQueryHandler(dataAccess.Object);
+            sut.Handle(message);
+
+            dataAccess.Verify(x => x.GetManagingOrganizationId(message.ActivityId), Times.Once);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/UpdateActivityHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Activities/UpdateActivityHandlerTests.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.Activities;
+using AllReady.Models;
+using Moq;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.Activities
+{
+    public class UpdateActivityHandlerTests
+    {
+        [Fact]
+        public async Task UpdateActivityHandlerInvokesUpdateActivityWithCorrectActivity()
+        {
+            var message = new UpdateActivity { Activity = new Activity() };
+            var dataAccess = new Mock<IAllReadyDataAccess>();
+            var sut = new UpdateActivityHandler(dataAccess.Object);
+            await sut.Handle(message);
+
+            dataAccess.Verify(x => x.UpdateActivity(message.Activity), Times.Once);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ActivityDetailQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ActivityDetailQuery.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Activities
 {
-    public class ActivityDetailQuery : IRequest<ActivityDetailModel>
+    public class ActivityDetailQuery : IAsyncRequest<ActivityDetailModel>
     {
         public int ActivityId { get; set; }
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/DeleteActivityCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/DeleteActivityCommand.cs
@@ -2,7 +2,7 @@
 
 namespace AllReady.Areas.Admin.Features.Activities
 {
-    public class DeleteActivityCommand : IRequest
+    public class DeleteActivityCommand : IAsyncRequest
     {
         public int ActivityId {get; set;}
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/DeleteActivityCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/DeleteActivityCommandHandler.cs
@@ -1,10 +1,11 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Models;
 using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Activities
 {
-    public class DeleteActivityCommandHandler : RequestHandler<DeleteActivityCommand>
+    public class DeleteActivityCommandHandler : AsyncRequestHandler<DeleteActivityCommand>
     {
         private AllReadyContext _context;
 
@@ -13,15 +14,14 @@ namespace AllReady.Areas.Admin.Features.Activities
             _context = context;
 
         }
-        protected override void HandleCore(DeleteActivityCommand message)
-        {
-            var activity = 
-                _context.Activities.SingleOrDefault(c => c.Id == message.ActivityId);
 
+        protected override async Task HandleCore(DeleteActivityCommand message)
+        {
+            var activity =  _context.Activities.SingleOrDefault(c => c.Id == message.ActivityId);
             if (activity != null)
             {
                 _context.Activities.Remove(activity);
-                _context.SaveChanges();
+                await _context.SaveChangesAsync().ConfigureAwait(false);
             }
         }
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/EditActivityCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/EditActivityCommand.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Activities
 {
-    public class EditActivityCommand : IRequest<int>
+    public class EditActivityCommand : IAsyncRequest<int>
     {
         public ActivityDetailModel Activity {get; set;}
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ManagingOrganizationIdByActivityIdQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ManagingOrganizationIdByActivityIdQuery.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Activities
+{
+    public class ManagingOrganizationIdByActivityIdQuery : IRequest<int>
+    {
+        public int ActivityId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ManagingOrganizationIdByActivityIdQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/ManagingOrganizationIdByActivityIdQueryHandler.cs
@@ -1,0 +1,20 @@
+﻿using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Activities
+{
+    public class ManagingOrganizationIdByActivityIdQueryHandler : IRequestHandler<ManagingOrganizationIdByActivityIdQuery, int>
+    {
+        private readonly IAllReadyDataAccess dataAccess;
+
+        public ManagingOrganizationIdByActivityIdQueryHandler(IAllReadyDataAccess dataAccess)
+        {
+            this.dataAccess = dataAccess;
+        }
+
+        public int Handle(ManagingOrganizationIdByActivityIdQuery message)
+        {
+            return dataAccess.GetManagingOrganizationId(message.ActivityId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/UpdateActivity.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/UpdateActivity.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Activities
+{
+    public class UpdateActivity : IAsyncRequest
+    {
+        public Activity Activity { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/UpdateActivityHanadler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/UpdateActivityHanadler.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Activities
+{
+    public class UpdateActivityHanadler : AsyncRequestHandler<UpdateActivity>
+    {
+        private readonly IAllReadyDataAccess dataAccess;
+
+        public UpdateActivityHanadler(IAllReadyDataAccess dataAccess)
+        {
+            this.dataAccess = dataAccess;
+        }
+
+        protected override async Task HandleCore(UpdateActivity message)
+        {
+            await dataAccess.UpdateActivity(message.Activity).ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/UpdateActivityHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Activities/UpdateActivityHandler.cs
@@ -4,11 +4,11 @@ using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Activities
 {
-    public class UpdateActivityHanadler : AsyncRequestHandler<UpdateActivity>
+    public class UpdateActivityHandler : AsyncRequestHandler<UpdateActivity>
     {
         private readonly IAllReadyDataAccess dataAccess;
 
-        public UpdateActivityHanadler(IAllReadyDataAccess dataAccess)
+        public UpdateActivityHandler(IAllReadyDataAccess dataAccess)
         {
             this.dataAccess = dataAccess;
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CampaignSummaryQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CampaignSummaryQueryHandler.cs
@@ -16,6 +16,7 @@ namespace AllReady.Areas.Admin.Features.Campaigns
             _context = context;
 
         }
+
         public async Task<CampaignSummaryModel> Handle(CampaignSummaryQuery message)
         {
             CampaignSummaryModel result = null;

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/LocationExtensions.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/LocationExtensions.cs
@@ -6,7 +6,11 @@ namespace AllReady.Areas.Admin.Models
     {
         public static LocationDisplayModel ToModel(this Location location)
         {
-            if (location == null) { return new LocationDisplayModel(); }
+            if (location == null)
+            {
+                return new LocationDisplayModel();
+            }
+
             return new LocationDisplayModel
             {
                 Id = location.Id,
@@ -24,7 +28,11 @@ namespace AllReady.Areas.Admin.Models
         public static LocationEditModel ToEditModel(this Location location)
         {
             //TODO: Do I want to keep LocationEditModel and LocationDisplayModel ??
-            if (location == null) { return new LocationEditModel(); }
+            if (location == null)
+            {
+                return new LocationEditModel();
+            }
+
             return new LocationEditModel
             {
                 Id = location.Id,
@@ -38,7 +46,6 @@ namespace AllReady.Areas.Admin.Models
                 State = location.State
             };            
         }
-
 
         public static Location UpdateModel(this Location location, LocationEditModel locationEditModel)
         {

--- a/AllReadyApp/Web-App/AllReady/Extensions/FormFileExtensions.cs
+++ b/AllReadyApp/Web-App/AllReady/Extensions/FormFileExtensions.cs
@@ -14,7 +14,7 @@ namespace AllReady.Extensions
         /// <returns></returns>
         public static bool IsAcceptableImageContentType(this IFormFile file)
         {
-            bool isImageContentType = false;
+            var isImageContentType = false;
             var contentType = file.ContentType.ToLowerInvariant();
 
             if (contentType == "image/png" ||


### PR DESCRIPTION
Fixes #666

- stubbed out remaining unit tests
- refactored ActivityDetailQueryHandler to async
- refactored EditActivityCommandHAndler to async
- refactored DeleteActivityCommandHandler to async
- replaced _dataAccess.GetActivity invocations with _mediator.Send(new ActivityByActivityIdQuery
- replaced _dataAccess.UpdateActivity(activity); with new created UpdateActivity/Handler
- replaced _dataAccess.GetManagingOrganizationId(activity.Id); with newly created ManagingOrganizationIdByActivityIdQueryHandler
- removed IAllReadyDataAccess dependency from ActivityAdminController