### PR TITLE
Updating Request model to allow relationship with event.

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Migrations/20160607185847_RequestToEventMapping.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20160607185847_RequestToEventMapping.Designer.cs
@@ -1,0 +1,794 @@
+using System;
+using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Migrations;
+using AllReady.Models;
+
+namespace AllReady.Migrations
+{
+    [DbContext(typeof(AllReadyContext))]
+    [Migration("20160607185847_RequestToEventMapping")]
+    partial class RequestToEventMapping
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "7.0.0-rc1-16348")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset?>("EndDateTime");
+
+                    b.Property<int?>("EventId");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<DateTimeOffset?>("StartDateTime");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PendingNewEmail");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasAnnotation("Relational:Name", "EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .HasAnnotation("Relational:Name", "UserNameIndex");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUsers");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignImpactId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<string>("ExternalUrl");
+
+                    b.Property<string>("ExternalUrlText");
+
+                    b.Property<bool>("Featured");
+
+                    b.Property<string>("FullDescription");
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<bool>("Locked");
+
+                    b.Property<int>("ManagingOrganizationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.Property<int>("CampaignId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.HasKey("CampaignId", "ContactId", "ContactType");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignImpact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CurrentImpactLevel");
+
+                    b.Property<bool>("Display");
+
+                    b.Property<int>("ImpactType");
+
+                    b.Property<int>("NumericImpactGoal");
+
+                    b.Property<string>("TextualImpactGoal");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignId");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ClosestLocation", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<double>("Distance");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Contact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Event", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CampaignId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<int>("EventType");
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<DateTime?>("CheckinDateTime");
+
+                    b.Property<int?>("EventId");
+
+                    b.Property<string>("PreferredEmail");
+
+                    b.Property<string>("PreferredPhoneNumber");
+
+                    b.Property<DateTime>("SignupDateTime");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSkill", b =>
+                {
+                    b.Property<int>("EventId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("EventId", "SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Itinerary", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime>("Date");
+
+                    b.Property<int>("EventId");
+
+                    b.Property<string>("Name");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>
+                {
+                    b.Property<int>("ItineraryId");
+
+                    b.Property<Guid>("RequestId");
+
+                    b.HasKey("ItineraryId", "RequestId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Location", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address1");
+
+                    b.Property<string>("Address2");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("Country");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("LogoUrl");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("PrivacyPolicy");
+
+                    b.Property<string>("WebUrl");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.Property<int>("OrganizationId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.HasKey("OrganizationId", "ContactId", "ContactType");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeo", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeoCoordinate", b =>
+                {
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.HasKey("Latitude", "Longitude");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.Property<Guid>("RequestId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("Email");
+
+                    b.Property<int?>("EventId");
+
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("Phone");
+
+                    b.Property<string>("ProviderData");
+
+                    b.Property<string>("ProviderId");
+
+                    b.Property<string>("State");
+
+                    b.Property<int>("Status");
+
+                    b.Property<string>("Zip");
+
+                    b.HasKey("RequestId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Resource", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("CategoryTag");
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("MediaUrl");
+
+                    b.Property<string>("Name");
+
+                    b.Property<DateTime>("PublishDateBegin");
+
+                    b.Property<DateTime>("PublishDateEnd");
+
+                    b.Property<string>("ResourceUrl");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int?>("OwningOrganizationId");
+
+                    b.Property<int?>("ParentSkillId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<int?>("ItineraryId");
+
+                    b.Property<string>("PreferredEmail");
+
+                    b.Property<string>("PreferredPhoneNumber");
+
+                    b.Property<string>("Status");
+
+                    b.Property<DateTime>("StatusDateTimeUtc");
+
+                    b.Property<string>("StatusDescription");
+
+                    b.Property<int?>("TaskId");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.Property<int>("TaskId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("TaskId", "SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("UserId", "SkillId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRole", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Name")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .HasAnnotation("Relational:Name", "RoleNameIndex");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetRoles");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("RoleId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetRoleClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider");
+
+                    b.Property<string>("ProviderKey");
+
+                    b.Property<string>("ProviderDisplayName");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserLogins");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<string>("RoleId");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserRoles");
+                });
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.HasOne("AllReady.Models.CampaignImpact")
+                        .WithMany()
+                        .HasForeignKey("CampaignImpactId");
+
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("ManagingOrganizationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Event", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSignup", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Itinerary", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>
+                {
+                    b.HasOne("AllReady.Models.Itinerary")
+                        .WithMany()
+                        .HasForeignKey("ItineraryId");
+
+                    b.HasOne("AllReady.Models.Request")
+                        .WithMany()
+                        .HasForeignKey("RequestId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OwningOrganizationId");
+
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("ParentSkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.HasOne("AllReady.Models.Itinerary")
+                        .WithMany()
+                        .HasForeignKey("ItineraryId");
+
+                    b.HasOne("AllReady.Models.AllReadyTask")
+                        .WithMany()
+                        .HasForeignKey("TaskId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+
+                    b.HasOne("AllReady.Models.AllReadyTask")
+                        .WithMany()
+                        .HasForeignKey("TaskId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNet.Identity.EntityFramework.IdentityRole")
+                        .WithMany()
+                        .HasForeignKey("RoleId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNet.Identity.EntityFramework.IdentityRole")
+                        .WithMany()
+                        .HasForeignKey("RoleId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20160607185847_RequestToEventMapping.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20160607185847_RequestToEventMapping.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Migrations;
+
+namespace AllReady.Migrations
+{
+    public partial class RequestToEventMapping : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "Lattitude", table: "Request");
+            migrationBuilder.AddColumn<int>(
+                name: "EventId",
+                table: "Request",
+                nullable: true);
+            migrationBuilder.AddColumn<double>(
+                name: "Latitude",
+                table: "Request",
+                nullable: false,
+                defaultValue: 0);
+            migrationBuilder.AddForeignKey(
+                name: "FK_Request_Event_EventId",
+                table: "Request",
+                column: "EventId",
+                principalTable: "Event",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);            
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {           
+            migrationBuilder.DropForeignKey(name: "FK_Request_Event_EventId", table: "Request");
+            migrationBuilder.DropColumn(name: "EventId", table: "Request");
+            migrationBuilder.DropColumn(name: "Latitude", table: "Request");
+            migrationBuilder.AddColumn<double>(
+                name: "Lattitude",
+                table: "Request",
+                nullable: false,
+                defaultValue: 0);            
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
@@ -382,7 +382,9 @@ namespace AllReady.Migrations
 
                     b.Property<string>("Email");
 
-                    b.Property<double>("Lattitude");
+                    b.Property<int?>("EventId");
+
+                    b.Property<double>("Latitude");
 
                     b.Property<double>("Longitude");
 
@@ -698,6 +700,13 @@ namespace AllReady.Migrations
                     b.HasOne("AllReady.Models.Organization")
                         .WithMany()
                         .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
                 });
 
             modelBuilder.Entity("AllReady.Models.Skill", b =>

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
@@ -146,6 +146,7 @@ namespace AllReady.Models
             builder.HasMany(a => a.RequiredSkills).WithOne(acsk => acsk.Event);
             builder.Property(p => p.Name).IsRequired();
             builder.HasMany(x => x.Itineraries).WithOne(x => x.Event).HasForeignKey(x => x.EventId).IsRequired();
+            builder.HasMany(x => x.Requests).WithOne(x => x.Event).HasForeignKey(x => x.EventId).IsRequired(false).OnDelete(DeleteBehavior.SetNull);
         }
 
         private void Map(EntityTypeBuilder<EventSkill> builder)

--- a/AllReadyApp/Web-App/AllReady/Models/Event.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Event.cs
@@ -62,6 +62,7 @@ namespace AllReady.Models
             return Tasks.Any(task => task.AssignedVolunteers.Any(av => av.User.Id == userId));
         }
 
+        public ICollection<Request> Requests { get; set; }
         public ICollection<Itinerary> Itineraries { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Models/Request.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Request.cs
@@ -22,12 +22,15 @@ namespace AllReady.Models
         public RequestStatus Status { get; set; }
 
         // no support yet for spatial types
-        public double Lattitude { get; set; }
+        public double Latitude { get; set; }
         public double Longitude { get; set; }
 
         // allow for unique identifiers and mapping information
         public string ProviderId { get; set; }      // for RedCross, "serial"
         public string ProviderData { get; set; }    // for Red Cross, "assigned_rc_region"
+
+        public int? EventId { get; set; }
+        public Event Event { get; set; }
 
         public ICollection<ItineraryRequest> Itineraries { get; set; }
     }


### PR DESCRIPTION
Fixes #813 and fixes #814

This has been added as optional in case we do not know the event id when request is added via api. This could allow unassigned requests to be managed and linked to events via the application if necessary. Also as this is an optional relationship we ensure that on deletion of an event we won't cascade deletion of requests. They will instead be orphaned so we retain their history.

@MisterJames If this is not the behaviour we want then we can adjust this mapping.