### PR TITLE
Updated TypeScriptToolsVersion.

### DIFF
--- a/AllReadyApp/Mobile-App/AllReadyApp.jsproj
+++ b/AllReadyApp/Mobile-App/AllReadyApp.jsproj
@@ -78,7 +78,7 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup>
-    <TypeScriptToolsVersion>1.5</TypeScriptToolsVersion>
+    <TypeScriptToolsVersion>1.8</TypeScriptToolsVersion>
   </PropertyGroup>
   <PropertyGroup>
     <TypeScriptCompileOnSaveEnabled>false</TypeScriptCompileOnSaveEnabled>


### PR DESCRIPTION
This will avoid Visual Studio Update 1 & Update 2 developers from getting the dialog alerting them to having a older version of type script tools in this project. The dialog happens automatically and by default. Only the solutions that load the Mobile-App will be effected. Background: Visual Studio 2015 Update 1 included 1.6 and 1.7 releases of the TypeScript tools. Visual Studio 2015 Update 2 includes TypeScript 1.8. The latest version (1.8) can be downloaded separately at https://www.microsoft.com/en-us/download/details.aspx?id=48593. These typescript tools updates brings significant enhancements to TypeScript's type system and enables support for the polymorphic type, intersection types, local type declarations, generic type aliasing, and user-defined type guard functions. It also completes ES6 support in TypeScript by adding ES6 Generators and ES6 Class expressions, and brings support for new ES7 feature proposals like ES7 Exponentiation operator and ES7 Async functions. The compiler now highlights common bugs such as unreachable code, missing return statements, and unused labels.