### PR TITLE
Adding featured campaign to homepage

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/HomeControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/HomeControllerTests.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.AspNet.Mvc;
 using Moq;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace AllReady.UnitTest.Controllers
@@ -12,15 +13,36 @@ namespace AllReady.UnitTest.Controllers
     public class HomeControllerTests
     {
         [Fact]
-        public void IndexSendsCampaignQuery()
+        public async Task IndexSendsCampaignQuery()
         {
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(m => m.Send(It.IsAny<CampaignQuery>())).Returns(new List<CampaignViewModel>());
 
             var sut = new HomeController(mockMediator.Object);
-            sut.Index();
+            var result = (ViewResult)await sut.Index();
 
             mockMediator.Verify(x => x.Send(It.IsAny<CampaignQuery>()), Times.Once());
+        }
+
+        [Fact]
+        public async Task IndexSendsFeaturedCampaignQuery()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            var sut = new HomeController(mockMediator.Object);
+            var result = (ViewResult)await sut.Index();
+
+            mockMediator.Verify(x => x.SendAsync(It.IsAny<FeaturedCampaignQueryAsync>()), Times.Once());
+        }
+
+        [Fact]
+        public async Task IndexReturnsCorrectViewResult()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            var sut = new HomeController(mockMediator.Object);
+            var result = (ViewResult)await sut.Index();
+
+            Assert.NotNull(result);       
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Campaigns/FeaturedCampaignQueryHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Campaigns/FeaturedCampaignQueryHandlerAsyncTests.cs
@@ -1,0 +1,88 @@
+﻿using AllReady.Features.Campaigns;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Features.Campaigns
+{
+    public class FeaturedCampaignQueryHandlerAsyncTests : InMemoryContextTest
+    {
+        [Fact]
+        public async Task ReturnsSingleCampaignThatIsFeatured()
+        {
+            // Arrange
+            var handler = new FeaturedCampaignQueryHandlerAsync(Context);            
+
+            // Act
+            var result = await handler.Handle(new FeaturedCampaignQueryAsync());
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("This is featured", result.Title);            
+        }
+
+        [Fact]
+        public async Task FeaturedCampaignIncludesOrg()
+        {
+            // Arrange
+            var handler = new FeaturedCampaignQueryHandlerAsync(Context);
+
+            // Act
+            var result = await handler.Handle(new FeaturedCampaignQueryAsync());
+
+            // Assert
+            Assert.NotNull(result.Organization);
+            Assert.Equal("Some Organization", result.Organization.Name);
+        }
+
+        [Fact]
+        public async Task ReturnNullIfNoCampaignsAreFeatured()
+        {
+            var results = Context.Campaigns.Where(x => x.Featured);
+            Context.RemoveRange(results);
+            Context.SaveChanges();
+
+            // Arrange
+            var handler = new FeaturedCampaignQueryHandlerAsync(Context);
+
+            // Act
+            var result = await handler.Handle(new FeaturedCampaignQueryAsync());
+
+            // Assert
+            Assert.Null(result);
+        }
+
+        protected override void LoadTestData()
+        {
+            var org = new Models.Organization
+            {
+                Name = "Some Organization"
+            };
+
+            Context.Organizations.Add(org);
+
+            Context.Campaigns.Add(new Models.Campaign
+            {
+                Name = "This is featured",
+                Featured = true,
+                ManagingOrganization = org                
+            });
+
+            Context.Campaigns.Add(new Models.Campaign
+            {
+                Name = "This is not featured",
+                Featured = false,
+                ManagingOrganization = org
+            });
+
+            Context.Campaigns.Add(new Models.Campaign
+            {
+                Name = "This is also featured",
+                Featured = true,
+                ManagingOrganization = org
+            });
+
+            Context.SaveChanges();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/ViewModels/HomePageViewModelTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/ViewModels/HomePageViewModelTests.cs
@@ -1,0 +1,31 @@
+﻿using AllReady.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.ViewModels
+{
+    public class HomePageViewModelTests
+    {
+        [Fact]
+        public void HasFeaturedCampaignShouldReturnFalseIfViewModelHasNoFeaturedCampaign()
+        {
+            var sut = new HomePageViewModel();
+
+            Assert.False(sut.HasFeaturedCampaign);
+        }
+
+        [Fact]
+        public void HasFeaturedCampaignShouldReturnTrueIfViewMModelHasAFeaturedCampaign()
+        {
+            var sut = new HomePageViewModel()
+            {
+                FeaturedCampaign = new CampaignSummaryViewModel { Id = 1, Title = "Something" }
+            };
+
+            Assert.True(sut.HasFeaturedCampaign);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Controllers/HomeController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/HomeController.cs
@@ -1,6 +1,8 @@
 ﻿using AllReady.Features.Campaigns;
+using AllReady.ViewModels;
 using MediatR;
 using Microsoft.AspNet.Mvc;
+using System.Threading.Tasks;
 
 namespace AllReady.Controllers
 {
@@ -13,10 +15,14 @@ namespace AllReady.Controllers
             this.mediator = mediator;
         }
 
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
-            var results = mediator.Send(new CampaignQuery());
-            return View(results);
+            var model = new HomePageViewModel();
+
+            model.Campaigns = mediator.Send(new CampaignQuery());
+            model.FeaturedCampaign = await mediator.SendAsync(new FeaturedCampaignQueryAsync());
+
+            return View(model);
         }
 
         public IActionResult About()

--- a/AllReadyApp/Web-App/AllReady/Features/Campaigns/FeaturedCampaignQueryAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Campaigns/FeaturedCampaignQueryAsync.cs
@@ -1,0 +1,9 @@
+﻿using AllReady.ViewModels;
+using MediatR;
+
+namespace AllReady.Features.Campaigns
+{
+    public class FeaturedCampaignQueryAsync : IAsyncRequest<CampaignSummaryViewModel>
+    {
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Campaigns/FeaturedCampaignQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Campaigns/FeaturedCampaignQueryHandlerAsync.cs
@@ -1,0 +1,36 @@
+﻿using AllReady.Models;
+using AllReady.ViewModels;
+using MediatR;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity;
+
+namespace AllReady.Features.Campaigns
+{
+    public class FeaturedCampaignQueryHandlerAsync : IAsyncRequestHandler<FeaturedCampaignQueryAsync, CampaignSummaryViewModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public FeaturedCampaignQueryHandlerAsync(AllReadyContext dataAccess)
+        {
+            _context = dataAccess;
+        }
+
+        public async Task<CampaignSummaryViewModel> Handle(FeaturedCampaignQueryAsync message)
+        {
+            return await _context.Campaigns.AsNoTracking()
+                .Where(c => c.Featured)
+                .Include(c => c.ManagingOrganization)
+                .Select(c => new CampaignSummaryViewModel
+                {
+                    Id = c.Id,
+                    Title = c.Name,
+                    Description = c.Description,
+                    ImageUrl = c.ImageUrl,
+                    Organization = c.ManagingOrganization,
+                })
+                .OrderBy(c => c.Id)
+                .FirstOrDefaultAsync();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20160418113633_FeaturedArticleFlag.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20160418113633_FeaturedArticleFlag.Designer.cs
@@ -1,0 +1,709 @@
+using System;
+using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Migrations;
+using AllReady.Models;
+
+namespace AllReady.Migrations
+{
+    [DbContext(typeof(AllReadyContext))]
+    [Migration("20160418113633_FeaturedArticleFlag")]
+    partial class FeaturedArticleFlag
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "7.0.0-rc1-16348")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("AllReady.Models.Activity", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("ActivityType");
+
+                    b.Property<int>("CampaignId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ActivitySignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("ActivityId");
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<DateTime?>("CheckinDateTime");
+
+                    b.Property<string>("PreferredEmail");
+
+                    b.Property<string>("PreferredPhoneNumber");
+
+                    b.Property<DateTime>("SignupDateTime");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ActivitySkill", b =>
+                {
+                    b.Property<int>("ActivityId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("ActivityId", "SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("ActivityId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset?>("EndDateTime");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<DateTimeOffset?>("StartDateTime");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PendingNewEmail");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasAnnotation("Relational:Name", "EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .HasAnnotation("Relational:Name", "UserNameIndex");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUsers");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignImpactId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<bool>("Featured");
+
+                    b.Property<string>("FullDescription");
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<bool>("Locked");
+
+                    b.Property<int>("ManagingOrganizationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.Property<int>("CampaignId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.HasKey("CampaignId", "ContactId", "ContactType");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignImpact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CurrentImpactLevel");
+
+                    b.Property<bool>("Display");
+
+                    b.Property<int>("ImpactType");
+
+                    b.Property<int>("NumericImpactGoal");
+
+                    b.Property<string>("TextualImpactGoal");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignId");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ClosestLocation", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<double>("Distance");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Contact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Location", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address1");
+
+                    b.Property<string>("Address2");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("Country");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<string>("PostalCodePostalCode");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("LogoUrl");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("PrivacyPolicy");
+
+                    b.Property<string>("WebUrl");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.Property<int>("OrganizationId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.HasKey("OrganizationId", "ContactId", "ContactType");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeo", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeoCoordinate", b =>
+                {
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.HasKey("Latitude", "Longitude");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Resource", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("CategoryTag");
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("MediaUrl");
+
+                    b.Property<string>("Name");
+
+                    b.Property<DateTime>("PublishDateBegin");
+
+                    b.Property<DateTime>("PublishDateEnd");
+
+                    b.Property<string>("ResourceUrl");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int?>("OwningOrganizationId");
+
+                    b.Property<int?>("ParentSkillId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<string>("PreferredEmail");
+
+                    b.Property<string>("PreferredPhoneNumber");
+
+                    b.Property<string>("Status");
+
+                    b.Property<DateTime>("StatusDateTimeUtc");
+
+                    b.Property<string>("StatusDescription");
+
+                    b.Property<int?>("TaskId");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.Property<int>("TaskId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("TaskId", "SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("UserId", "SkillId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRole", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Name")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .HasAnnotation("Relational:Name", "RoleNameIndex");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetRoles");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("RoleId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetRoleClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider");
+
+                    b.Property<string>("ProviderKey");
+
+                    b.Property<string>("ProviderDisplayName");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserLogins");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<string>("RoleId");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserRoles");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Activity", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ActivitySignup", b =>
+                {
+                    b.HasOne("AllReady.Models.Activity")
+                        .WithMany()
+                        .HasForeignKey("ActivityId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ActivitySkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Activity")
+                        .WithMany()
+                        .HasForeignKey("ActivityId");
+
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.HasOne("AllReady.Models.Activity")
+                        .WithMany()
+                        .HasForeignKey("ActivityId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.HasOne("AllReady.Models.CampaignImpact")
+                        .WithMany()
+                        .HasForeignKey("CampaignImpactId");
+
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("ManagingOrganizationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Location", b =>
+                {
+                    b.HasOne("AllReady.Models.PostalCodeGeo")
+                        .WithMany()
+                        .HasForeignKey("PostalCodePostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OwningOrganizationId");
+
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("ParentSkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.HasOne("AllReady.Models.AllReadyTask")
+                        .WithMany()
+                        .HasForeignKey("TaskId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+
+                    b.HasOne("AllReady.Models.AllReadyTask")
+                        .WithMany()
+                        .HasForeignKey("TaskId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNet.Identity.EntityFramework.IdentityRole")
+                        .WithMany()
+                        .HasForeignKey("RoleId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNet.Identity.EntityFramework.IdentityRole")
+                        .WithMany()
+                        .HasForeignKey("RoleId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20160418113633_FeaturedArticleFlag.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20160418113633_FeaturedArticleFlag.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Migrations;
+
+namespace AllReady.Migrations
+{
+    public partial class FeaturedArticleFlag : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(name: "FK_Activity_Campaign_CampaignId", table: "Activity");
+            migrationBuilder.DropForeignKey(name: "FK_ActivitySkill_Activity_ActivityId", table: "ActivitySkill");
+            migrationBuilder.DropForeignKey(name: "FK_ActivitySkill_Skill_SkillId", table: "ActivitySkill");
+            migrationBuilder.DropForeignKey(name: "FK_Campaign_Organization_ManagingOrganizationId", table: "Campaign");
+            migrationBuilder.DropForeignKey(name: "FK_CampaignContact_Campaign_CampaignId", table: "CampaignContact");
+            migrationBuilder.DropForeignKey(name: "FK_CampaignContact_Contact_ContactId", table: "CampaignContact");
+            migrationBuilder.DropForeignKey(name: "FK_OrganizationContact_Contact_ContactId", table: "OrganizationContact");
+            migrationBuilder.DropForeignKey(name: "FK_OrganizationContact_Organization_OrganizationId", table: "OrganizationContact");
+            migrationBuilder.DropForeignKey(name: "FK_TaskSkill_Skill_SkillId", table: "TaskSkill");
+            migrationBuilder.DropForeignKey(name: "FK_TaskSkill_AllReadyTask_TaskId", table: "TaskSkill");
+            migrationBuilder.DropForeignKey(name: "FK_UserSkill_Skill_SkillId", table: "UserSkill");
+            migrationBuilder.DropForeignKey(name: "FK_UserSkill_ApplicationUser_UserId", table: "UserSkill");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityRoleClaim<string>_IdentityRole_RoleId", table: "AspNetRoleClaims");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserClaim<string>_ApplicationUser_UserId", table: "AspNetUserClaims");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserLogin<string>_ApplicationUser_UserId", table: "AspNetUserLogins");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserRole<string>_IdentityRole_RoleId", table: "AspNetUserRoles");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserRole<string>_ApplicationUser_UserId", table: "AspNetUserRoles");
+            migrationBuilder.AddColumn<bool>(
+                name: "Featured",
+                table: "Campaign",
+                nullable: false,
+                defaultValue: false);
+            migrationBuilder.AddForeignKey(
+                name: "FK_Activity_Campaign_CampaignId",
+                table: "Activity",
+                column: "CampaignId",
+                principalTable: "Campaign",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivitySkill_Activity_ActivityId",
+                table: "ActivitySkill",
+                column: "ActivityId",
+                principalTable: "Activity",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivitySkill_Skill_SkillId",
+                table: "ActivitySkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_Campaign_Organization_ManagingOrganizationId",
+                table: "Campaign",
+                column: "ManagingOrganizationId",
+                principalTable: "Organization",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_CampaignContact_Campaign_CampaignId",
+                table: "CampaignContact",
+                column: "CampaignId",
+                principalTable: "Campaign",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_CampaignContact_Contact_ContactId",
+                table: "CampaignContact",
+                column: "ContactId",
+                principalTable: "Contact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationContact_Contact_ContactId",
+                table: "OrganizationContact",
+                column: "ContactId",
+                principalTable: "Contact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationContact_Organization_OrganizationId",
+                table: "OrganizationContact",
+                column: "OrganizationId",
+                principalTable: "Organization",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_TaskSkill_Skill_SkillId",
+                table: "TaskSkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_TaskSkill_AllReadyTask_TaskId",
+                table: "TaskSkill",
+                column: "TaskId",
+                principalTable: "AllReadyTask",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSkill_Skill_SkillId",
+                table: "UserSkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSkill_ApplicationUser_UserId",
+                table: "UserSkill",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityRoleClaim<string>_IdentityRole_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserClaim<string>_ApplicationUser_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserLogin<string>_ApplicationUser_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserRole<string>_IdentityRole_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserRole<string>_ApplicationUser_UserId",
+                table: "AspNetUserRoles",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(name: "FK_Activity_Campaign_CampaignId", table: "Activity");
+            migrationBuilder.DropForeignKey(name: "FK_ActivitySkill_Activity_ActivityId", table: "ActivitySkill");
+            migrationBuilder.DropForeignKey(name: "FK_ActivitySkill_Skill_SkillId", table: "ActivitySkill");
+            migrationBuilder.DropForeignKey(name: "FK_Campaign_Organization_ManagingOrganizationId", table: "Campaign");
+            migrationBuilder.DropForeignKey(name: "FK_CampaignContact_Campaign_CampaignId", table: "CampaignContact");
+            migrationBuilder.DropForeignKey(name: "FK_CampaignContact_Contact_ContactId", table: "CampaignContact");
+            migrationBuilder.DropForeignKey(name: "FK_OrganizationContact_Contact_ContactId", table: "OrganizationContact");
+            migrationBuilder.DropForeignKey(name: "FK_OrganizationContact_Organization_OrganizationId", table: "OrganizationContact");
+            migrationBuilder.DropForeignKey(name: "FK_TaskSkill_Skill_SkillId", table: "TaskSkill");
+            migrationBuilder.DropForeignKey(name: "FK_TaskSkill_AllReadyTask_TaskId", table: "TaskSkill");
+            migrationBuilder.DropForeignKey(name: "FK_UserSkill_Skill_SkillId", table: "UserSkill");
+            migrationBuilder.DropForeignKey(name: "FK_UserSkill_ApplicationUser_UserId", table: "UserSkill");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityRoleClaim<string>_IdentityRole_RoleId", table: "AspNetRoleClaims");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserClaim<string>_ApplicationUser_UserId", table: "AspNetUserClaims");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserLogin<string>_ApplicationUser_UserId", table: "AspNetUserLogins");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserRole<string>_IdentityRole_RoleId", table: "AspNetUserRoles");
+            migrationBuilder.DropForeignKey(name: "FK_IdentityUserRole<string>_ApplicationUser_UserId", table: "AspNetUserRoles");
+            migrationBuilder.DropColumn(name: "Featured", table: "Campaign");
+            migrationBuilder.AddForeignKey(
+                name: "FK_Activity_Campaign_CampaignId",
+                table: "Activity",
+                column: "CampaignId",
+                principalTable: "Campaign",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivitySkill_Activity_ActivityId",
+                table: "ActivitySkill",
+                column: "ActivityId",
+                principalTable: "Activity",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_ActivitySkill_Skill_SkillId",
+                table: "ActivitySkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_Campaign_Organization_ManagingOrganizationId",
+                table: "Campaign",
+                column: "ManagingOrganizationId",
+                principalTable: "Organization",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_CampaignContact_Campaign_CampaignId",
+                table: "CampaignContact",
+                column: "CampaignId",
+                principalTable: "Campaign",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_CampaignContact_Contact_ContactId",
+                table: "CampaignContact",
+                column: "ContactId",
+                principalTable: "Contact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationContact_Contact_ContactId",
+                table: "OrganizationContact",
+                column: "ContactId",
+                principalTable: "Contact",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_OrganizationContact_Organization_OrganizationId",
+                table: "OrganizationContact",
+                column: "OrganizationId",
+                principalTable: "Organization",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_TaskSkill_Skill_SkillId",
+                table: "TaskSkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_TaskSkill_AllReadyTask_TaskId",
+                table: "TaskSkill",
+                column: "TaskId",
+                principalTable: "AllReadyTask",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSkill_Skill_SkillId",
+                table: "UserSkill",
+                column: "SkillId",
+                principalTable: "Skill",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_UserSkill_ApplicationUser_UserId",
+                table: "UserSkill",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityRoleClaim<string>_IdentityRole_RoleId",
+                table: "AspNetRoleClaims",
+                column: "RoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserClaim<string>_ApplicationUser_UserId",
+                table: "AspNetUserClaims",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserLogin<string>_ApplicationUser_UserId",
+                table: "AspNetUserLogins",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserRole<string>_IdentityRole_RoleId",
+                table: "AspNetUserRoles",
+                column: "RoleId",
+                principalTable: "AspNetRoles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+            migrationBuilder.AddForeignKey(
+                name: "FK_IdentityUserRole<string>_ApplicationUser_UserId",
+                table: "AspNetUserRoles",
+                column: "UserId",
+                principalTable: "AspNetUsers",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
@@ -175,6 +175,8 @@ namespace AllReady.Migrations
 
                     b.Property<DateTimeOffset>("EndDateTime");
 
+                    b.Property<bool>("Featured");
+
                     b.Property<string>("FullDescription");
 
                     b.Property<string>("ImageUrl");

--- a/AllReadyApp/Web-App/AllReady/Models/Campaign.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Campaign.cs
@@ -56,5 +56,7 @@ namespace AllReady.Models
         public List<CampaignContact> CampaignContacts { get; set; }
 
         public bool Locked { get; set; }
+
+        public bool Featured { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/CampaignSummaryViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/CampaignSummaryViewModel.cs
@@ -1,0 +1,14 @@
+﻿using AllReady.Models;
+using System;
+
+namespace AllReady.ViewModels
+{
+    public class CampaignSummaryViewModel
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public string ImageUrl { get; set; }
+        public Organization Organization { get; set; }   
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/ViewModels/HomePageViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/HomePageViewModel.cs
@@ -11,14 +11,7 @@ namespace AllReady.ViewModels
         {
             get
             {
-                if (FeaturedCampaign != null)
-                {
-                    return true;
-                }
-                else
-                {
-                    return false;
-                }
+                return FeaturedCampaign != null;               
             }
         }
     }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/HomePageViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/HomePageViewModel.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace AllReady.ViewModels
+{
+    public class HomePageViewModel
+    {
+        public List<CampaignViewModel> Campaigns { get; set; }
+        public CampaignSummaryViewModel FeaturedCampaign { get; set; }
+
+        public bool HasFeaturedCampaign
+        {
+            get
+            {
+                if (FeaturedCampaign != null)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Views/Home/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Home/Index.cshtml
@@ -1,58 +1,93 @@
-﻿@model IList<CampaignViewModel>
+﻿@model HomePageViewModel
 @{
     ViewData["Title"] = "Home Page";
     Layout = "_LayoutMainPage";
     @addTagHelper "*, Microsoft.AspNet.Mvc.TagHelpers"
 }
 
+@if (Model.HasFeaturedCampaign)
+{
     <div class="row">
-        <div class="col-md-12">
-            <h2>Active/Upcoming Campaigns</h2>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="hide text-center" data-bind="css: { hide: campaigns().length }">
-            <div class="alert alert-warning" role="alert">
-                <strong>No matching campaigns.</strong>
-            </div>
-        </div>
-        <div class="col-md-12">
-            <div id="campaignGrid" class="table-responsive">
-                <table class="table" data-bind="css: { hide: !campaigns().length }">
-                    <tr>
-                        <th><span title="Name of the campaign">Title</span></th>
-                        <th><span title="Description of the campaign">Description</span></th>
-                        <th><span title="Date of the campaign">Dates</span></th>
-                        <th><span title="Locations of the campaign">Locations</span></th>
-                    </tr>
-                    <!-- ko foreach: campaigns -->
-                    <tr>
-                        <td>
-                            <a data-bind="attr: { href: '/Campaign/' + Id }, text: Name"></a>
-                        </td>
-                        <td>
-                            <span data-bind="text: Description"></span>
-                        </td>
-                        <td>
-                            <span data-bind="text: displayDate()"></span>
-                        </td>
-                        <td>
-                            <a data-bind="attr: { href: '/Campaign/Map/' + Id }">Map</a>
-                        </td>
-                    </tr>
-                    <!-- /ko -->
-                </table>
+        <div class="col-md-10 col-md-offset-1">
+            <div class="featured-campaign">
+                <div class="row">
+                    <div class="col-md-12">
+                        <h2>Featured Campaign</h2>
+                    </div>
+                </div>
+                <div class="row">
+                    <a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.FeaturedCampaign.Id">
+                        @if (!String.IsNullOrEmpty(Model.FeaturedCampaign.ImageUrl))
+                {
+                            <div class="col-md-3">
+                                <img src="@Model.FeaturedCampaign.ImageUrl" class="img-responsive" />
+                            </div>
+                                <div class="col-md-9">
+                                    <h3>@Model.FeaturedCampaign.Title</h3>
+                                    <h4>Managed by @Model.FeaturedCampaign.Organization.Name</h4>
+                                    <p>@Model.FeaturedCampaign.Description</p>
+                                </div>
+                        }
+                        else
+                        {
+                            <div class="col-md-12">
+                                <h3>@Model.FeaturedCampaign.Title</h3>
+                                <h4>Managed by @Model.FeaturedCampaign.Organization.Name</h4>
+                                <p>@Model.FeaturedCampaign.Description</p>
+                            </div>
+                        }
+                    </a>
+                </div>
             </div>
         </div>
     </div>
+}
 
-    @section scripts {
-        <script>
-            var modelCampaigns = @Json.Serialize(Model);
-        </script>
-        <script src="~/js/index.js"></script>
-    }
+<div class="row">
+    <div class="col-md-12">
+        <h2>Active/Upcoming Campaigns</h2>
+    </div>
+</div>
 
+<div class="row">
+    <div class="hide text-center" data-bind="css: { hide: campaigns().length }">
+        <div class="alert alert-warning" role="alert">
+            <strong>No matching campaigns.</strong>
+        </div>
+    </div>
+    <div class="col-md-12">
+        <div id="campaignGrid" class="table-responsive">
+            <table class="table" data-bind="css: { hide: !campaigns().length }">
+                <tr>
+                    <th><span title="Name of the campaign">Title</span></th>
+                    <th><span title="Description of the campaign">Description</span></th>
+                    <th><span title="Date of the campaign">Dates</span></th>
+                    <th><span title="Locations of the campaign">Locations</span></th>
+                </tr>
+                <!-- ko foreach: campaigns -->
+                <tr>
+                    <td>
+                        <a data-bind="attr: { href: '/Campaign/' + Id }, text: Name"></a>
+                    </td>
+                    <td>
+                        <span data-bind="text: Description"></span>
+                    </td>
+                    <td>
+                        <span data-bind="text: displayDate()"></span>
+                    </td>
+                    <td>
+                        <a data-bind="attr: { href: '/Campaign/Map/' + Id }">Map</a>
+                    </td>
+                </tr>
+                <!-- /ko -->
+            </table>
+        </div>
+    </div>
+</div>
 
-
+@section scripts {
+    <script>
+        var modelCampaigns = @Json.Serialize(Model.Campaigns);
+    </script>
+    <script src="~/js/index.js"></script>
+}

--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/mainPage.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/mainPage.css
@@ -89,3 +89,27 @@ input.main-search {
 .inline-form {
     display: inline-block;
 }
+
+.featured-campaign {
+    border: 1px solid #d58033;
+    padding: 6px;
+    margin: 10px;
+    background: #e4cdb8;
+}
+
+.featured-campaign h2 {
+    margin-top: 5px;
+    margin-bottom: 15px;
+}
+
+.featured-campaign h3 {
+    margin-top: 0;
+}
+
+.featured-campaign h4 {
+    margin-top: 5px;
+}
+
+.featured-campaign h4, p{
+    color: black;
+}


### PR DESCRIPTION
Fixes #689 

I've added the basics to meet the current requirements. I've done some basic styling on the featured campaign which can be updated / improved in line with issue #693 

Current layout when a featured campaign is set:
![image](https://cloud.githubusercontent.com/assets/3669103/14639479/eb919e80-0634-11e6-8649-f11b385463e7.png)

NOTE: Per the immediate requirement, setting a campaign as featured is currently a manual change to the campaign record in the database.

- Added "featured" column to the campaign DB table to allow campaigns to be marked as featured
- Updated home page view model to include a featured campaign summary
- Updated controller to call Mediator query to get featured campaign
- Implemented a new Mediator query to return a single featured campaign or null
- Updated UI to render featured campaign if available in the model
- Added tests