### PR TITLE
Add tests to register post

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -163,10 +163,28 @@ namespace AllReady.UnitTest.Controllers
             [Fact]
             public void It_should_send_a_confirmation_email()
             {
+                //var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+                //var callbackUrl = Url.Action(new UrlActionContext
+                //{
+                //    Action = nameof(ConfirmEmail),
+                //    Controller = "Account",
+                //    Values = new { userId = user.Id, token = token },
+                //    Protocol = HttpContext.Request.Scheme
+                //});
+
+                var callbackUrl = Guid.NewGuid().ToString();
+                urlHelperMock.Setup(x => x.Action(It.Is<UrlActionContext>(
+                    y => y.Action == "ConfirmEmail" &&
+                         y.Controller == "Account" &&
+                         y.Protocol == requestScheme)))
+                         .Returns(callbackUrl);
+
                 Subject.Register(registerViewModel).Wait();
+
                 Mocked<IEmailSender>()
-                    .Verify(x => x.SendEmailAsync(It.IsAny<string>(),
-                        It.IsAny<string>(), It.IsAny<string>()));
+                    .Verify(x => x.SendEmailAsync(registerViewModel.Email,
+                        "Confirm your allReady account",
+                        $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>"));
             }
 
             [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -109,12 +109,6 @@ namespace AllReady.UnitTest.Controllers
             }
 
             [Fact]
-            public void New_test()
-            {
-                Subject.Register(registerViewModel).Wait();
-            }
-
-            [Fact]
             public void It_should_redirect_to_home_page_after_a_success_user_creation()
             {
                 var result = Subject.Register(registerViewModel);
@@ -137,6 +131,32 @@ namespace AllReady.UnitTest.Controllers
                 result.Result.ShouldBeOfType(typeof(ViewResult));
 
                 (result.Result as ViewResult).ViewData.Model.ShouldBeSameAs(registerViewModel);
+            }
+
+            [Fact]
+            public void It_should_stay_on_the_registration_page_if_the_input_is_bad()
+            {
+                var key = Guid.NewGuid().ToString();
+                var errorMessage = Guid.NewGuid().ToString();
+                Subject.ViewData.ModelState.AddModelError(key, errorMessage);
+
+                var result = Subject.Register(registerViewModel);
+
+                result.Result.ShouldBeOfType(typeof(ViewResult));
+                (result.Result as ViewResult).ViewData.Model.ShouldBeSameAs(registerViewModel);
+            }
+
+            [Fact]
+            public void It_should_not_attempt_to_create_a_new_user_when_the_input_is_bad()
+            {
+                var key = Guid.NewGuid().ToString();
+                var errorMessage = Guid.NewGuid().ToString();
+                Subject.ViewData.ModelState.AddModelError(key, errorMessage);
+
+                userManagerMock.Setup(x=>x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()))
+                    .Throws(new Exception("Should not have been called!"));
+
+                Subject.Register(registerViewModel).Wait();
             }
         }
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using AllReady.Controllers;
 using AllReady.Models;
 using AllReady.Services;
+using AllReady.UnitTest.Extensions;
 using AutoMoq;
 using AutoMoq.Helpers;
 using Microsoft.AspNet.Http;
@@ -141,7 +142,6 @@ namespace AllReady.UnitTest.Controllers
             [Fact]
             public void It_should_sign_in_the_new_user()
             {
-                    //await _signInManager.SignInAsync(user, isPersistent: false);
                 Subject.Register(registerViewModel).Wait();
                 signInManagerMock.Verify(x => x.SignInAsync(
                     It.Is<ApplicationUser>(
@@ -149,6 +149,15 @@ namespace AllReady.UnitTest.Controllers
                             y.Email == registerViewModel.Email && y.UserName == registerViewModel.Email &&
                             y.TimeZoneId == defaultTimeZone)
                     , false, null));
+            }
+
+            [Fact]
+            public void It_should_send_a_confirmation_email()
+            {
+                Subject.Register(registerViewModel).Wait();
+                Mocked<IEmailSender>()
+                    .Verify(x => x.SendEmailAsync(It.IsAny<string>(),
+                        It.IsAny<string>(), It.IsAny<string>()));
             }
 
             [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Dynamic;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using AllReady.Controllers;
 using AllReady.Models;
@@ -15,6 +16,7 @@ using Moq;
 using Xunit;
 using MediatR;
 using Shouldly;
+using ClaimTypes = AllReady.Security.ClaimTypes;
 
 namespace AllReady.UnitTest.Controllers
 {
@@ -118,6 +120,18 @@ namespace AllReady.UnitTest.Controllers
                 var redirect = result.Result as RedirectToActionResult;
                 redirect.ActionName.ShouldBe("Index");
                 redirect.ControllerName.ShouldBe("Home");
+            }
+
+            [Fact]
+            public void It_should_issue_a_profile_incomplete_claim_after_a_successful_user_creation()
+            {
+                Subject.Register(registerViewModel).Wait();
+
+                userManagerMock.Verify(x => x.AddClaimAsync(It.Is<ApplicationUser>(
+                    y =>
+                        y.Email == registerViewModel.Email && y.UserName == registerViewModel.Email &&
+                        y.TimeZoneId == defaultTimeZone),
+                    It.Is<Claim>(y => y.Type == ClaimTypes.ProfileIncomplete && y.Value == "NewUser")));
             }
 
             [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -79,13 +79,19 @@ namespace AllReady.UnitTest.Controllers
         {
             private RegisterViewModel registerViewModel;
             private Mock<UserManager<ApplicationUser>> userManagerMock;
+            private string defaultTimeZone;
 
             public RegisterPostTests()
             {
                 ResetSubject();
                 var setup = CommonSetup(Mocker);
-
                 userManagerMock = setup.UserManagerMock;
+
+                defaultTimeZone = Guid.NewGuid().ToString();
+                var generalSettings = new GeneralSettings {DefaultTimeZone = defaultTimeZone};
+                Mocked<IOptions<GeneralSettings>>()
+                    .Setup(x => x.Value)
+                    .Returns(generalSettings);
 
                 registerViewModel = new RegisterViewModel();
                 registerViewModel.Password = Guid.NewGuid().ToString();
@@ -95,7 +101,12 @@ namespace AllReady.UnitTest.Controllers
             [Fact]
             public void It_should_redirect_to_home_page_after_a_success_user_creation()
             {
-                userManagerMock.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), registerViewModel.Password))
+                userManagerMock.Setup(
+                    x =>
+                        x.CreateAsync(
+                            It.Is<ApplicationUser>(
+                                y => y.Email == registerViewModel.Email && y.UserName == registerViewModel.Email && y.TimeZoneId == defaultTimeZone),
+                            registerViewModel.Password))
                     .Returns(Task.FromResult(IdentityResult.Success));
 
                 var result = Subject.Register(registerViewModel);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -16,6 +16,7 @@ using Microsoft.Extensions.OptionsModel;
 using Moq;
 using Xunit;
 using MediatR;
+using Microsoft.AspNet.Mvc.Routing;
 using Microsoft.AspNet.Mvc.ViewFeatures;
 using Shouldly;
 using ClaimTypes = AllReady.Security.ClaimTypes;
@@ -86,6 +87,8 @@ namespace AllReady.UnitTest.Controllers
             private Mock<UserManager<ApplicationUser>> userManagerMock;
             private string defaultTimeZone;
             private Mock<SignInManager<ApplicationUser>> signInManagerMock;
+            private string requestScheme;
+            private Mock<UrlHelper> urlHelperMock;
 
             public RegisterPostTests()
             {
@@ -113,6 +116,12 @@ namespace AllReady.UnitTest.Controllers
                                 y => y.Email == registerViewModel.Email && y.UserName == registerViewModel.Email && y.TimeZoneId == defaultTimeZone),
                             registerViewModel.Password))
                     .Returns(Task.FromResult(IdentityResult.Success));
+
+                requestScheme = Guid.NewGuid().ToString();
+                Subject.SetFakeHttpRequestSchemeTo(requestScheme);
+
+                urlHelperMock = new Mock<UrlHelper>(null, null);
+                Subject.Url = urlHelperMock.Object;
             }
 
             [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -20,10 +20,8 @@ namespace AllReady.UnitTest.Controllers
 
         public class RegisterGetTests : AutoMoqTestFixture<AccountController>
         {
-            [Fact]
-            public void Returns_a_view()
+            public RegisterGetTests()
             {
-
                 var store = Mocked<IUserStore<ApplicationUser>>();
                 var userManagerMock = new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null,
                     null, null);
@@ -55,7 +53,11 @@ namespace AllReady.UnitTest.Controllers
 
                 Mocker.SetInstance(signInManagerMock.Object);
                 Mocker.SetInstance(userManagerMock.Object);
+            }
 
+            [Fact]
+            public void Returns_a_view()
+            {
                 var result = Subject.Register();
                 result.ShouldBeOfType(typeof (ViewResult));
             }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -80,8 +80,15 @@ namespace AllReady.UnitTest.Controllers
             [Fact]
             public void Returns_a_view()
             {
-                var result = Subject.Register();
-                result.ShouldBeOfType(typeof (ViewResult));
+                var registerViewModel = new RegisterViewModel();
+
+                var result = Subject.Register(registerViewModel);
+
+                result.Result.ShouldBeOfType(typeof(RedirectToActionResult));
+
+                var redirect = result.Result as RedirectToActionResult;
+                redirect.ActionName.ShouldBe("Index");
+                redirect.ControllerName.ShouldBe("Home");
             }
         }
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -93,14 +93,12 @@ namespace AllReady.UnitTest.Controllers
                     .Setup(x => x.Value)
                     .Returns(generalSettings);
 
-                registerViewModel = new RegisterViewModel();
-                registerViewModel.Password = Guid.NewGuid().ToString();
-                registerViewModel.Email = Guid.NewGuid().ToString();
-            }
+                registerViewModel = new RegisterViewModel
+                {
+                    Password = Guid.NewGuid().ToString(),
+                    Email = Guid.NewGuid().ToString()
+                };
 
-            [Fact]
-            public void It_should_redirect_to_home_page_after_a_success_user_creation()
-            {
                 userManagerMock.Setup(
                     x =>
                         x.CreateAsync(
@@ -108,7 +106,17 @@ namespace AllReady.UnitTest.Controllers
                                 y => y.Email == registerViewModel.Email && y.UserName == registerViewModel.Email && y.TimeZoneId == defaultTimeZone),
                             registerViewModel.Password))
                     .Returns(Task.FromResult(IdentityResult.Success));
+            }
 
+            [Fact]
+            public void New_test()
+            {
+                Subject.Register(registerViewModel).Wait();
+            }
+
+            [Fact]
+            public void It_should_redirect_to_home_page_after_a_success_user_creation()
+            {
                 var result = Subject.Register(registerViewModel);
 
                 result.Result.ShouldBeOfType(typeof(RedirectToActionResult));

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -58,6 +58,7 @@ namespace AllReady.UnitTest.Controllers
 
             dynamic result = new ExpandoObject();
             result.UserManagerMock = userManagerMock;
+            result.SignInManagerMock = signInManagerMock;
             return result;
         }
 
@@ -82,12 +83,14 @@ namespace AllReady.UnitTest.Controllers
             private RegisterViewModel registerViewModel;
             private Mock<UserManager<ApplicationUser>> userManagerMock;
             private string defaultTimeZone;
+            private Mock<SignInManager<ApplicationUser>> signInManagerMock;
 
             public RegisterPostTests()
             {
                 ResetSubject();
                 var setup = CommonSetup(Mocker);
                 userManagerMock = setup.UserManagerMock;
+                signInManagerMock = setup.SignInManagerMock;
 
                 defaultTimeZone = Guid.NewGuid().ToString();
                 var generalSettings = new GeneralSettings {DefaultTimeZone = defaultTimeZone};
@@ -132,6 +135,19 @@ namespace AllReady.UnitTest.Controllers
                         y.Email == registerViewModel.Email && y.UserName == registerViewModel.Email &&
                         y.TimeZoneId == defaultTimeZone),
                     It.Is<Claim>(y => y.Type == ClaimTypes.ProfileIncomplete && y.Value == "NewUser")));
+            }
+
+            [Fact]
+            public void It_should_sign_in_the_new_user()
+            {
+                    //await _signInManager.SignInAsync(user, isPersistent: false);
+                Subject.Register(registerViewModel).Wait();
+                signInManagerMock.Verify(x => x.SignInAsync(
+                    It.Is<ApplicationUser>(
+                        y =>
+                            y.Email == registerViewModel.Email && y.UserName == registerViewModel.Email &&
+                            y.TimeZoneId == defaultTimeZone)
+                    , false, null));
             }
 
             [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -78,7 +78,7 @@ namespace AllReady.UnitTest.Controllers
             }
 
             [Fact]
-            public void Returns_a_view()
+            public void It_should_redirect_to_home_page_after_a_success_user_creation()
             {
                 var registerViewModel = new RegisterViewModel();
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/project.json
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/project.json
@@ -7,17 +7,18 @@
         "warningsAsErrors": true
     },
 
-    "dependencies": {
-        "AllReady": "1.0.0-*",
-        "EntityFramework.InMemory": "7.0.0-rc1-final",
-        "Microsoft.AspNet.TestHost": "1.0.0-rc1-final",
-        "Moq": "4.2.1510.2205",
-        "xunit": "2.1.0",
-        "xunit.runner.dnx": "2.1.0-rc1-build204",
-        "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
-        "Microsoft.AspNet.Mvc.ViewFeatures": "6.0.0-rc1-final",
-        "Shouldly": "2.6.0"
-    },
+  "dependencies": {
+    "AllReady": "1.0.0-*",
+    "EntityFramework.InMemory": "7.0.0-rc1-final",
+    "Microsoft.AspNet.TestHost": "1.0.0-rc1-final",
+    "Moq": "4.2.1510.2205",
+    "xunit": "2.1.0",
+    "xunit.runner.dnx": "2.1.0-rc1-build204",
+    "Microsoft.AspNet.Mvc": "6.0.0-rc1-final",
+    "Microsoft.AspNet.Mvc.ViewFeatures": "6.0.0-rc1-final",
+    "Shouldly": "2.6.0",
+    "AutoMoq": "1.7.1"
+  },
 
     "commands": {
         "test": "xunit.runner.dnx"

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -150,16 +150,15 @@ namespace AllReady.Controllers
 
         private async Task SendAConfirmationEmail(RegisterViewModel model, ApplicationUser user)
         {
-            //var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+            var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
-            var callbackUrl = "";
-            //var callbackUrl = Url.Action(new UrlActionContext
-            //{
-            //    Action = nameof(ConfirmEmail),
-            //    Controller = "Account",
-            //    Values = new {userId = user.Id, token = token},
-            //    Protocol = HttpContext.Request.Scheme
-            //});
+            var callbackUrl = Url.Action(new UrlActionContext
+            {
+                Action = nameof(ConfirmEmail),
+                Controller = "Account",
+                Values = new { userId = user.Id, token = token },
+                Protocol = HttpContext.Request.Scheme
+            });
 
             await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account",
                 $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -135,7 +135,7 @@ namespace AllReady.Controllers
             //        await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
             //            $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
                     await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.ProfileIncomplete, "NewUser"));
-            //        await _signInManager.SignInAsync(user, isPersistent: false);
+                    await _signInManager.SignInAsync(user, isPersistent: false);
 
                       return RedirectToAction(nameof(HomeController.Index), "Home");
                 }

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -116,15 +116,14 @@ namespace AllReady.Controllers
         {
             //if (ModelState.IsValid)
             //{
-            //    var user = new ApplicationUser
-            //    {
-            //        UserName = model.Email,
-            //        Email = model.Email,
-            //        TimeZoneId = _generalSettings.Value.DefaultTimeZone
-            //    };
+                var user = new ApplicationUser
+                {
+                    UserName = model.Email,
+                    Email = model.Email,
+                    TimeZoneId = _generalSettings.Value.DefaultTimeZone
+                };
 
-            //    var result = await _userManager.CreateAsync(user, model.Password);
-                var result = await _userManager.CreateAsync(null, model.Password);
+                var result = await _userManager.CreateAsync(user, model.Password);
                 if (result.Succeeded)
                 {
             //        // Send an email with this link

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -134,7 +134,7 @@ namespace AllReady.Controllers
 
             //        await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
             //            $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
-            //        await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.ProfileIncomplete, "NewUser"));
+                    await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.ProfileIncomplete, "NewUser"));
             //        await _signInManager.SignInAsync(user, isPersistent: false);
 
                       return RedirectToAction(nameof(HomeController.Index), "Home");

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -140,7 +140,7 @@ namespace AllReady.Controllers
                       return RedirectToAction(nameof(HomeController.Index), "Home");
                 }
 
-            //    AddErrorsToModelState(result);
+                AddErrorsToModelState(result);
             }
 
             // If we got this far, something failed, redisplay form

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -114,8 +114,8 @@ namespace AllReady.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Register(RegisterViewModel model)
         {
-            //if (ModelState.IsValid)
-            //{
+            if (ModelState.IsValid)
+            {
                 var user = new ApplicationUser
                 {
                     UserName = model.Email,
@@ -141,9 +141,9 @@ namespace AllReady.Controllers
                 }
 
             //    AddErrorsToModelState(result);
-            //}
+            }
 
-            //// If we got this far, something failed, redisplay form
+            // If we got this far, something failed, redisplay form
             return View(model);
         }
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -124,8 +124,9 @@ namespace AllReady.Controllers
             //    };
 
             //    var result = await _userManager.CreateAsync(user, model.Password);
-            //    if (result.Succeeded)
-            //    {
+                var result = await _userManager.CreateAsync(null, model.Password);
+                if (result.Succeeded)
+                {
             //        // Send an email with this link
             //        var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
@@ -138,13 +139,13 @@ namespace AllReady.Controllers
             //        await _signInManager.SignInAsync(user, isPersistent: false);
 
                       return RedirectToAction(nameof(HomeController.Index), "Home");
-            //    }
+                }
 
             //    AddErrorsToModelState(result);
             //}
 
             //// If we got this far, something failed, redisplay form
-            //return View(model);
+            return View(model);
         }
 
         //

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -125,7 +125,7 @@ namespace AllReady.Controllers
                 return View(model);
             }
 
-            //await SendAConfirmationEmail(model, user);
+            await SendAConfirmationEmail(model, user);
             await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.ProfileIncomplete, "NewUser"));
             await _signInManager.SignInAsync(user, isPersistent: false);
 
@@ -152,6 +152,7 @@ namespace AllReady.Controllers
         {
             //var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
+            var callbackUrl = "";
             //var callbackUrl = Url.Action(new UrlActionContext
             //{
             //    Action = nameof(ConfirmEmail),
@@ -160,8 +161,8 @@ namespace AllReady.Controllers
             //    Protocol = HttpContext.Request.Scheme
             //});
 
-            //await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account",
-            //    $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
+            await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account",
+                $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
         }
 
         //

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -114,37 +114,37 @@ namespace AllReady.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Register(RegisterViewModel model)
         {
-            if (ModelState.IsValid)
-            {
-                var user = new ApplicationUser
-                {
-                    UserName = model.Email,
-                    Email = model.Email,
-                    TimeZoneId = _generalSettings.Value.DefaultTimeZone
-                };
+            //if (ModelState.IsValid)
+            //{
+            //    var user = new ApplicationUser
+            //    {
+            //        UserName = model.Email,
+            //        Email = model.Email,
+            //        TimeZoneId = _generalSettings.Value.DefaultTimeZone
+            //    };
 
-                var result = await _userManager.CreateAsync(user, model.Password);
-                if (result.Succeeded)
-                {
-                    // Send an email with this link
-                    var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+            //    var result = await _userManager.CreateAsync(user, model.Password);
+            //    if (result.Succeeded)
+            //    {
+            //        // Send an email with this link
+            //        var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
-                    var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmEmail), Controller = "Account", Values = new { userId = user.Id, token = token },
-                        Protocol = HttpContext.Request.Scheme });
+            //        var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmEmail), Controller = "Account", Values = new { userId = user.Id, token = token },
+            //            Protocol = HttpContext.Request.Scheme });
 
-                    await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
-                        $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
-                    await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.ProfileIncomplete, "NewUser"));
-                    await _signInManager.SignInAsync(user, isPersistent: false);
+            //        await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
+            //            $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
+            //        await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.ProfileIncomplete, "NewUser"));
+            //        await _signInManager.SignInAsync(user, isPersistent: false);
 
-                    return RedirectToAction(nameof(HomeController.Index), "Home");
-                }
+                      return RedirectToAction(nameof(HomeController.Index), "Home");
+            //    }
 
-                AddErrorsToModelState(result);
-            }
+            //    AddErrorsToModelState(result);
+            //}
 
-            // If we got this far, something failed, redisplay form
-            return View(model);
+            //// If we got this far, something failed, redisplay form
+            //return View(model);
         }
 
         //

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -126,14 +126,7 @@ namespace AllReady.Controllers
                 var result = await _userManager.CreateAsync(user, model.Password);
                 if (result.Succeeded)
                 {
-            //        // Send an email with this link
-            //        var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-
-            //        var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmEmail), Controller = "Account", Values = new { userId = user.Id, token = token },
-            //            Protocol = HttpContext.Request.Scheme });
-
-            //        await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
-            //            $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
+                    //await SendAConfirmationEmail(model, user);
                     await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.ProfileIncomplete, "NewUser"));
                     await _signInManager.SignInAsync(user, isPersistent: false);
 
@@ -145,6 +138,22 @@ namespace AllReady.Controllers
 
             // If we got this far, something failed, redisplay form
             return View(model);
+        }
+
+        private async Task SendAConfirmationEmail(RegisterViewModel model, ApplicationUser user)
+        {
+            //var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+
+            //var callbackUrl = Url.Action(new UrlActionContext
+            //{
+            //    Action = nameof(ConfirmEmail),
+            //    Controller = "Account",
+            //    Values = new {userId = user.Id, token = token},
+            //    Protocol = HttpContext.Request.Scheme
+            //});
+
+            //await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account",
+            //    $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
         }
 
         //


### PR DESCRIPTION
Adds unit tests to to the ```Register``` actions (both the GET and POST).

**Note** I am not unit testing with the same pattern as used previously... but I'd strongly recommend **NOT** having a single test fixture for the entire controller.  The actions are just too different, so trying to mush them into one common setup makes testing harder.  So instead, I have a test fixture per action.

Also note:  I added a test dependency on an automocking tool:  AutoMoq.  I'd also recommend using it for tests like these, as it drops the number of lines of test code considerably.