### PR TITLE
Upgrade typescript tools version on mobile-app

### DIFF
--- a/AllReadyApp/Mobile-App/AllReadyApp.jsproj
+++ b/AllReadyApp/Mobile-App/AllReadyApp.jsproj
@@ -78,7 +78,7 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <TypeScriptToolsVersion>1.5</TypeScriptToolsVersion>
+    <TypeScriptToolsVersion>1.8</TypeScriptToolsVersion>
   </PropertyGroup>
   <PropertyGroup>
     <TypeScriptCompileOnSaveEnabled>false</TypeScriptCompileOnSaveEnabled>

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -136,9 +136,22 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             mediator.Verify(m => m.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)), Times.Once);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void EditUserGetReturnsCorrectViewModelWhenOrganizationIdIsNull()
         {
+            var mediator = new Mock<IMediator>();
+            var logger = new Mock<ILogger<SiteController>>();
+
+            string userId = It.IsAny<string>();
+            mediator.Setup(x => x.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)))
+                .Returns(new ApplicationUser());
+            var controller = new SiteController(null, logger.Object, mediator.Object);
+            
+            var result = controller.EditUser(userId);
+            var model = ((ViewResult)result).ViewData.Model as EditUserModel;
+                        
+            Assert.Equal(model.Organization, null);
+            Assert.IsType<EditUserModel>(model);
         }
 
         [Fact(Skip = "NotImplemented")]
@@ -628,6 +641,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         private static Mock<UserManager<ApplicationUser>> CreateApplicationUserMock()
         {
             return new Mock<UserManager<ApplicationUser>>(Mock.Of<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null, null);
-        }    
+        }
+      
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -642,6 +642,5 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         {
             return new Mock<UserManager<ApplicationUser>>(Mock.Of<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null, null);
         }
-      
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -628,6 +628,6 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         private static Mock<UserManager<ApplicationUser>> CreateApplicationUserMock()
         {
             return new Mock<UserManager<ApplicationUser>>(Mock.Of<IUserStore<ApplicationUser>>(), null, null, null, null, null, null, null, null, null);
-        }
+        }    
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -136,22 +136,9 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             mediator.Verify(m => m.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)), Times.Once);
         }
 
-        [Fact]
+        [Fact(Skip = "NotImplemented")]
         public void EditUserGetReturnsCorrectViewModelWhenOrganizationIdIsNull()
         {
-            var mediator = new Mock<IMediator>();
-            var logger = new Mock<ILogger<SiteController>>();
-
-            string userId = It.IsAny<string>();
-            mediator.Setup(x => x.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)))
-                .Returns(new ApplicationUser());
-            var controller = new SiteController(null, logger.Object, mediator.Object);
-            
-            var result = controller.EditUser(userId);
-            var model = ((ViewResult)result).ViewData.Model as EditUserModel;
-                        
-            Assert.Equal(model.Organization, null);
-            Assert.IsType<EditUserModel>(model);
         }
 
         [Fact(Skip = "NotImplemented")]


### PR DESCRIPTION
My first commit updated TypeScript tools version. This will avoid Visual Studio Update 1 & Update 2 developers from getting the dialog alerting them to having a older version of type script tools in this project.  The dialog happens automatically and by default. Only the solution with with the mobile-app project in it will be effected. 