### PR TITLE
refactoring IEmailSender and ISmsSender out of AdminController

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Features/Admin/SendAccountConfirmationEmail.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Admin/SendAccountConfirmationEmail.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Admin
+{
+    public class SendAccountConfirmationEmail : IAsyncRequest
+    {
+        public string Email { get; set; }
+        public string CallbackUrl { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Admin/SendAccountConfirmationEmailHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Admin/SendAccountConfirmationEmailHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using AllReady.Services;
+using MediatR;
+
+namespace AllReady.Features.Admin
+{
+    public class SendAccountConfirmationEmailHandler : AsyncRequestHandler<SendAccountConfirmationEmail>
+    {
+        private readonly IEmailSender emailSender;
+
+        public SendAccountConfirmationEmailHandler(IEmailSender emailSender)
+        {
+            this.emailSender = emailSender;
+        }
+
+        protected override async Task HandleCore(SendAccountConfirmationEmail message)
+        {
+            await emailSender.SendEmailAsync(message.Email, "Confirm your account", $"Please confirm your account by clicking this <a href=\"{message.CallbackUrl}\">link</a>")
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Admin/SendApproveOrganizationUserAccountEmail.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Admin/SendApproveOrganizationUserAccountEmail.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Admin
+{
+    public class SendApproveOrganizationUserAccountEmail : IAsyncRequest
+    {
+        public string DefaultAdminUsername { get; set; }
+        public string CallbackUrl { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Admin/SendApproveOrganizationUserAccountEmailHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Admin/SendApproveOrganizationUserAccountEmailHandler.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using AllReady.Services;
+using MediatR;
+
+namespace AllReady.Features.Admin
+{
+    public class SendApproveOrganizationUserAccountEmailHandler : AsyncRequestHandler<SendApproveOrganizationUserAccountEmail>
+    {
+        private readonly IEmailSender emailSender;
+
+        public SendApproveOrganizationUserAccountEmailHandler(IEmailSender emailSender)
+        {
+            this.emailSender = emailSender;
+        }
+
+        protected override async Task HandleCore(SendApproveOrganizationUserAccountEmail message)
+        {
+            await emailSender.SendEmailAsync(message.DefaultAdminUsername, "Approve organization user account", 
+                $"Please approve this account by clicking this <a href=\"{message.CallbackUrl}\">link</a>")
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Admin/SendSecurityCodeEmail.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Admin/SendSecurityCodeEmail.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Admin
+{
+    public class SendSecurityCodeEmail : IAsyncRequest
+    {
+        public string Email { get; set; }
+        public string Token { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Admin/SendSecurityCodeEmailHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Admin/SendSecurityCodeEmailHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using AllReady.Services;
+using MediatR;
+
+namespace AllReady.Features.Admin
+{
+    public class SendSecurityCodeEmailHandler : AsyncRequestHandler<SendSecurityCodeEmail>
+    {
+        private readonly IEmailSender emailSender;
+
+        public SendSecurityCodeEmailHandler(IEmailSender emailSender)
+        {
+            this.emailSender = emailSender;
+        }
+
+        protected override async Task HandleCore(SendSecurityCodeEmail message)
+        {
+            await emailSender.SendEmailAsync(message.Email, "Security Code", $"Your security code is: {message.Token}")
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Admin/SendSecurityCodeSms.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Admin/SendSecurityCodeSms.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Admin
+{
+    public class SendSecurityCodeSms : IAsyncRequest
+    {
+        public string PhoneNumber { get; set; }
+        public string Token { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Admin/SendSecurityCodeSmsHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Admin/SendSecurityCodeSmsHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using AllReady.Services;
+using MediatR;
+
+namespace AllReady.Features.Admin
+{
+    public class SendSecurityCodeSmsHandler : AsyncRequestHandler<SendSecurityCodeSms>
+    {
+        private readonly ISmsSender smsSender;
+
+        public SendSecurityCodeSmsHandler(ISmsSender smsSender)
+        {
+            this.smsSender = smsSender;
+        }
+
+        protected override async Task HandleCore(SendSecurityCodeSms message)
+        {
+            await smsSender.SendSmsAsync(message.PhoneNumber, $"Your security code is: {message.Token}")
+                .ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
- removed IEmailSender and ISmsSender from AdminController and replaced with Mediator
- added messsage/handlers for each email/sms sent from controller that is now being sent by Mediator
- updated unit tests for AdminControllerTests
- **TODO**: add unit tests for newly added handlers (this will be a separate PR)