### PR TITLE
Fixing error where closed tasks can be volunteered for.

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/AllReady.UnitTest.xproj
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/AllReady.UnitTest.xproj
@@ -17,5 +17,8 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\AllReady.Models\AllReady.Models.csproj" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Tasks/TaskSignupHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Tasks/TaskSignupHandlerTests.cs
@@ -1,0 +1,80 @@
+﻿using AllReady.Features.Tasks;
+using AllReady.Models;
+using AllReady.ViewModels;
+using MediatR;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Features.Tasks
+{
+    public class TaskSignupHandlerTests : InMemoryContextTest
+    {
+        [Fact]
+        public async Task Result_ShouldBe_ClosedTaskFailure_IfTaskIsClosed()
+        {
+            var mockMediator = new Mock<IMediator>();
+            var message = new TaskSignupCommandAsync { TaskSignupModel = new EventSignupViewModel { TaskId = 1, EventId = 1, UserId = "abc" } };
+
+            var sut = new TaskSignupHandlerAsync(mockMediator.Object, Context);
+            var result = await sut.Handle(message);
+
+            Assert.Equal(TaskSignupResult.FAILURE_CLOSEDTASK, result.Status);
+            Assert.Equal(0, Context.TaskSignups.Count());
+        }
+
+        [Fact]
+        public async Task Result_ShouldBe_CampaignNotFound_IfCampaignIdDoesNotExist()
+        {
+            var mockMediator = new Mock<IMediator>();
+            var message = new TaskSignupCommandAsync { TaskSignupModel = new EventSignupViewModel { TaskId = 1, EventId = 100, UserId = "abc" } };
+
+            var sut = new TaskSignupHandlerAsync(mockMediator.Object, Context);
+            var result = await sut.Handle(message);
+
+            Assert.Equal(TaskSignupResult.FAILURE_EVENTNOTFOUND, result.Status);
+            Assert.Equal(0, Context.TaskSignups.Count());
+        }
+
+        [Fact]
+        public async Task Result_ShouldBe_TaskNotFound_IfTaskIdDoesNotExist()
+        {
+            var mockMediator = new Mock<IMediator>();
+            var message = new TaskSignupCommandAsync { TaskSignupModel = new EventSignupViewModel { TaskId = 100, EventId = 1, UserId = "abc" } };
+
+            var sut = new TaskSignupHandlerAsync(mockMediator.Object, Context);
+            var result = await sut.Handle(message);
+
+            Assert.Equal(TaskSignupResult.FAILURE_TASKNOTFOUND, result.Status);
+            Assert.Equal(0, Context.TaskSignups.Count());
+        }
+
+        [Fact]
+        public async Task Result_ShouldBe_Success_IfTaskIsNotClosed()
+        {
+            var mockMediator = new Mock<IMediator>();
+            var message = new TaskSignupCommandAsync { TaskSignupModel = new EventSignupViewModel { TaskId = 2, EventId = 1, UserId = "abc" } };
+
+            var sut = new TaskSignupHandlerAsync(mockMediator.Object, Context);
+            var result = await sut.Handle(message);
+
+            Assert.Equal(TaskSignupResult.SUCCESS, result.Status);
+            Assert.Equal(1, Context.TaskSignups.Count());
+        }
+
+        protected override void LoadTestData()
+        {
+            Context.Users.Add(new ApplicationUser { Id = "abc" });
+
+            var campaignEvent = new Models.Event { Id = 1, Name = "Some Event" };
+            Context.Events.Add(campaignEvent);
+
+            Context.Tasks.Add(new AllReadyTask { Id = 1, Name = "Closed Task", EndDateTime = DateTime.UtcNow.AddDays(-100), Event = campaignEvent });
+            Context.Tasks.Add(new AllReadyTask { Id = 2, Name = "Open Task", EndDateTime = DateTime.UtcNow.AddDays(100), Event = campaignEvent });
+
+            Context.SaveChanges();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Models/AllReadyTaskTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Models/AllReadyTaskTests.cs
@@ -1,0 +1,37 @@
+﻿using AllReady.Models;
+using System;
+using Xunit;
+
+namespace AllReady.UnitTest.DataModels
+{
+    public class AllReadyTaskTests
+    {
+        [Fact]
+        public void IsClosed_ShouldBeTrue_IfEndDatePriorToCurrentDate()
+        {
+            var sut = new AllReadyTask();
+
+            sut.EndDateTime = DateTime.UtcNow.AddDays(-1);
+
+            Assert.True(sut.IsClosed);
+        }
+
+        [Fact]
+        public void IsClosed_ShouldBeFalse_IfEndDateLaterThanCurrentDate()
+        {
+            var sut = new AllReadyTask();
+
+            sut.EndDateTime = DateTime.UtcNow.AddDays(1);
+
+            Assert.False(sut.IsClosed);
+        }
+
+        [Fact]
+        public void IsClosed_ShouldBeFalse_IfEndDateIsNull()
+        {
+            var sut = new AllReadyTask();
+
+            Assert.False(sut.IsClosed);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TaskApiController.cs
@@ -21,6 +21,11 @@ namespace AllReady.Controllers
         private readonly IMediator _mediator;
         private readonly IDetermineIfATaskIsEditable _determineIfATaskIsEditable;
 
+        public const string FAILED_SIGNUP_TASK_CLOSED = "Signup failed - Task is closed";
+        public const string FAILED_SIGNUP_EVENT_NOT_FOUND = "Signup failed - The event could not be found";
+        public const string FAILED_SIGNUP_TASK_NOT_FOUND = "Signup failed - The task could not be found";
+        public const string FAILED_SIGNUP_UNKOWN_ERROR = "Unkown error";
+
         public TaskApiController(IMediator mediator, IDetermineIfATaskIsEditable determineIfATaskIsEditable)
         {
             _mediator = mediator;
@@ -36,7 +41,7 @@ namespace AllReady.Controllers
             {
                 return HttpBadRequest("Should have found a matching event Id");
             }
-            
+
             var hasPermissions = _determineIfATaskIsEditable.For(User, allReadyTask);
             if (!hasPermissions)
             {
@@ -47,7 +52,7 @@ namespace AllReady.Controllers
             {
                 return HttpBadRequest();
             }
-            
+
             await _mediator.SendAsync(new AddTaskCommandAsync { AllReadyTask = allReadyTask });
 
             //http://stackoverflow.com/questions/1860645/create-request-with-post-which-response-codes-200-or-201-and-content
@@ -112,8 +117,43 @@ namespace AllReady.Controllers
                 return Json(new { errors = ModelState.GetErrorMessages() });
             }
 
-            var result = await _mediator.SendAsync(new TaskSignupCommand { TaskSignupModel = signupModel });
-            return Json(new { result.Status, Task = result.Task == null ? null : new TaskViewModel(result.Task, signupModel.UserId) });
+            var result = await _mediator.SendAsync(new TaskSignupCommandAsync { TaskSignupModel = signupModel });
+
+            switch (result.Status)
+            {
+                case TaskSignupResult.SUCCESS:
+                    return Json(new
+                    {
+                        isSuccess = true,
+                        task = result.Task == null ? null : new TaskViewModel(result.Task, signupModel.UserId)
+                    });
+
+                case TaskSignupResult.FAILURE_CLOSEDTASK:
+                    return Json(new {
+                        isSuccess = false,
+                        errors = new string[] { FAILED_SIGNUP_TASK_CLOSED },
+                    });
+
+                case TaskSignupResult.FAILURE_EVENTNOTFOUND:
+                    return Json(new
+                    {
+                        isSuccess = false,
+                        errors = new string[] { FAILED_SIGNUP_EVENT_NOT_FOUND },
+                    });
+
+                case TaskSignupResult.FAILURE_TASKNOTFOUND:
+                    return Json(new
+                    {
+                        isSuccess = false,
+                        errors = new string[] { FAILED_SIGNUP_TASK_NOT_FOUND },
+                    });
+
+                default:
+                    return Json(new {
+                        isSuccess = false,
+                        errors = new string[] { FAILED_SIGNUP_UNKOWN_ERROR },
+                    });
+            }
         }
 
         [HttpDelete("{id}/signup")]
@@ -161,7 +201,7 @@ namespace AllReady.Controllers
             {
                 return true;
             }
-            
+
             if (user.IsUserType(UserType.OrgAdmin))
             {
                 //TODO: Modify to check that user is organization admin for organization of task
@@ -177,7 +217,7 @@ namespace AllReady.Controllers
             {
                 return true;
             }
-            
+
             return false;
         }
     }

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/TaskSignupCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/TaskSignupCommand.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace AllReady.Features.Tasks
 {
-    public class TaskSignupCommand : IAsyncRequest<TaskSignupResult>
+    public class TaskSignupCommandAsync : IAsyncRequest<TaskSignupResult>
     {
         public EventSignupViewModel TaskSignupModel { get; set; }
     }

--- a/AllReadyApp/Web-App/AllReady/Features/Tasks/TaskSignupResult.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Tasks/TaskSignupResult.cs
@@ -4,6 +4,12 @@ namespace AllReady.Features.Tasks
 {
     public class TaskSignupResult
     {
+        // TODO - Move to enum
+        public const string FAILURE_CLOSEDTASK = "failure-taskclosed";
+        public const string SUCCESS = "success";
+        public const string FAILURE_EVENTNOTFOUND = "failure-eventnotfound";
+        public const string FAILURE_TASKNOTFOUND = "failure-tasknotfound";
+
         public string Status { get; set; }
         public AllReadyTask Task { get; set; }
     }

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyTask.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyTask.cs
@@ -25,5 +25,19 @@ namespace AllReady.Models
         public bool IsFull => NumberOfUsersSignedUp >= NumberOfVolunteersRequired;
         [NotMapped]
         public bool IsAllowSignups => !IsLimitVolunteers || !IsFull || IsAllowWaitList;
+
+        [NotMapped]
+        public bool IsClosed
+        {
+            get
+            {
+                if (EndDateTime.HasValue)
+                {
+                    return EndDateTime.Value.UtcDateTime < DateTimeOffset.UtcNow;
+                }
+
+                return false;
+            }
+        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/TaskViewModel.cs
@@ -63,7 +63,7 @@ namespace AllReady.ViewModels
                 AssignedVolunteers = new List<TaskSignupViewModel>();
 
                 if (IsUserSignedUpForTask)
-                {                    
+                {
                     foreach (var t in task.AssignedVolunteers.Where(au => au.User.Id == userId))
                     {
                         AssignedVolunteers.Add(new TaskSignupViewModel(t));
@@ -81,7 +81,7 @@ namespace AllReady.ViewModels
             NumberOfUsersSignedUp = task.NumberOfUsersSignedUp;
             IsLimitVolunteers = task.IsLimitVolunteers;
             IsAllowWaitList = task.IsAllowWaitList;
-
+            IsClosed = task.IsClosed;
         }
 
         public int Id { get; set; }
@@ -122,6 +122,8 @@ namespace AllReady.ViewModels
 
         public List<TaskSignupViewModel> AssignedVolunteers { get; set; } = new List<TaskSignupViewModel>();
 
+        public bool IsClosed { get; private set; } = false;
+     
         public int AcceptedVolunteerCount => AssignedVolunteers?.Where(v => v.Status == "Accepted").Count() ?? 0;
         public bool IsLimitVolunteers { get; set; } = true;
         public bool IsAllowWaitList { get; set; } = true;
@@ -168,7 +170,7 @@ namespace AllReady.ViewModels
             {
                 return null;
             }
-            
+
             var newTask = true;
             AllReadyTask dbtask;
             if (taskViewModel.Id == 0)

--- a/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
@@ -238,8 +238,8 @@
                                             <span class="task-datetime" data-bind="html: DisplayDateTime"></span><br />
                                         </div>
                                         <div class="btn-group">
-                                            <button class="btn btn-default" data-bind="visible: IsAllowSignups && $root.isSignedIn, click: $root.signupForTask , attr: { href: '#signup' }">Volunteer</button>
-                                            <button class="btn btn-default" data-bind="visible: IsAllowSignups && !$root.isSignedIn, click: $root.confirmGoToLogin , attr: { href: '#signup' }">Volunteer</button>
+                                            <button class="btn btn-default" data-bind="visible: !IsClosed && IsAllowSignups && $root.isSignedIn, click: $root.signupForTask , attr: { href: '#signup' }">Volunteer</button>
+                                            <button class="btn btn-default" data-bind="visible: !IsClosed && IsAllowSignups && !$root.isSignedIn, click: $root.confirmGoToLogin , attr: { href: '#signup' }">Volunteer</button>
                                         </div>
                                     </div>
                                 </div>

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/event.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/event.js
@@ -280,14 +280,14 @@
                 contentType: "application/x-www-form-urlencoded"
             }).done(function (result) {
                 self.isSubmitting(false);
-                switch (result.Status) {
-                    case "success":
+                switch (result.isSuccess) {
+                    case true:
                         if (isTaskSignup) {
-                            self.UpdatedTask = result.Task;
+                            self.UpdatedTask = result.task;
                         }
                         self.modal.close(self);
                         break;
-                    case "error":
+                    case false:
                         self.validationErrors(result.errors);
                         break;
                     default:


### PR DESCRIPTION
Fixes issue #719

NOTE: Must merge after PR #722 and PR #723 as it is based on the renaming exercise. I will need to rebase this if/when those are accepted.

Primarily I have hidden the volunteer buttons for tasks which are closed. In addition I have hardened the API and handler to fail if a closed task id is sent.

Changes made:
Added bool isClosed calculated property to the task model (not mapped)
Passed the isClosed value to the TaskViewModel
Used the isClosed property to hide the volunteer buttons for closed tasks
Updated TaskSignupHandler to check for closed tasks and issue error in result
Also added checks for Event and Task not found scenarios
Updated register method for TaskAPI to handle and output correct JSON for the various error responses
Added tests for all changes with expected behaviours