### PR TITLE
Refactoring IEmailSender out of SiteAdminController

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -18,18 +18,24 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact(Skip = "NotImplemented")]
-        public void DeleteUserSendsUserQueryWithCorrectUserId()
+        public async Task DeleteUserSendsUserQueryWithCorrectUserId()
         {
+            //delete this line when starting work on this unit test
+            await TaskFromResultZero;
         }
 
         [Fact(Skip = "NotImplemented")]
-        public void DeleteUserReturnsTheCorrectViewModel()
+        public async Task DeleteUserReturnsTheCorrectViewModel()
         {
+            //delete this line when starting work on this unit test
+            await TaskFromResultZero;
         }
 
         [Fact(Skip = "NotImplemented")]
-        public void DeleteUserHasHttpGetAttribute()
+        public async Task DeleteUserHasHttpGetAttribute()
         {
+            //delete this line when starting work on this unit test
+            await TaskFromResultZero;
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -36,7 +36,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         public async Task ConfirmDeletUserSendsDeleteUserCommandAsync()
         {
             var mediator = new Mock<IMediator>();
-            var controller = new SiteController(null, null, null, null, mediator.Object);
+            var controller = new SiteController(null, null, null, mediator.Object);
             const string userId = "foo_id";
 
             await controller.ConfirmDeleteUser(userId);
@@ -116,7 +116,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact(Skip = "NotImplemented")]
-        public async Task EditUserPostInvokesSendEmailAsyncWithCorrectParametersWhenModelsIsOrganizationAdminIsTrueAndOrganizationAdminClaimWasAddedSuccessfully()
+        public async Task EditUserPostSendsSendAccountApprovalEmailWithCorrectDataWhenModelsIsOrganizationAdminIsTrueAndOrganizationAdminClaimWasAddedSuccessfully()
         {
             //delete this line when starting work on this unit test
             await TaskFromResultZero;
@@ -188,8 +188,15 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             await TaskFromResultZero;
         }
 
+        //[Fact(Skip = "NotImplemented")]
+        //public async Task ResetPasswordInvokesSendEmailAsyncWithCorrectParametersWhenUserIsNotNull()
+        //{
+        //    //delete this line when starting work on this unit test
+        //    await TaskFromResultZero;
+        //}
+
         [Fact(Skip = "NotImplemented")]
-        public async Task ResetPasswordInvokesSendEmailAsyncWithCorrectParametersWhenUserIsNotNull()
+        public async Task ResetPasswordSendsSendResetPasswordEmailWithCorrectDataWhenUserIsNotNull()
         {
             //delete this line when starting work on this unit test
             await TaskFromResultZero;

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -188,13 +188,6 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             await TaskFromResultZero;
         }
 
-        //[Fact(Skip = "NotImplemented")]
-        //public async Task ResetPasswordInvokesSendEmailAsyncWithCorrectParametersWhenUserIsNotNull()
-        //{
-        //    //delete this line when starting work on this unit test
-        //    await TaskFromResultZero;
-        //}
-
         [Fact(Skip = "NotImplemented")]
         public async Task ResetPasswordSendsSendResetPasswordEmailWithCorrectDataWhenUserIsNotNull()
         {

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Site/SendAccountApprovalEmailHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Site/SendAccountApprovalEmailHandlerShould.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.Site;
+using AllReady.Services;
+using Moq;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.Site
+{
+    public class SendAccountApprovalEmailHandlerShould
+    {
+        [Fact]
+        public async Task InvokeSendEmailAsyncWithTheCorrectParameters()
+        {
+            var message = new SendAccountApprovalEmail { Email = "email", CallbackUrl = "callBackUrl" };
+            var emailMessage = $"Your account has been approved by an administrator. Please <a href=\"{message.CallbackUrl}\">Click here to Log in</a>";
+
+            var emailSender = new Mock<IEmailSender>();
+            var sut = new SendAccountApprovalEmailHandler(emailSender.Object);
+            await sut.Handle(message);
+
+            emailSender.Verify(x => x.SendEmailAsync(message.Email, "Account Approval", emailMessage), Times.Once);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Site/SendResetPasswordEmailHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Site/SendResetPasswordEmailHandlerShould.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.Site;
+using AllReady.Services;
+using Moq;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.Site
+{
+    public class SendResetPasswordEmailHandlerShould
+    {
+        [Fact]
+        public async Task InvokeSendEmailAsyncWithTheCorrectParameters()
+        {
+            var message = new SendResetPasswordEmail { Email = "email", CallbackUrl = "callBackUrl" };
+            var emailMessage = $"Please reset your password by clicking here: <a href=\"{message.CallbackUrl}\">link</a>";
+
+            var emailSender = new Mock<IEmailSender>();
+            var sut = new SendResetPasswordEmailHandler(emailSender.Object);
+            await sut.Handle(message);
+
+            emailSender.Verify(x => x.SendEmailAsync(message.Email, "Reset Password", emailMessage), Times.Once);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -45,15 +45,15 @@ namespace AllReady.Areas.Admin.Controllers
         }
 
         [HttpGet]
-        public IActionResult DeleteUser(string userId)
+        public async Task<IActionResult> DeleteUser(string userId)
         {
-            var user = _mediator.Send(new UserQuery { UserId = userId });
-
+            var user = await _mediator.SendAsync(new UserQuery { UserId = userId });
             var viewModel = new DeleteUserModel
             {
                 UserId = userId,
                 UserName = user.UserName,
             };
+
             return View(viewModel);
         }
 
@@ -93,7 +93,7 @@ namespace AllReady.Areas.Admin.Controllers
             }
 
             //Skill associations
-            var user = _dataAccess.GetUser(viewModel.UserId);
+            var user = GetUser(viewModel.UserId);
             user.AssociatedSkills.RemoveAll(usk => viewModel.AssociatedSkills == null || !viewModel.AssociatedSkills.Any(msk => msk.SkillId == usk.SkillId));
 
             if (viewModel.AssociatedSkills != null)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -150,7 +150,6 @@ namespace AllReady.Areas.Admin.Controllers
                     return View();
                 }
 
-                // Send an email with this link
                 var code = await _userManager.GeneratePasswordResetTokenAsync(user);
                 //mgmccarthy: there is no ResetPassword action methd on the AdminController. Not too sure what to do here.
                 var callbackUrl = Url.Action(new UrlActionContext { Action = "ResetPassword", Controller = "Admin", Values = new { userId = user.Id, code = code }, Protocol = HttpContext.Request.Scheme });

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -24,7 +24,7 @@ namespace AllReady.Areas.Admin.Controllers
     {
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly IAllReadyDataAccess _dataAccess;
-        private ILogger<SiteController> _logger;
+        private readonly ILogger<SiteController> _logger;
         private readonly IMediator _mediator;
 
         public SiteController(UserManager<ApplicationUser> userManager, IAllReadyDataAccess dataAccess, ILogger<SiteController> logger, IMediator mediator)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -146,7 +146,7 @@ namespace AllReady.Areas.Admin.Controllers
                 var user = GetUser(userId);
                 if (user == null)
                 {
-                    ViewBag.ErrorMessage = $"User not found.";
+                    ViewBag.ErrorMessage = "User not found.";
                     return View();
                 }
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -37,7 +37,7 @@ namespace AllReady.Areas.Admin.Controllers
 
         public IActionResult Index()
         {
-            var viewModel = new SiteAdminModel()
+            var viewModel = new SiteAdminModel
             {
                 Users = _dataAccess.Users.OrderBy(u => u.UserName).ToList()
             };
@@ -49,7 +49,7 @@ namespace AllReady.Areas.Admin.Controllers
         {
             var user = _mediator.Send(new UserQuery { UserId = userId });
 
-            var viewModel = new DeleteUserModel()
+            var viewModel = new DeleteUserModel
             {
                 UserId = userId,
                 UserName = user.UserName,
@@ -67,7 +67,7 @@ namespace AllReady.Areas.Admin.Controllers
 
         public IActionResult EditUser(string userId)
         {
-            var user = _dataAccess.GetUser(userId);
+            var user = GetUser(userId);
             var organizationId = user.GetOrganizationId();
 
             var viewModel = new EditUserModel
@@ -143,7 +143,7 @@ namespace AllReady.Areas.Admin.Controllers
         {
             try
             {
-                var user = _dataAccess.GetUser(userId);
+                var user = GetUser(userId);
                 if (user == null)
                 {
                     ViewBag.ErrorMessage = $"User not found.";
@@ -174,7 +174,7 @@ namespace AllReady.Areas.Admin.Controllers
         {
             try
             {
-                var user = _dataAccess.GetUser(userId);
+                var user = GetUser(userId);
                 await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.UserType, UserType.SiteAdmin.ToName()));
                 return RedirectToAction(nameof(Index));
             }
@@ -189,7 +189,7 @@ namespace AllReady.Areas.Admin.Controllers
         [HttpGet]
         public IActionResult AssignOrganizationAdmin(string userId)
         {
-            var user = _dataAccess.GetUser(userId);
+            var user = GetUser(userId);
             if (user.IsUserType(UserType.OrgAdmin) || user.IsUserType(UserType.SiteAdmin))
             {
                 return RedirectToAction(nameof(Index));
@@ -243,7 +243,7 @@ namespace AllReady.Areas.Admin.Controllers
         {
             try
             {
-                var user = _dataAccess.GetUser(userId);
+                var user = GetUser(userId);
                 await _userManager.RemoveClaimAsync(user, new Claim(Security.ClaimTypes.UserType, UserType.SiteAdmin.ToName()));
                 return RedirectToAction(nameof(Index));
             }
@@ -260,7 +260,7 @@ namespace AllReady.Areas.Admin.Controllers
         {
             try
             {
-                var user = _dataAccess.GetUser(userId);
+                var user = GetUser(userId);
                 var claims = await _userManager.GetClaimsAsync(user);
                 await _userManager.RemoveClaimAsync(user, claims.First(c => c.Type == Security.ClaimTypes.UserType));
                 await _userManager.RemoveClaimAsync(user, claims.First(c => c.Type == Security.ClaimTypes.Organization));
@@ -272,6 +272,11 @@ namespace AllReady.Areas.Admin.Controllers
                 ViewBag.ErrorMessage = $"Failed to assign site admin for {userId}. Exception thrown.";
                 return View();
             }
+        }
+
+        private ApplicationUser GetUser(string userId)
+        {
+            return _dataAccess.GetUser(userId);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Site/SendAccountApprovalEmail.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Site/SendAccountApprovalEmail.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Site
+{
+    public class SendAccountApprovalEmail : IAsyncRequest
+    {
+        public string Email { get; set; }
+        public string CallbackUrl { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Site/SendAccountApprovalEmailHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Site/SendAccountApprovalEmailHandler.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using AllReady.Services;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Site
+{
+    public class SendAccountApprovalEmailHandler : AsyncRequestHandler<SendAccountApprovalEmail>
+    {
+        private readonly IEmailSender emailSender;
+
+        public SendAccountApprovalEmailHandler(IEmailSender emailSender)
+        {
+            this.emailSender = emailSender;
+        }
+
+        protected override async Task HandleCore(SendAccountApprovalEmail message)
+        {
+            await emailSender.SendEmailAsync(message.Email, "Account Approval", 
+                $"Your account has been approved by an administrator. Please <a href=\"{message.CallbackUrl}\">Click here to Log in</a>")
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Site/SendResetPasswordEmail.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Site/SendResetPasswordEmail.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Site
+{
+    public class SendResetPasswordEmail : IAsyncRequest
+    {
+        public string Email { get; set; }
+        public string CallbackUrl { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Site/SendResetPasswordEmailHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Site/SendResetPasswordEmailHandler.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading.Tasks;
+using AllReady.Services;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Site
+{
+    public class SendResetPasswordEmailHandler : AsyncRequestHandler<SendResetPasswordEmail>
+    {
+        private readonly IEmailSender emailSender;
+
+        public SendResetPasswordEmailHandler(IEmailSender emailSender)
+        {
+            this.emailSender = emailSender;
+        }
+
+        protected override async Task HandleCore(SendResetPasswordEmail message)
+        {
+            await emailSender.SendEmailAsync(message.Email, "Reset Password", $"Please reset your password by clicking here: <a href=\"{message.CallbackUrl}\">link</a>");
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Users/UserQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Users/UserQuery.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Users
 {
-    public class UserQuery : IRequest<EditUserModel>
+    public class UserQuery : IAsyncRequest<EditUserModel>
     {
         public string UserId { get; set; }
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Users/UserQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Users/UserQueryHandler.cs
@@ -3,7 +3,6 @@ using AllReady.Areas.Admin.Models;
 using AllReady.Models;
 using AllReady.Security;
 using MediatR;
-using Microsoft.AspNet.Identity;
 using Microsoft.Data.Entity;
 
 namespace AllReady.Areas.Admin.Features.Users
@@ -11,25 +10,23 @@ namespace AllReady.Areas.Admin.Features.Users
     public class UserQueryHandler : IRequestHandler<UserQuery, EditUserModel>
     {
         private readonly AllReadyContext _context;
-        private readonly UserManager<ApplicationUser> _userManager;
 
-        public UserQueryHandler(AllReadyContext context, UserManager<ApplicationUser> userManager)
+        public UserQueryHandler(AllReadyContext context)
         {
             _context = context;
-            _userManager = userManager;
         }
 
         public EditUserModel Handle(UserQuery message)
         {
             var user = _context.Users
                 .Where(u => u.Id == message.UserId)
-                .Include(u => u.AssociatedSkills).ThenInclude((UserSkill us) => us.Skill)
+                .Include(u => u.AssociatedSkills).ThenInclude(us => us.Skill)
                 .Include(u => u.Claims)
                 .SingleOrDefault();
 
             var organizationId = user.GetOrganizationId();
 
-            var viewModel = new EditUserModel()
+            var viewModel = new EditUserModel
             {
                 UserId = message.UserId,
                 UserName = user.UserName,

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Users/UserQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Users/UserQueryHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Areas.Admin.Models;
 using AllReady.Models;
 using AllReady.Security;
@@ -7,7 +8,7 @@ using Microsoft.Data.Entity;
 
 namespace AllReady.Areas.Admin.Features.Users
 {
-    public class UserQueryHandler : IRequestHandler<UserQuery, EditUserModel>
+    public class UserQueryHandler : IAsyncRequestHandler<UserQuery, EditUserModel>
     {
         private readonly AllReadyContext _context;
 
@@ -16,13 +17,14 @@ namespace AllReady.Areas.Admin.Features.Users
             _context = context;
         }
 
-        public EditUserModel Handle(UserQuery message)
+        public async Task<EditUserModel> Handle(UserQuery message)
         {
-            var user = _context.Users
+            var user = await _context.Users
                 .Where(u => u.Id == message.UserId)
                 .Include(u => u.AssociatedSkills).ThenInclude(us => us.Skill)
                 .Include(u => u.Claims)
-                .SingleOrDefault();
+                .SingleOrDefaultAsync()
+                .ConfigureAwait(false);
 
             var organizationId = user.GetOrganizationId();
 
@@ -33,7 +35,7 @@ namespace AllReady.Areas.Admin.Features.Users
                 AssociatedSkills = user.AssociatedSkills,
                 IsOrganizationAdmin = user.IsUserType(UserType.OrgAdmin),
                 IsSiteAdmin = user.IsUserType(UserType.SiteAdmin),
-                Organization = organizationId != null ? _context.Organizations.First(t=>t.Id == organizationId.Value) : null
+                Organization = organizationId != null ? await _context.Organizations.FirstAsync(t=>t.Id == organizationId.Value).ConfigureAwait(false) : null
             };
 
             return viewModel;

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -43,6 +43,7 @@ namespace AllReady.Controllers
         private const string MANAGE_CONTROLLER = "Manage";
         //View Names
         private const string ERROR_VIEW = "Error";
+
         private readonly UserManager<ApplicationUser> _userManager;
         private readonly SignInManager<ApplicationUser> _signInManager;
         private readonly IEmailSender _emailSender;
@@ -138,7 +139,6 @@ namespace AllReady.Controllers
         {
             var user = await _userManager.FindByIdAsync(User.GetUserId());
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-            //var callbackUrl = Url.Action(nameof(ConfirmNewEmail), ACCOUNT_CONTROLLER, new { userId = user.Id, code = code }, protocol: HttpContext.Request.Scheme);
             var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmNewEmail), Controller = ACCOUNT_CONTROLLER, Values = new { userId = user.Id, code = code },
                 Protocol = HttpContext.Request.Scheme });
             await _emailSender.SendEmailAsync(user.Email, EMAIL_CONFIRMATION_SUBJECT, string.Format(RESEND_EMAIL_CONFIRM, callbackUrl));
@@ -377,7 +377,6 @@ namespace AllReady.Controllers
                 await _userManager.UpdateAsync(user);
 
                 var token = await _userManager.GenerateChangeEmailTokenAsync(user, model.NewEmail);
-                //var callbackUrl = Url.Action(nameof(ConfirmNewEmail), MANAGE_CONTROLLER, new { token = token }, protocol: HttpContext.Request.Scheme);
                 var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmNewEmail), Controller = MANAGE_CONTROLLER, Values = new { token = token },
                     Protocol = HttpContext.Request.Scheme });
                 await _emailSender.SendEmailAsync(user.Email, EMAIL_CONFIRMATION_SUBJECT, string.Format(NEW_EMAIL_CONFIRM, callbackUrl));
@@ -428,7 +427,6 @@ namespace AllReady.Controllers
             }
 
             var token = await _userManager.GenerateChangeEmailTokenAsync(user, user.PendingNewEmail);
-            //var callbackUrl = Url.Action(nameof(ConfirmNewEmail), MANAGE_CONTROLLER, new { token = token }, protocol: HttpContext.Request.Scheme);
             var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmNewEmail), Controller = MANAGE_CONTROLLER, Values = new { token = token },
                 Protocol = HttpContext.Request.Scheme });
             await _emailSender.SendEmailAsync(user.Email, EMAIL_CONFIRMATION_SUBJECT, string.Format(NEW_EMAIL_CONFIRM, callbackUrl));
@@ -514,7 +512,6 @@ namespace AllReady.Controllers
         public IActionResult LinkLogin(string provider)
         {
             // Request a redirect to the external login provider to link a login for the current user
-            //var redirectUrl = Url.Action(nameof(LinkLoginCallback), MANAGE_CONTROLLER);
             var redirectUrl = Url.Action(new UrlActionContext { Action = nameof(LinkLoginCallback), Controller = MANAGE_CONTROLLER });
             var properties = _signInManager.ConfigureExternalAuthenticationProperties(provider, redirectUrl, User.GetUserId());
             return new ChallengeResult(provider, properties);


### PR DESCRIPTION
Fixes #660

- using mediator to send mail from this controller by ways of explicitly named messages
- refactored any _dataAccess.GetUser(userId) calls into private GetUser method in SiteAdminController to ready for refactoring to mediator
- update QueryHandler to async as well as removing an unneeded dependency from constructor
- updated all pertinent unit tests/stubs to reflect the refactoring changes