### PR TITLE
Adding task model validator

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/AllReady.UnitTest.xproj
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/AllReady.UnitTest.xproj
@@ -17,8 +17,5 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\AllReady.Models\AllReady.Models.csproj" />
-  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/EditTaskCommandHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/EditTaskCommandHandlerAsyncTests.cs
@@ -55,7 +55,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
         public async Task ModelIsCreated()
         {
             var sut = new EditTaskCommandHandlerAsync(Context);
-            var actual = await sut.Handle(new EditTaskCommandAsync { Task = new TaskEditModel { EventId = _queenAnne.Id, TimeZoneId = "Eastern Standard Time" } });
+            var actual = await sut.Handle(new EditTaskCommandAsync { Task = new TaskSummaryModel { EventId = _queenAnne.Id, TimeZoneId = "Eastern Standard Time" } });
             Assert.Equal(1, actual);
         }
     }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Models/Validators/TaskEditModelValidatorTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Models/Validators/TaskEditModelValidatorTests.cs
@@ -1,0 +1,154 @@
+﻿using AllReady.Areas.Admin.Models;
+using AllReady.Areas.Admin.Models.Validators;
+using AllReady.Features.Event;
+using AllReady.Models;
+using MediatR;
+using Moq;
+using System;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Models.Validators
+{
+    public class TaskSummaryModelValidatorTests
+    {
+        private readonly DateTimeOffset eventStartDate = new DateTimeOffset(new DateTime(2016, 1, 1));
+        private readonly DateTimeOffset eventEndDate = new DateTimeOffset(new DateTime(2020, 12, 31));
+
+        [Fact]
+        public void ReturnsCorrectErrorWhenEndDateTimeIsLessThanStartDateTime()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            mockMediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Id = 1, Campaign = new Campaign { TimeZoneId = "UTC" } });
+
+            var validator = new TaskSummaryModelValidator(mockMediator.Object);
+
+            var model = new TaskSummaryModel
+            {
+                StartDateTime = new DateTimeOffset(new DateTime(2000, 1, 1)),
+                EndDateTime = new DateTimeOffset(new DateTime(1999, 1, 1))
+            };
+
+            var errors = validator.Validate(model);
+
+            Assert.True(errors.Exists(x => x.Key.Equals("EndDateTime")));
+            Assert.Equal(errors.Find(x => x.Key == "EndDateTime").Value, "End date cannot be earlier than the start date");
+        }
+
+        [Fact]
+        public void ReturnsCorrectErrorWhenModelsStartDateTimeIsLessThanParentEventStartDate()
+        {
+            var validator = GetValidator();
+
+            var model = new TaskSummaryModel
+            {
+                StartDateTime = eventStartDate.AddDays(-10),
+                EndDateTime = eventEndDate.AddDays(-1)
+            };
+
+            var errors = validator.Validate(model);
+
+            Assert.True(errors.Exists(x => x.Key.Equals("StartDateTime")));
+            Assert.Equal(errors.Find(x => x.Key == "StartDateTime").Value, "Start date cannot be earlier than the event start date " + eventStartDate.ToString("d"));
+        }
+
+        [Fact]
+        public void ReturnsCorrectErrorWhenModelsEndDateTimeIsGreaterThanParentEventStartDate()
+        {
+            var validator = GetValidator();
+
+            var model = new TaskSummaryModel
+            {
+                StartDateTime = eventStartDate.AddDays(1),
+                EndDateTime = eventEndDate.AddDays(10)
+            };
+
+            var errors = validator.Validate(model);
+
+            Assert.True(errors.Exists(x => x.Key.Equals("EndDateTime")));
+            Assert.Equal(errors.Find(x => x.Key == "EndDateTime").Value, "End date cannot be later than the event end date " + eventEndDate.ToString("d"));
+        }
+
+        [Fact]
+        public void ReturnsCorrectErrorWhenItineraryTaskWithStartAndEndDatesNotOnSameDay()
+        {
+            var validator = GetValidator();
+
+            var model = new TaskSummaryModel
+            {
+                StartDateTime = new DateTimeOffset(new DateTime(1999, 12, 1)),
+                EndDateTime = new DateTimeOffset(new DateTime(2000, 12, 1))
+            };
+
+            var errors = validator.Validate(model);
+
+            Assert.True(errors.Exists(x => x.Key.Equals("EndDateTime")));
+            Assert.Equal(errors.Find(x => x.Key == "EndDateTime").Value, "For itinerary events the task end date must occur on the same day as the start date. Tasks cannot span multiple days");
+        }
+
+        [Fact]
+        public void ReturnsNoErrorForNonItineraryTaskWhenModelsDatesAreValid()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            mockMediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event
+            {
+                Id = 1,
+                Campaign = new Campaign
+                {
+                    TimeZoneId = "UTC",
+                },
+                StartDateTime = eventStartDate,
+                EndDateTime = eventEndDate,
+                EventType = EventTypes.EventManaged
+            });
+
+            var validator = new TaskSummaryModelValidator(mockMediator.Object);
+
+            var model = new TaskSummaryModel
+            {
+                StartDateTime = eventStartDate.AddDays(1),
+                EndDateTime = eventEndDate.AddDays(-1)
+            };
+
+            var errors = validator.Validate(model);
+
+            Assert.True(errors.Count == 0);
+        }
+
+        [Fact]
+        public void ReturnsNoErrorForItineraryTaskWhenModelsDatesAreValid()
+        {
+            var validator = GetValidator();
+
+            var model = new TaskSummaryModel
+            {
+                StartDateTime = eventStartDate.AddDays(1),
+                EndDateTime = eventStartDate.AddDays(1).AddHours(2),
+            };
+
+            var errors = validator.Validate(model);
+
+            Assert.True(errors.Count == 0);
+        }
+
+        private TaskSummaryModelValidator GetValidator()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            mockMediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event
+            {
+                Id = 1,
+                Campaign = new Campaign
+                {
+                    TimeZoneId = "UTC",
+                },
+                StartDateTime = eventStartDate,
+                EndDateTime = eventEndDate,
+                EventType = EventTypes.ItineraryManaged
+            });
+
+            return new TaskSummaryModelValidator(mockMediator.Object);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskControllerTests.cs
@@ -16,6 +16,7 @@ using AllReady.Areas.Admin.Features.Tasks;
 using System.Threading.Tasks;
 using AllReady.Features.Event;
 using AllReady.Extensions;
+using AllReady.Areas.Admin.Models.Validators;
 
 namespace AllReady.UnitTest.Controllers
 {
@@ -26,7 +27,8 @@ namespace AllReady.UnitTest.Controllers
         {
             const int eventId = 1;
             var mediator = new Mock<IMediator>();
-            var sut = new TaskController(mediator.Object);
+            var mockValidator = new Mock<ITaskSummaryModelValidator>();
+            var sut = new TaskController(mediator.Object, mockValidator.Object);
             sut.Create(eventId);
 
             mediator.Verify(x => x.Send(It.Is<EventByIdQuery>(y => y.EventId == eventId)), Times.Once);
@@ -35,7 +37,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void CreateGetReturnsHttpUnauthorizedResultWhenEventIsNull()
         {
-            var sut = new TaskController(Mock.Of<IMediator>());
+            var sut = new TaskController(Mock.Of<IMediator>(), Mock.Of<ITaskSummaryModelValidator>());
             var result = sut.Create(It.IsAny<int>());
 
             Assert.IsType<HttpUnauthorizedResult>(result);
@@ -45,9 +47,9 @@ namespace AllReady.UnitTest.Controllers
         public void CreateGetReturnsHttpUnauthorizedResultWhenUserIsNotOrganizationAdminForTheirOrganization()
         {
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = 1 }});
+            mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = 1 } });
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             sut.SetDefaultHttpContext();
 
             var result = sut.Create(It.IsAny<int>());
@@ -82,11 +84,11 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(campaignEvent);
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
             var result = sut.Create(It.IsAny<int>()) as ViewResult;
-            var modelResult = result.ViewData.Model as TaskEditModel;
+            var modelResult = result.ViewData.Model as TaskSummaryModel;
 
             Assert.Equal(modelResult.EventId, campaignEvent.Id);
             Assert.Equal(modelResult.EventName, campaignEvent.Name);
@@ -104,9 +106,9 @@ namespace AllReady.UnitTest.Controllers
             const int organizationId = 1;
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = organizationId }});
+            mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = organizationId } });
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
             var result = sut.Create(It.IsAny<int>()) as ViewResult;
@@ -117,7 +119,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void CreateGetHasHttpGetAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.Create(It.IsAny<int>())).OfType<HttpGetAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -125,38 +127,61 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void CreateGetHasRouteAttributeWithCorrectTemplate()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.Create(It.IsAny<int>())).OfType<RouteAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "Admin/Task/Create/{eventId}");
         }
 
         [Fact]
-        public async Task CreatePostAddsCorrectModelStateErrorWhenEndDateTimeIsLessThanStartDateTime()
+        public async Task CreatePostCallsValidateOnTaskSummaryModelValidator()
+        {
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { TimeZoneId = "Eastern Standard Time" } });
+
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>>());
+
+            var sut = new TaskController(mediator.Object, validator.Object);
+            sut.SetFakeUserType(UserType.OrgAdmin);
+
+            await sut.Create(It.IsAny<int>(), new TaskSummaryModel { OrganizationId = 1 });
+
+            validator.Verify(x => x.Validate(It.IsAny<TaskSummaryModel>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreatePostAddsCorrectModelStateErrorWhenValidatorReturnsError()
         {
             var mediator = new Mock<IMediator>();
             //mgmccarthy: for a list of time zone's to feed to TimeZoneInfo.FindSystemTimeZoneById, check here:
             //http://stackoverflow.com/questions/7908343/list-of-timezone-ids-for-use-with-findtimezonebyid-in-c
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { TimeZoneId = "Eastern Standard Time" } });
 
-            var sut = new TaskController(mediator.Object);
-            await sut.Create(It.IsAny<int>(), new TaskEditModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1) });
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>(nameof(TaskSummaryModel.EndDateTime), "Ending time cannot be earlier than the starting time") });
 
-            var modelStateErrorCollection = sut.ModelState.GetErrorMessagesByKey(nameof(TaskEditModel.EndDateTime));
+            var sut = new TaskController(mediator.Object, validator.Object);
+            await sut.Create(It.IsAny<int>(), new TaskSummaryModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1) });
+
+            var modelStateErrorCollection = sut.ModelState.GetErrorMessagesByKey(nameof(TaskSummaryModel.EndDateTime));
             Assert.Equal(modelStateErrorCollection.Single().ErrorMessage, "Ending time cannot be earlier than the starting time");
         }
 
         [Fact]
-        public async Task CreatePostReturnsCorrectViewAndViewModelWhenEndDateTimeIsLessThanStartDateTimeAndModelStateIsInvalid()
+        public async Task CreatePostReturnsCorrectViewAndViewModelWhenValidatorReturnsError()
         {
-            var model = new TaskEditModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1) };
+            var model = new TaskSummaryModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1) };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { TimeZoneId = "Eastern Standard Time" } });
 
-            var sut = new TaskController(mediator.Object);
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>(nameof(TaskSummaryModel.EndDateTime), "Ending time cannot be earlier than the starting time") });
+
+            var sut = new TaskController(mediator.Object, validator.Object);
             var result = await sut.Create(It.IsAny<int>(), model) as ViewResult;
-            var modelResult = result.ViewData.Model as TaskEditModel;
+            var modelResult = result.ViewData.Model as TaskSummaryModel;
 
             Assert.IsType<ViewResult>(result);
             Assert.Equal(modelResult, model);
@@ -167,7 +192,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var startDateTime = DateTimeOffset.Now.AddDays(-1);
             var endDateTime = DateTimeOffset.Now.AddDays(1);
-            var model = new TaskEditModel { StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = 1 };
+            var model = new TaskSummaryModel { StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = 1 };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event
@@ -177,7 +202,10 @@ namespace AllReady.UnitTest.Controllers
                 EndDateTime = endDateTime.AddDays(1)
             });
 
-            var sut = new TaskController(mediator.Object);
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>>());
+
+            var sut = new TaskController(mediator.Object, validator.Object);
             sut.SetDefaultHttpContext();
 
             var result = await sut.Create(It.IsAny<int>(), model);
@@ -193,7 +221,7 @@ namespace AllReady.UnitTest.Controllers
             var startDateTime = DateTimeOffset.Now.AddDays(-1);
             var endDateTime = DateTimeOffset.Now.AddDays(1);
 
-            var model = new TaskEditModel { StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = organizationId };
+            var model = new TaskSummaryModel { StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = organizationId };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event
@@ -204,7 +232,10 @@ namespace AllReady.UnitTest.Controllers
             });
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskSummaryModel);
 
-            var sut = new TaskController(mediator.Object);
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>>());
+
+            var sut = new TaskController(mediator.Object, validator.Object);
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
             await sut.Create(It.IsAny<int>(), model);
@@ -219,8 +250,8 @@ namespace AllReady.UnitTest.Controllers
             var taskSummaryModel = new TaskSummaryModel { OrganizationId = organizationId };
             var startDateTime = DateTimeOffset.Now.AddDays(-1);
             var endDateTime = DateTimeOffset.Now.AddDays(1);
-            const int taskEditModelId = 1;
-            var model = new TaskEditModel { Id = taskEditModelId, StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = organizationId };
+            const int TaskSummaryModelId = 1;
+            var model = new TaskSummaryModel { Id = TaskSummaryModelId, StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = organizationId };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event
@@ -233,10 +264,13 @@ namespace AllReady.UnitTest.Controllers
 
             var routeValues = new Dictionary<string, object> { ["id"] = model.Id };
 
-            var sut = new TaskController(mediator.Object);
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>>());
+
+            var sut = new TaskController(mediator.Object, validator.Object);
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
-            var result = await sut.Create(taskEditModelId, model) as RedirectToActionResult;
+            var result = await sut.Create(TaskSummaryModelId, model) as RedirectToActionResult;
 
             Assert.Equal(result.ActionName, nameof(TaskController.Details));
             Assert.Equal(result.ControllerName, "Event");
@@ -246,16 +280,16 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void CreatePostHasHttpGetAttribute()
         {
-            var sut = new TaskController(null);
-            var attribute = sut.GetAttributesOn(x => x.Create(It.IsAny<int>(), It.IsAny<TaskEditModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
+            var attribute = sut.GetAttributesOn(x => x.Create(It.IsAny<int>(), It.IsAny<TaskSummaryModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
 
         [Fact]
         public void CreatePostHasRouteAttributeWithCorrectTemplate()
         {
-            var sut = new TaskController(null);
-            var attribute = sut.GetAttributesOn(x => x.Create(It.IsAny<int>(), It.IsAny<TaskEditModel>())).OfType<RouteAttribute>().SingleOrDefault();
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
+            var attribute = sut.GetAttributesOn(x => x.Create(It.IsAny<int>(), It.IsAny<TaskSummaryModel>())).OfType<RouteAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "Admin/Task/Create/{eventId}");
         }
@@ -266,7 +300,7 @@ namespace AllReady.UnitTest.Controllers
             const int taskId = 1;
             var mediator = new Mock<IMediator>();
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             await sut.Edit(taskId);
 
             mediator.Verify(x => x.SendAsync(It.Is<EditTaskQueryAsync>(y => y.TaskId == taskId)), Times.Once);
@@ -275,7 +309,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task EditGetReturnsHttpNotFoundResultWhenTaskIsNull()
         {
-            var sut = new TaskController(Mock.Of<IMediator>());
+            var sut = new TaskController(Mock.Of<IMediator>(), Mock.Of<ITaskSummaryModelValidator>());
             var result = await sut.Edit(It.IsAny<int>());
 
             Assert.IsType<HttpNotFoundResult>(result);
@@ -285,9 +319,9 @@ namespace AllReady.UnitTest.Controllers
         public async Task EditGetReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
         {
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<EditTaskQueryAsync>())).ReturnsAsync(new TaskEditModel());
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditTaskQueryAsync>())).ReturnsAsync(new TaskSummaryModel());
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             sut.SetDefaultHttpContext();
             var result = await sut.Edit(It.IsAny<int>());
 
@@ -298,26 +332,26 @@ namespace AllReady.UnitTest.Controllers
         public async Task EditGetReturnsCorrectViewModelAndView()
         {
             const int organizationId = 1;
-            var taskEditModel = new TaskEditModel { OrganizationId = organizationId };
+            var TaskSummaryModel = new TaskSummaryModel { OrganizationId = organizationId };
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<EditTaskQueryAsync>())).ReturnsAsync(taskEditModel);
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditTaskQueryAsync>())).ReturnsAsync(TaskSummaryModel);
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
             var result = await sut.Edit(It.IsAny<int>()) as ViewResult;
-            var modelResult = result.ViewData.Model as TaskEditModel;
+            var modelResult = result.ViewData.Model as TaskSummaryModel;
 
             Assert.IsType<ViewResult>(result);
-            Assert.IsType<TaskEditModel>(modelResult);
-            Assert.Equal(modelResult, taskEditModel);
+            Assert.IsType<TaskSummaryModel>(modelResult);
+            Assert.Equal(modelResult, TaskSummaryModel);
         }
 
         [Fact]
         public void EditGetHasHttpGetAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.Edit(It.IsAny<int>())).OfType<HttpGetAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -325,36 +359,62 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void EditGetHasRouteAttributeWithCorrectTemplate()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.Edit(It.IsAny<int>())).OfType<RouteAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "Admin/Task/Edit/{id}");
         }
 
         [Fact]
-        public async Task EditPostAddsCorrectModelStateErrorWhenEndDateTimeIsLessThanStartDateTime()
+        public async Task EditPostCallsValidateOnTaskSummaryModelValidator()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { TimeZoneId = "Eastern Standard Time" } });
 
-            var sut = new TaskController(mediator.Object);
-            await sut.Edit(new TaskEditModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1)});
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>>());
 
-            var modelStateErrorCollection = sut.ModelState.GetErrorMessagesByKey(nameof(TaskEditModel.EndDateTime));
+            var sut = new TaskController(mediator.Object, validator.Object);
+            sut.SetFakeUserType(UserType.OrgAdmin);
+
+            await sut.Edit(new TaskSummaryModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1), OrganizationId = 1 });
+
+            validator.Verify(x => x.Validate(It.IsAny<TaskSummaryModel>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task EditPostAddsCorrectModelStateErrorWhenValidatorReturnsError()
+        {
+            var model = new TaskSummaryModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1) };
+
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { TimeZoneId = "Eastern Standard Time" } });
+
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>(nameof(TaskSummaryModel.EndDateTime), "Ending time cannot be earlier than the starting time") });
+
+            var sut = new TaskController(mediator.Object, validator.Object);
+            var result = await sut.Edit(model) as ViewResult;
+            var modelResult = result.ViewData.Model as TaskSummaryModel;
+
+            var modelStateErrorCollection = sut.ModelState.GetErrorMessagesByKey(nameof(TaskSummaryModel.EndDateTime));
             Assert.Equal(modelStateErrorCollection.Single().ErrorMessage, "Ending time cannot be earlier than the starting time");
         }
 
         [Fact]
-        public async Task EditPostReturnsCorrectViewAndViewModelWhenEndDateTimeIsLessThanStartDateTimeAndModelStateIsInvalid()
+        public async Task EditPostReturnsCorrectViewAndViewModelWhenValidatorReturnsError()
         {
-            var model = new TaskEditModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1) };
+            var model = new TaskSummaryModel { EndDateTime = DateTimeOffset.Now.AddDays(-1), StartDateTime = DateTimeOffset.Now.AddDays(1) };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { TimeZoneId = "Eastern Standard Time" } });
 
-            var sut = new TaskController(mediator.Object);
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>(nameof(TaskSummaryModel.EndDateTime), "Ending time cannot be earlier than the starting time") });
+
+            var sut = new TaskController(mediator.Object, validator.Object);
             var result = await sut.Edit(model) as ViewResult;
-            var modelResult = result.ViewData.Model as TaskEditModel;
+            var modelResult = result.ViewData.Model as TaskSummaryModel;
 
             Assert.IsType<ViewResult>(result);
             Assert.Equal(modelResult, model);
@@ -365,7 +425,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var startDateTime = DateTimeOffset.Now.AddDays(-1);
             var endDateTime = DateTimeOffset.Now.AddDays(1);
-            var model = new TaskEditModel { StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = 1 };
+            var model = new TaskSummaryModel { StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = 1 };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event
@@ -375,7 +435,10 @@ namespace AllReady.UnitTest.Controllers
                 EndDateTime = endDateTime.AddDays(1)
             });
 
-            var sut = new TaskController(mediator.Object);
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>>());
+
+            var sut = new TaskController(mediator.Object, validator.Object);
             sut.SetDefaultHttpContext();
 
             var result = await sut.Edit(model);
@@ -391,16 +454,21 @@ namespace AllReady.UnitTest.Controllers
             var startDateTime = DateTimeOffset.Now.AddDays(-1);
             var endDateTime = DateTimeOffset.Now.AddDays(1);
 
-            var model = new TaskEditModel { StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = organizationId };
+            var model = new TaskSummaryModel { StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = organizationId };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event
             {
-                Campaign = new Campaign { TimeZoneId = "Eastern Standard Time" }, StartDateTime = startDateTime.AddDays(-1), EndDateTime = endDateTime.AddDays(1)
+                Campaign = new Campaign { TimeZoneId = "Eastern Standard Time" },
+                StartDateTime = startDateTime.AddDays(-1),
+                EndDateTime = endDateTime.AddDays(1)
             });
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskSummaryModel);
 
-            var sut = new TaskController(mediator.Object);
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>>());
+
+            var sut = new TaskController(mediator.Object, validator.Object);
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
             await sut.Edit(model);
@@ -415,7 +483,7 @@ namespace AllReady.UnitTest.Controllers
             var taskSummaryModel = new TaskSummaryModel { OrganizationId = organizationId };
             var startDateTime = DateTimeOffset.Now.AddDays(-1);
             var endDateTime = DateTimeOffset.Now.AddDays(1);
-            var model = new TaskEditModel { Id = 1, StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = organizationId };
+            var model = new TaskSummaryModel { Id = 1, StartDateTime = startDateTime, EndDateTime = endDateTime, OrganizationId = organizationId };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event
@@ -426,12 +494,15 @@ namespace AllReady.UnitTest.Controllers
             });
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskSummaryModel);
 
-            var sut = new TaskController(mediator.Object);
+            var validator = new Mock<ITaskSummaryModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<TaskSummaryModel>())).Returns(new List<KeyValuePair<string, string>>());
+
+            var sut = new TaskController(mediator.Object, validator.Object);
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
             var result = await sut.Edit(model) as RedirectToActionResult;
 
-            var routeValues = new Dictionary<string, object>{ ["id"] = model.Id };
+            var routeValues = new Dictionary<string, object> { ["id"] = model.Id };
 
             Assert.Equal(result.ControllerName, "Task");
             Assert.Equal(result.ActionName, nameof(TaskController.Details));
@@ -441,16 +512,16 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void EditPostHasHttpPostAttribute()
         {
-            var sut = new TaskController(null);
-            var attribute = sut.GetAttributesOn(x => x.Edit(It.IsAny<TaskEditModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
+            var attribute = sut.GetAttributesOn(x => x.Edit(It.IsAny<TaskSummaryModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
 
         [Fact]
         public void EditPostHasValidateAntiForgeryTokenAttribute()
         {
-            var sut = new TaskController(null);
-            var attribute = sut.GetAttributesOn(x => x.Edit(It.IsAny<TaskEditModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
+            var attribute = sut.GetAttributesOn(x => x.Edit(It.IsAny<TaskSummaryModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
 
@@ -459,7 +530,7 @@ namespace AllReady.UnitTest.Controllers
         {
             const int taskId = 1;
             var mediator = new Mock<IMediator>();
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             await sut.Delete(taskId);
 
             mediator.Verify(x => x.SendAsync(It.Is<TaskQueryAsync>(y => y.TaskId == taskId)), Times.Once);
@@ -468,7 +539,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task DeleteReturnsHttpNotFoundResultWhenTaskIsNull()
         {
-            var sut = new TaskController(Mock.Of<IMediator>());
+            var sut = new TaskController(Mock.Of<IMediator>(), Mock.Of<ITaskSummaryModelValidator>());
             var result = await sut.Delete(It.IsAny<int>());
             Assert.IsType<HttpNotFoundResult>(result);
         }
@@ -479,7 +550,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(new TaskSummaryModel());
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             sut.SetDefaultHttpContext();
             var result = await sut.Delete(It.IsAny<int>());
 
@@ -495,7 +566,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskSummaryModel);
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
             var result = await sut.Delete(It.IsAny<int>()) as ViewResult;
@@ -511,7 +582,7 @@ namespace AllReady.UnitTest.Controllers
         {
             const int taskId = 1;
             var mediator = new Mock<IMediator>();
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             await sut.Details(taskId);
 
             mediator.Verify(x => x.SendAsync(It.Is<TaskQueryAsync>(y => y.TaskId == taskId)), Times.Once);
@@ -520,7 +591,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task DetailsReturnsHttpNotFoundResultWhenTaskIsNull()
         {
-            var sut = new TaskController(Mock.Of<IMediator>());
+            var sut = new TaskController(Mock.Of<IMediator>(), Mock.Of<ITaskSummaryModelValidator>());
             var result = await sut.Details(It.IsAny<int>());
             Assert.IsType<HttpNotFoundResult>(result);
         }
@@ -533,7 +604,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskSummaryModel);
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             var result = await sut.Details(It.IsAny<int>()) as ViewResult;
             var modelResult = result.ViewData.Model as TaskSummaryModel;
 
@@ -545,7 +616,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void DetailsHasHttpGetAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.Details(It.IsAny<int>())).OfType<HttpGetAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -553,7 +624,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void DetailsHasRouteAttributeWithCorrectTemplate()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.Details(It.IsAny<int>())).OfType<RouteAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Template, "Admin/Task/Details/{id}");
@@ -564,7 +635,7 @@ namespace AllReady.UnitTest.Controllers
         {
             const int taskId = 1;
             var mediator = new Mock<IMediator>();
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             await sut.DeleteConfirmed(taskId);
 
             mediator.Verify(x => x.SendAsync(It.Is<TaskQueryAsync>(y => y.TaskId == taskId)), Times.Once);
@@ -573,7 +644,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task DeleteConfirmedReturnsHttpNotFoundResultWhenTaskSummaryModelIsNull()
         {
-            var sut = new TaskController(Mock.Of<IMediator>());
+            var sut = new TaskController(Mock.Of<IMediator>(), Mock.Of<ITaskSummaryModelValidator>());
             var result = await sut.DeleteConfirmed(It.IsAny<int>());
             Assert.IsType<HttpNotFoundResult>(result);
         }
@@ -584,7 +655,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(new TaskSummaryModel());
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             sut.SetDefaultHttpContext();
 
             var result = await sut.DeleteConfirmed(It.IsAny<int>());
@@ -601,7 +672,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(new TaskSummaryModel { OrganizationId = 1 });
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
             await sut.DeleteConfirmed(taskId);
 
@@ -618,7 +689,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskSummaryModel);
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
             var result = await sut.DeleteConfirmed(taskId) as RedirectToActionResult;
 
@@ -632,14 +703,14 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void DeleteConfirmedHasHttpPostAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.DeleteConfirmed(It.IsAny<int>())).OfType<HttpPostAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
-  
+
         public void DeleteConfirmedHasActionNameAttributeWithCorrectActionName()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.DeleteConfirmed(It.IsAny<int>())).OfType<ActionNameAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Name, "Delete");
@@ -648,7 +719,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void DeleteConfirmedHasValidateAntiForgeryTokenAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.DeleteConfirmed(It.IsAny<int>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -663,7 +734,7 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = 1 } });
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskModelSummary);
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             sut.SetDefaultHttpContext();
             await sut.Assign(taskId, null);
 
@@ -679,7 +750,7 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskModelSummary);
             mediator.Setup(x => x.Send(It.IsAny<EventByIdQuery>())).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = 1 } });
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             sut.SetDefaultHttpContext();
             var result = await sut.Assign(1, null);
 
@@ -696,9 +767,9 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskModelSummary);
-            mediator.Setup(x => x.Send(It.Is<EventByIdQuery>(y => y.EventId == taskModelSummary.EventId))).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = organizationId }});
+            mediator.Setup(x => x.Send(It.Is<EventByIdQuery>(y => y.EventId == taskModelSummary.EventId))).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = organizationId } });
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
             await sut.Assign(taskId, userIds);
 
@@ -716,7 +787,7 @@ namespace AllReady.UnitTest.Controllers
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(taskModelSummary);
             mediator.Setup(x => x.Send(It.Is<EventByIdQuery>(y => y.EventId == taskModelSummary.EventId))).Returns(new Event { Campaign = new Campaign { ManagingOrganizationId = organizationId } });
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
 
             var result = await sut.Assign(taskId, null) as RedirectToRouteResult;
@@ -730,7 +801,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void AssignHasHttpPostAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.Assign(It.IsAny<int>(), It.IsAny<List<string>>())).OfType<HttpPostAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -738,7 +809,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void AssignHasValidateAntiForgeryTokenAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.Assign(It.IsAny<int>(), It.IsAny<List<string>>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -746,7 +817,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task MessageAllVolunteersReturnsBadRequestObjectResultWhenModelStateIsInvalid()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             sut.AddModelStateError();
             var result = await sut.MessageAllVolunteers(It.IsAny<MessageTaskVolunteersModel>());
             Assert.IsType<BadRequestObjectResult>(result);
@@ -758,7 +829,7 @@ namespace AllReady.UnitTest.Controllers
             var model = new MessageTaskVolunteersModel { TaskId = 1 };
             var mediator = new Mock<IMediator>();
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             await sut.MessageAllVolunteers(model);
 
             mediator.Verify(x => x.SendAsync(It.Is<TaskQueryAsync>(y => y.TaskId == model.TaskId)), Times.Once);
@@ -769,7 +840,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var mediator = new Mock<IMediator>();
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             var result = await sut.MessageAllVolunteers(new MessageTaskVolunteersModel());
 
             Assert.IsType<HttpNotFoundResult>(result);
@@ -781,7 +852,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(new TaskSummaryModel());
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             sut.SetDefaultHttpContext();
             var result = await sut.MessageAllVolunteers(new MessageTaskVolunteersModel());
 
@@ -797,11 +868,11 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(new TaskSummaryModel { OrganizationId = organizationId });
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
             await sut.MessageAllVolunteers(model);
 
-            mediator.Verify(x => x.SendAsync(It.Is<MessageTaskVolunteersCommandAsync>(y => y.Model ==  model)), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.Is<MessageTaskVolunteersCommandAsync>(y => y.Model == model)), Times.Once);
         }
 
         [Fact]
@@ -812,7 +883,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<TaskQueryAsync>())).ReturnsAsync(new TaskSummaryModel { OrganizationId = organizationId });
 
-            var sut = new TaskController(mediator.Object);
+            var sut = new TaskController(mediator.Object, Mock.Of<ITaskSummaryModelValidator>());
             MakeUserOrganizationAdminUser(sut, organizationId.ToString());
             var result = await sut.MessageAllVolunteers(new MessageTaskVolunteersModel());
 
@@ -822,7 +893,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void MessageAllVolunteersHasHttpPostAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.MessageAllVolunteers(It.IsAny<MessageTaskVolunteersModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -830,7 +901,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void MessageAllVolunteersHasValidateAntiForgeryTokenAttribute()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributesOn(x => x.MessageAllVolunteers(It.IsAny<MessageTaskVolunteersModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
         }
@@ -838,7 +909,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void ControllerHasAreaAtttributeWithTheCorrectAreaName()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             sut.SetDefaultHttpContext();
             var attribute = sut.GetAttributes().OfType<AreaAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
@@ -848,7 +919,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void ControllerHasAuthorizeAtttributeWithTheCorrectPolicy()
         {
-            var sut = new TaskController(null);
+            var sut = new TaskController(null, Mock.Of<ITaskSummaryModelValidator>());
             var attribute = sut.GetAttributes().OfType<AuthorizeAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
             Assert.Equal(attribute.Policy, "OrgAdmin");

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/TaskController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/TaskController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Tasks;
 using AllReady.Areas.Admin.Models;
@@ -9,6 +8,8 @@ using AllReady.Security;
 using MediatR;
 using Microsoft.AspNet.Authorization;
 using Microsoft.AspNet.Mvc;
+using AllReady.Areas.Admin.Models.Validators;
+using System.Linq;
 
 namespace AllReady.Areas.Admin.Controllers
 {
@@ -17,10 +18,12 @@ namespace AllReady.Areas.Admin.Controllers
     public class TaskController : Controller
     {
         private readonly IMediator _mediator;
+        private readonly ITaskSummaryModelValidator _taskDetailModelValidator;
 
-        public TaskController(IMediator mediator)
+        public TaskController(IMediator mediator, ITaskSummaryModelValidator taskDetailModelValidator)
         {
             _mediator = mediator;
+            _taskDetailModelValidator = taskDetailModelValidator;
         }
 
         [HttpGet]
@@ -33,10 +36,10 @@ namespace AllReady.Areas.Admin.Controllers
                 return HttpUnauthorized();
             }
             
-            var viewModel = new TaskEditModel
+            var viewModel = new TaskSummaryModel
             {
                 EventId = campaignEvent.Id,
-                EventName = campaignEvent.Name,
+                EventName = campaignEvent.Name,                
                 CampaignId = campaignEvent.CampaignId,
                 CampaignName = campaignEvent.Campaign.Name,
                 OrganizationId = campaignEvent.Campaign.ManagingOrganizationId,
@@ -51,14 +54,11 @@ namespace AllReady.Areas.Admin.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [Route("Admin/Task/Create/{eventId}")]
-        public async Task<IActionResult> Create(int eventId, TaskEditModel model)
+        public async Task<IActionResult> Create(int eventId, TaskSummaryModel model)
         {
-            if (model.EndDateTime < model.StartDateTime)
-            {
-                ModelState.AddModelError(nameof(model.EndDateTime), "Ending time cannot be earlier than the starting time");
-            }
-            
-            WarnDateTimeOutOfRange(ref model);
+            var errors = _taskDetailModelValidator.Validate(model);
+
+            errors.ToList().ForEach(e => ModelState.AddModelError(e.Key, e.Value));
 
             if (ModelState.IsValid)
             {
@@ -78,14 +78,11 @@ namespace AllReady.Areas.Admin.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(TaskEditModel model)
+        public async Task<IActionResult> Edit(TaskSummaryModel model)
         {
-            if (model.EndDateTime < model.StartDateTime)
-            {
-                ModelState.AddModelError(nameof(model.EndDateTime), "Ending time cannot be earlier than the starting time");
-            }
-            
-            WarnDateTimeOutOfRange(ref model);
+            var errors = _taskDetailModelValidator.Validate(model);
+
+            errors.ToList().ForEach(e => ModelState.AddModelError(e.Key, e.Value));
 
             if (ModelState.IsValid)
             {
@@ -212,40 +209,6 @@ namespace AllReady.Areas.Admin.Controllers
             await _mediator.SendAsync(new MessageTaskVolunteersCommandAsync { Model = model });
 
             return Ok();
-        }
-
-        private void WarnDateTimeOutOfRange(ref TaskEditModel model)
-        {
-            if (model.StartDateTime.HasValue || model.EndDateTime.HasValue)
-            {
-                var campaignEvent = GetEventBy(model.EventId);
-                var timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(campaignEvent.Campaign.TimeZoneId);
-
-                DateTimeOffset? convertedStartDateTime = null;
-                if (model.StartDateTime.HasValue)
-                {
-                    var startDateValue = model.StartDateTime.Value;
-                    var startDateTimeOffset = timeZoneInfo.GetUtcOffset(startDateValue);
-                    convertedStartDateTime = new DateTimeOffset(startDateValue.Year, startDateValue.Month, startDateValue.Day, startDateValue.Hour, startDateValue.Minute, 0, startDateTimeOffset);
-                }
-
-                DateTimeOffset? convertedEndDateTime = null;
-                if (model.EndDateTime.HasValue)
-                {
-                    var endDateValue = model.EndDateTime.Value;
-                    var endDateTimeOffset = timeZoneInfo.GetUtcOffset(endDateValue);
-                    convertedEndDateTime = new DateTimeOffset(endDateValue.Year, endDateValue.Month, endDateValue.Day, endDateValue.Hour, endDateValue.Minute, 0, endDateTimeOffset);
-                }
-
-                if ((convertedStartDateTime < campaignEvent.StartDateTime || convertedEndDateTime > campaignEvent.EndDateTime) &&
-                    (model.IgnoreTimeRangeWarning == false))
-                {
-                    ModelState.AddModelError("", "Although valid, task time is out of range for event time from " +
-                        campaignEvent.StartDateTime.DateTime.ToString("g") + " to " + campaignEvent.EndDateTime.DateTime.ToString("g") + " " + campaignEvent.Campaign.TimeZoneId);
-                    ModelState.Remove("IgnoreTimeRangeWarning");
-                    model.IgnoreTimeRangeWarning = true;
-                }
-            }
         }
 
         //mgmccarthy: mediator query and handler need to be changed to async when Issue #622 is addressed

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/EditTaskCommandAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/EditTaskCommandAsync.cs
@@ -5,6 +5,6 @@ namespace AllReady.Areas.Admin.Features.Tasks
 {
     public class EditTaskCommandAsync : IAsyncRequest<int>
     {
-        public TaskEditModel Task {get; set;}
+        public TaskSummaryModel Task {get; set;}
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/EditTaskQueryAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/EditTaskQueryAsync.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Tasks
 {
-    public class EditTaskQueryAsync : IAsyncRequest<TaskEditModel>
+    public class EditTaskQueryAsync : IAsyncRequest<TaskSummaryModel>
     {
         public int TaskId { get; set; }
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/EditTaskQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/EditTaskQueryHandlerAsync.cs
@@ -6,7 +6,7 @@ using Microsoft.Data.Entity;
 
 namespace AllReady.Areas.Admin.Features.Tasks
 {
-    public class EditTaskQueryHandlerAsync : IAsyncRequestHandler<EditTaskQueryAsync, TaskEditModel>
+    public class EditTaskQueryHandlerAsync : IAsyncRequestHandler<EditTaskQueryAsync, TaskSummaryModel>
     {
         private AllReadyContext _context;
 
@@ -15,14 +15,14 @@ namespace AllReady.Areas.Admin.Features.Tasks
             _context = context;
         }
 
-        public async Task<TaskEditModel> Handle(EditTaskQueryAsync message)
+        public async Task<TaskSummaryModel> Handle(EditTaskQueryAsync message)
         {
             var task = await _context.Tasks.AsNoTracking()
                 .Include(t => t.Event).ThenInclude(a => a.Campaign)
                 .Include(t => t.RequiredSkills).ThenInclude(ts => ts.Skill)
                 .SingleOrDefaultAsync(t => t.Id == message.TaskId);
 
-            var viewModel = new TaskEditModel
+            var viewModel = new TaskSummaryModel
             {
                 Id = task.Id,
                 EventId = task.Event.Id,

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/TaskEditModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/TaskEditModel.cs
@@ -1,7 +1,0 @@
-﻿namespace AllReady.Areas.Admin.Models
-{
-    public class TaskEditModel : TaskSummaryModel
-    {
-        public bool IgnoreTimeRangeWarning { get; set; }
-    }
-}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/TaskEditModelValidator.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/TaskEditModelValidator.cs
@@ -1,0 +1,86 @@
+﻿using AllReady.Features.Event;
+using AllReady.Models;
+using MediatR;
+using System;
+using System.Collections.Generic;
+
+namespace AllReady.Areas.Admin.Models.Validators
+{
+    public class TaskSummaryModelValidator : ITaskSummaryModelValidator
+    {
+        private readonly IMediator _mediator;
+
+        public TaskSummaryModelValidator(IMediator mediator)
+        {
+            if (mediator == null)
+            {
+                throw new ArgumentNullException(nameof(mediator));
+            }
+
+            _mediator = mediator;
+        }
+
+        public List<KeyValuePair<string, string>> Validate(TaskSummaryModel model)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+
+            if (model.StartDateTime.HasValue || model.EndDateTime.HasValue)
+            {
+                var campaignEvent = _mediator.Send(new EventByIdQuery { EventId = model.EventId });
+
+                var timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(campaignEvent.Campaign.TimeZoneId);
+
+                // sgordon: Date time conversion seems overly complex and may be refactored per #710
+                DateTimeOffset? convertedStartDateTime = null;
+                if (model.StartDateTime.HasValue)
+                {
+                    var startDateValue = model.StartDateTime.Value;
+                    var startDateTimeOffset = timeZoneInfo.GetUtcOffset(startDateValue);
+                    convertedStartDateTime = new DateTimeOffset(startDateValue.Year, startDateValue.Month, startDateValue.Day, startDateValue.Hour, startDateValue.Minute, 0, startDateTimeOffset);
+                }
+
+                DateTimeOffset? convertedEndDateTime = null;
+                if (model.EndDateTime.HasValue)
+                {
+                    var endDateValue = model.EndDateTime.Value;
+                    var endDateTimeOffset = timeZoneInfo.GetUtcOffset(endDateValue);
+                    convertedEndDateTime = new DateTimeOffset(endDateValue.Year, endDateValue.Month, endDateValue.Day, endDateValue.Hour, endDateValue.Minute, 0, endDateTimeOffset);
+                }
+
+                // Rule - End date cannot be earlier than start date
+                if (convertedStartDateTime.HasValue && convertedEndDateTime.HasValue && convertedEndDateTime.Value < convertedStartDateTime.Value)
+                {
+                    result.Add(new KeyValuePair<string, string>(nameof(model.EndDateTime), "End date cannot be earlier than the start date"));
+                }
+
+                // Rule - Start date cannot be out of range of parent event
+                if (convertedStartDateTime.HasValue && convertedStartDateTime < campaignEvent.StartDateTime)
+                {
+                    result.Add(new KeyValuePair<string, string>(nameof(model.StartDateTime), "Start date cannot be earlier than the event start date " + campaignEvent.StartDateTime.ToString("d")));
+                }
+
+                // Rule - End date cannot be out of range of parent event
+                if (convertedEndDateTime.HasValue && convertedEndDateTime > campaignEvent.EndDateTime)
+                {
+                    result.Add(new KeyValuePair<string, string>(nameof(model.EndDateTime), "End date cannot be later than the event end date " + campaignEvent.EndDateTime.ToString("d")));
+                }
+
+                // Rule - Itinerary tasks must start and end on same calendar day
+                if (campaignEvent.EventType == EventTypes.ItineraryManaged && convertedStartDateTime.HasValue && convertedEndDateTime.HasValue)
+                {
+                    if (convertedStartDateTime.Value.Date != convertedEndDateTime.Value.Date)
+                    {
+                        result.Add(new KeyValuePair<string, string>(nameof(model.EndDateTime), "For itinerary events the task end date must occur on the same day as the start date. Tasks cannot span multiple days"));
+                    }
+                }
+            }
+
+            return result;
+        }
+    }
+
+    public interface ITaskSummaryModelValidator
+    {
+        List<KeyValuePair<string, string>> Validate(TaskSummaryModel model);
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@model TaskEditModel
+﻿@model TaskSummaryModel
 @inject AllReady.Services.ISelectListService SelectListService
 
 @{
@@ -47,7 +47,6 @@
         <input type="hidden" asp-for="TimeZoneId" />
         <input type="hidden" asp-for="CampaignName" />
         <input type="hidden" asp-for="OrganizationId" />
-        <input type="hidden" asp-for="IgnoreTimeRangeWarning" />
         <div class="form-group">
             <label asp-for="CampaignName" class="control-label col-md-2"></label>
             <div class="col-md-10">

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -116,6 +116,7 @@ namespace AllReady
             services.AddTransient<IAllReadyDataAccess, AllReadyDataAccessEF7>();
             services.AddTransient<IDetermineIfATaskIsEditable, DetermineIfATaskIsEditable>();
             services.AddTransient<IValidateEventDetailModels, EventDetailModelValidator>();
+            services.AddTransient<ITaskSummaryModelValidator, TaskSummaryModelValidator>();
             services.AddSingleton<IImageService, ImageService>();
             //services.AddSingleton<GeoService>();
             services.AddTransient<SampleDataGenerator>();


### PR DESCRIPTION
Fixes  #782 

The validator checks the start date and end date properties on the TaskSummaryModel used when creating / editing a task. Dates are validated against the business rules and this includes the addition of validation that an itinerary task does not span more than a day.