### PR TITLE
Create itinerary modal

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ItineraryAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ItineraryAdminControllerTests.cs
@@ -10,21 +10,59 @@ using Microsoft.AspNet.Mvc;
 using Moq;
 using Xunit;
 using System.Linq;
+using AllReady.Areas.Admin.Features.Events;
 using Microsoft.AspNet.Authorization;
 using AllReady.Areas.Admin.Features.Itineraries;
+using AllReady.Areas.Admin.Models;
 using AllReady.Areas.Admin.Models.ItineraryModels;
+using AllReady.Areas.Admin.Models.Validators;
 
 namespace AllReady.UnitTest.Areas.Admin.Controllers
 {
     public class ItineraryAdminControllerTests
     {
         [Fact]
+        public void ControllerHasAreaAtttributeWithTheCorrectAreaName()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var attribute = sut.GetAttributes().OfType<AreaAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.RouteValue, "Admin");
+        }
+
+        [Fact]
+        public void ControllerHasAreaAuthorizeAttributeWithCorrectPolicy()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var attribute = sut.GetAttributes().OfType<AuthorizeAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Policy, "OrgAdmin");
+        }
+
+        [Fact]
+        public void DetailsHasHttpGetAttribute()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var attribute = sut.GetAttributesOn(x => x.Details(It.IsAny<int>())).OfType<HttpGetAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void DetailsHasRouteAttributeWithCorrectRoute()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var routeAttribute = sut.GetAttributesOn(x => x.Details(It.IsAny<int>())).OfType<RouteAttribute>().SingleOrDefault();
+            Assert.NotNull(routeAttribute);
+            Assert.Equal(routeAttribute.Template, "Admin/Itinerary/Details/{id}");
+        }
+
+        [Fact]
         public async Task DetailsSendsEventDetailQueryAsyncWithCorrectEventId()
         {
             var mockMediator = new Mock<IMediator>();
             mockMediator.Setup(mock => mock.SendAsync(It.IsAny<ItineraryDetailQuery>())).ReturnsAsync(null).Verifiable();
 
-            var sut = new ItineraryController(mockMediator.Object);
+            var sut = new ItineraryController(mockMediator.Object, MockSuccessValidation().Object);
             await sut.Details(1);
 
             mockMediator.Verify(x => x.SendAsync(It.IsAny<ItineraryDetailQuery>()), Times.Once);
@@ -58,51 +96,273 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var sut = GetItineraryControllerWithDetailsQuery(UserType.SiteAdmin.ToString(), 0);
             Assert.IsType<ViewResult>(await sut.Details(It.IsAny<int>()));
         }
-
-        [Fact]
-        public void DetailsHasHttpGetAttribute()
-        {
-            var sut = new ItineraryController(Mock.Of<IMediator>());
-            var attribute = sut.GetAttributesOn(x => x.Details(It.IsAny<int>())).OfType<HttpGetAttribute>().SingleOrDefault();
-            Assert.NotNull(attribute);
-        }
-
-        [Fact]
-        public void DetailsHasRouteAttributeWithCorrectRoute()
-        {
-            var sut = new ItineraryController(Mock.Of<IMediator>());
-            var routeAttribute = sut.GetAttributesOn(x => x.Details(It.IsAny<int>())).OfType<RouteAttribute>().SingleOrDefault();
-            Assert.NotNull(routeAttribute);
-            Assert.Equal(routeAttribute.Template, "Admin/Itinerary/Details/{id}");
-        }
         
         [Fact]
-        public void ControllerHasAreaAtttributeWithTheCorrectAreaName()
+        public void CreateHasHttpPostAttribute()
         {
-            var sut = new ItineraryController(Mock.Of<IMediator>());
-            var attribute = sut.GetAttributes().OfType<AreaAttribute>().SingleOrDefault();
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var attribute = sut.GetAttributesOn(x => x.Create(It.IsAny<ItineraryEditModel>())).OfType<HttpPostAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
-            Assert.Equal(attribute.RouteValue, "Admin");
         }
 
         [Fact]
-        public void ControllerHasAreaAuthorizeAttributeWithCorrectPolicy()
+        public void CreateHasRouteAttributeWithCorrectRoute()
         {
-            var sut = new ItineraryController(Mock.Of<IMediator>());
-            var attribute = sut.GetAttributes().OfType<AuthorizeAttribute>().SingleOrDefault();
-            Assert.NotNull(attribute);
-            Assert.Equal(attribute.Policy, "OrgAdmin");
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var routeAttribute = sut.GetAttributesOn(x => x.Create(It.IsAny<ItineraryEditModel>())).OfType<RouteAttribute>().SingleOrDefault();
+            Assert.NotNull(routeAttribute);
+            Assert.Equal(routeAttribute.Template, "Admin/Itinerary/Create");
+        }
+
+        [Fact]
+        public void CreateHasValidateAntiForgeryAttribute()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var routeAttribute = sut.GetAttributesOn(x => x.Create(It.IsAny<ItineraryEditModel>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
+            Assert.NotNull(routeAttribute);
+        }
+
+        [Fact]
+        public async Task CreateReturnsHttpBadRequestWhenModelIsNull()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            Assert.IsType<BadRequestResult>(await sut.Create(null).ConfigureAwait(false));
+        }
+
+        [Fact]
+        public async Task CreateSendsEventSummaryQuery()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "Test",
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<EventSummaryQuery>()))
+                .ReturnsAsync(It.IsAny<EventSummaryModel>()).Verifiable();
+
+            var sut = new ItineraryController(mockMediator.Object, MockSuccessValidation().Object);
+            await sut.Create(model);
+
+            mockMediator.Verify(x => x.SendAsync(It.IsAny<EventSummaryQuery>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateReturnsHttpBadRequestIfEventNull()
+        {
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(null);
+
+            var sut = new ItineraryController(mockMediator.Object, MockSuccessValidation().Object);
+            Assert.IsType<BadRequestResult>(await sut.Create(It.IsAny<ItineraryEditModel>()).ConfigureAwait(false));
+        }
+
+        [Fact]
+        public async Task CreateReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdminForEventOrg()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "Test",
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var sut = GetItineraryControllerWithEventSummaryQuery(UserType.OrgAdmin.ToString(), 5);
+            Assert.IsType<HttpUnauthorizedResult>(await sut.Create(model));
+        }
+
+        [Fact]
+        public async Task CreateReturnsOkResultWhenUserIsOrgAdmin()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "Test",
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var sut = GetItineraryControllerWithEventSummaryQuery(UserType.OrgAdmin.ToString(), 1);
+            Assert.IsType<HttpOkObjectResult>(await sut.Create(model));
+        }
+
+        [Fact]
+        public async Task CreateReturnsOkResultWhenUserIsSiteAdmin_AndModelIsValid_AndSuccessfulAdd()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "Test",
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var sut = GetItineraryControllerWithEventSummaryQuery(UserType.SiteAdmin.ToString(), 0);
+            Assert.IsType<HttpOkObjectResult>(await sut.Create(model));
+        }
+
+        [Fact]
+        public async Task CreateReturnsHttpBadRequestResultWhenModelStateHasError()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var sut = GetItineraryControllerWithEventSummaryQuery(UserType.SiteAdmin.ToString(), 0);
+
+            sut.ModelState.AddModelError("key","Error");
+
+            var result = await sut.Create(model);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task CreateCallsValidator()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "Test",
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var mediator = new Mock<IMediator>();
+
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryModel { Id = 1, Name = "Event", OrganizationId = 1, StartDateTime = new DateTimeOffset(new DateTime(2016, 01, 01)), EndDateTime = new DateTimeOffset(new DateTime(2016, 12, 31)) });
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditItineraryCommand>())).ReturnsAsync(1);
+
+            var mockValidator = new Mock<IItineraryEditModelValidator>();
+            mockValidator.Setup(mock => mock.Validate(It.IsAny<ItineraryEditModel>(), It.IsAny<EventSummaryModel>())).Returns(new List<KeyValuePair<string, string>>()).Verifiable();
+
+            var sut = new ItineraryController(mediator.Object, mockValidator.Object);
+            sut.SetClaims(new List<Claim>
+            {
+                new Claim(AllReady.Security.ClaimTypes.UserType, UserType.SiteAdmin.ToString()),
+                new Claim(AllReady.Security.ClaimTypes.Organization, "1")
+            });
+
+            await sut.Create(model);
+
+            mockValidator.Verify(x => x.Validate(It.IsAny<ItineraryEditModel>(), It.IsAny<EventSummaryModel>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateReturnsHttpBadRequestResultWhenValidatonFails()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "Test",
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var mediator = new Mock<IMediator>();
+
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryModel { Id = 1, Name = "Event", OrganizationId = 1, StartDateTime = new DateTimeOffset(new DateTime(2016, 01, 01)), EndDateTime = new DateTimeOffset(new DateTime(2016, 12, 31)) });
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditItineraryCommand>())).ReturnsAsync(1);
+
+            var validatorError = new List<KeyValuePair<string, string>>
+            {
+                new KeyValuePair<string, string>("key", "value")
+            };
+
+            var mockValidator = new Mock<IItineraryEditModelValidator>();
+            mockValidator.Setup(mock => mock.Validate(It.IsAny<ItineraryEditModel>(), It.IsAny<EventSummaryModel>())).Returns(validatorError).Verifiable();
+
+            var sut = new ItineraryController(mediator.Object, mockValidator.Object);
+            sut.SetClaims(new List<Claim>
+            {
+                new Claim(AllReady.Security.ClaimTypes.UserType, UserType.SiteAdmin.ToString()),
+                new Claim(AllReady.Security.ClaimTypes.Organization, "1")
+            });
+
+            var result = await sut.Create(model);
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        [Fact]
+        public async Task CreateCallsEditCommand()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "Test",
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var mediator = new Mock<IMediator>();
+
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryModel { Id = 1, Name = "Event", OrganizationId = 1, StartDateTime = new DateTimeOffset(new DateTime(2016, 01, 01)), EndDateTime = new DateTimeOffset(new DateTime(2016, 12, 31)) });
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditItineraryCommand>())).ReturnsAsync(0).Verifiable();
+
+            var mockValidator = new Mock<IItineraryEditModelValidator>();
+            mockValidator.Setup(mock => mock.Validate(It.IsAny<ItineraryEditModel>(), It.IsAny<EventSummaryModel>())).Returns(new List<KeyValuePair<string, string>>()).Verifiable();
+
+            var sut = new ItineraryController(mediator.Object, mockValidator.Object);
+            sut.SetClaims(new List<Claim>
+            {
+                new Claim(AllReady.Security.ClaimTypes.UserType, UserType.SiteAdmin.ToString()),
+                new Claim(AllReady.Security.ClaimTypes.Organization, "1")
+            });
+
+            var result = await sut.Create(model);
+
+            mediator.Verify(x => x.SendAsync(It.IsAny<EditItineraryCommand>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task CreateReturnsHttpBadRequestResultWhenEditItineraryReturnsZero()
+        {
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "Test",
+                Date = new DateTime(2016, 06, 01)
+            };
+
+            var mediator = new Mock<IMediator>();
+
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryModel { Id = 1, Name = "Event", OrganizationId = 1, StartDateTime = new DateTimeOffset(new DateTime(2016, 01, 01)), EndDateTime = new DateTimeOffset(new DateTime(2016, 12, 31)) });
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditItineraryCommand>())).ReturnsAsync(0);
+
+            var mockValidator = new Mock<IItineraryEditModelValidator>();
+            mockValidator.Setup(mock => mock.Validate(It.IsAny<ItineraryEditModel>(), It.IsAny<EventSummaryModel>())).Returns(new List<KeyValuePair<string, string>>()).Verifiable();
+
+            var sut = new ItineraryController(mediator.Object, mockValidator.Object);
+            sut.SetClaims(new List<Claim>
+            {
+                new Claim(AllReady.Security.ClaimTypes.UserType, UserType.SiteAdmin.ToString()),
+                new Claim(AllReady.Security.ClaimTypes.Organization, "1")
+            });
+
+            var result = await sut.Create(model);
+
+            Assert.IsType<BadRequestResult>(result);
         }
 
         #region Helper Methods
+
         private static Mock<IMediator> MockMediatorItineraryDetailQuery(out ItineraryController controller)
         {
             var mockMediator = new Mock<IMediator>();
             mockMediator.Setup(mock => mock.SendAsync(It.IsAny<ItineraryDetailQuery>())).ReturnsAsync(null).Verifiable();
 
-            controller = new ItineraryController(mockMediator.Object);
+            controller = new ItineraryController(mockMediator.Object, MockSuccessValidation().Object);
 
             return mockMediator;
+        }
+
+        private static Mock<IItineraryEditModelValidator> MockSuccessValidation()
+        {
+            var mockValidator = new Mock<IItineraryEditModelValidator>();
+
+            mockValidator.Setup(mock => mock.Validate(It.IsAny<ItineraryEditModel>(), It.IsAny<EventSummaryModel>())).Returns(new List<KeyValuePair<string, string>>()).Verifiable();
+
+           return mockValidator;
         }
 
         private static ItineraryController GetItineraryControllerWithDetailsQuery(string userType, int organizationId)
@@ -111,7 +371,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             mediator.Setup(x => x.SendAsync(It.IsAny<ItineraryDetailQuery>())).ReturnsAsync(new ItineraryDetailsModel { Id = 1, Name = "Itinerary", EventId = 1, EventName = "Event Name", OrganizationId = 1, Date = new DateTime(2016, 07, 01) });
 
-            var sut = new ItineraryController(mediator.Object);
+            var sut = new ItineraryController(mediator.Object, MockSuccessValidation().Object);
             sut.SetClaims(new List<Claim>
             {
                 new Claim(AllReady.Security.ClaimTypes.UserType, userType),
@@ -119,7 +379,24 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             });
 
             return sut;
-        }      
+        }
+
+        private static ItineraryController GetItineraryControllerWithEventSummaryQuery(string userType, int organizationId)
+        {
+            var mediator = new Mock<IMediator>();
+
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryModel { Id = 1, Name = "Event", OrganizationId = 1, StartDateTime = new DateTimeOffset(new DateTime(2016, 01, 01)), EndDateTime = new DateTimeOffset(new DateTime(2016, 12, 31)) });
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditItineraryCommand>())).ReturnsAsync(1);
+
+            var sut = new ItineraryController(mediator.Object, MockSuccessValidation().Object);
+            sut.SetClaims(new List<Claim>
+            {
+                new Claim(AllReady.Security.ClaimTypes.UserType, userType),
+                new Claim(AllReady.Security.ClaimTypes.Organization, organizationId.ToString())
+            });
+
+            return sut;
+        }
 
         #endregion
     }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerAsyncTests.cs
@@ -1,0 +1,98 @@
+﻿using AllReady.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.Itineraries;
+using AllReady.Areas.Admin.Models.ItineraryModels;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
+{
+    public class EditItineraryCommandHandlerAsyncTests : InMemoryContextTest
+    {
+        protected override void LoadTestData()
+        {
+            var htb = new Organization
+            {
+                Name = "Humanitarian Toolbox",
+                LogoUrl = "http://www.htbox.org/upload/home/ht-hero.png",
+                WebUrl = "http://www.htbox.org",
+                Campaigns = new List<Campaign>()
+            };
+
+            var firePrev = new Campaign
+            {
+                Name = "Neighborhood Fire Prevention Days",
+                ManagingOrganization = htb
+            };
+            htb.Campaigns.Add(firePrev);
+
+            var queenAnne = new Event
+            {
+                Id = 1,
+                Name = "Queen Anne Fire Prevention Day",
+                Campaign = firePrev,
+                CampaignId = firePrev.Id,
+                StartDateTime = new DateTime(2015, 7, 4, 10, 0, 0).ToUniversalTime(),
+                EndDateTime = new DateTime(2015, 12, 31, 15, 0, 0).ToUniversalTime(),
+                Location = new Location { Id = 1 },
+                RequiredSkills = new List<EventSkill>(),
+                EventType = EventType.Itinerary
+            };
+
+            var itinerary = new Itinerary
+            {
+                Event = queenAnne,
+                Name = "1st Itinerary",
+                Date = new DateTime(2016, 07, 01)
+            };
+
+            Context.Events.Add(queenAnne);
+            Context.Itineraries.Add(itinerary);
+            Context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task AddsNewItineraryWhenItDoesNotExist()
+        {
+            var query = new EditItineraryCommand {  Itinerary = new ItineraryEditModel
+            {
+                EventId = 1,
+                Name = "New",
+                Date = DateTime.Now
+            }};
+
+            var sut = new EditItineraryCommandHandlerAsync(Context);
+            var result = await sut.Handle(query);
+
+            Assert.True(result > 0);
+            Assert.Equal(2, Context.Itineraries.Count());
+
+            var data = Context.Itineraries.Count(x => x.Id == result);
+
+            Assert.True(data == 1);
+        }
+
+        [Fact]
+        public async Task UpdatesItineraryWhenItExists()
+        {
+            var query = new EditItineraryCommand
+            {
+                Itinerary = new ItineraryEditModel
+                {
+                    Id = 1,
+                    EventId = 1,
+                    Name = "Updated",
+                    Date = DateTime.Now
+                }
+            };
+
+            var sut = new EditItineraryCommandHandlerAsync(Context);
+            var result = await sut.Handle(query);
+
+            Assert.True(result == 1);
+            Assert.Equal(1, Context.Itineraries.Count());
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Models/Validators/ItineraryEditModelValidatorTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Models/Validators/ItineraryEditModelValidatorTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using AllReady.Areas.Admin.Models;
+using AllReady.Areas.Admin.Models.ItineraryModels;
+using AllReady.Areas.Admin.Models.Validators;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Models.Validators
+{
+    public class ItineraryEditModelValidatorTests
+    {
+        private readonly DateTimeOffset eventStartDate = new DateTimeOffset(new DateTime(2016, 1, 1));
+        private readonly DateTimeOffset eventEndDate = new DateTimeOffset(new DateTime(2020, 12, 31));
+
+        [Fact]
+        public void ReturnsCorrectErrorWhenDateIsLessThanParentEventStartDate()
+        {
+            var sut = new ItineraryEditModelValidator();
+
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Date = eventStartDate.AddDays(-1).DateTime
+            };
+
+            var errors = sut.Validate(model, TestEvent);
+
+            Assert.True(errors.Exists(x => x.Key.Equals("Date")));
+            Assert.Equal(errors.Find(x => x.Key == "Date").Value, "Date cannot be earlier than the event start date " + eventStartDate.Date.ToString("d"));
+        }
+
+        [Fact]
+        public void ReturnsCorrectErrorWhenModelsDateIsGreaterThanParentEventEndDate()
+        {
+            var sut = new ItineraryEditModelValidator();
+
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Date = eventEndDate.AddDays(1).DateTime
+            };
+
+            var errors = sut.Validate(model, TestEvent);
+
+            Assert.True(errors.Exists(x => x.Key.Equals("Date")));
+            Assert.Equal(errors.Find(x => x.Key == "Date").Value, "Date cannot be later than the event end date " + eventEndDate.Date.ToString("d"));
+        }
+
+        [Fact]
+        public void ReturnsNoErrorForWhenDatesIsBetweenStartAndEndOfParentEvent()
+        {
+            var sut = new ItineraryEditModelValidator();
+
+            var model = new ItineraryEditModel
+            {
+                EventId = 1,
+                Date = eventStartDate.AddDays(1).DateTime
+            };
+
+            var errors = sut.Validate(model, TestEvent);
+
+            Assert.True(errors.Count == 0);
+        }
+
+        private EventSummaryModel TestEvent => new EventSummaryModel
+        {
+            Id = 1,
+            StartDateTime = eventStartDate,
+            EndDateTime = eventEndDate
+        };
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
@@ -49,7 +49,16 @@ namespace AllReady.Areas.Admin.Controllers
                 return HttpUnauthorized();
             }
 
+            campaignEvent.ItinerariesDetailsUrl = GenerateItineraryDetailsTemplateUrl();
+
             return View(campaignEvent);
+        }
+
+        private string GenerateItineraryDetailsTemplateUrl()
+        {
+            var url = Url.Action("Details", "Itinerary", new { Area = "Admin", id = 0 }).TrimEnd('0');
+
+            return string.Concat(url, "{id}");
         }
 
         // GET: Event/Create

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -5,6 +5,10 @@ using Microsoft.AspNet.Authorization;
 using Microsoft.AspNet.Mvc;
 using System;
 using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.Events;
+using AllReady.Areas.Admin.Models.ItineraryModels;
+using AllReady.Areas.Admin.Models.Validators;
+using System.Linq;
 
 namespace AllReady.Areas.Admin.Controllers
 {
@@ -12,35 +16,83 @@ namespace AllReady.Areas.Admin.Controllers
     [Authorize("OrgAdmin")]
     public class ItineraryController : Controller
     {
-        private readonly IMediator _mediator;       
+        private readonly IMediator _mediator;
+        private readonly IItineraryEditModelValidator _itineraryValidator;
 
-        public ItineraryController(IMediator mediator)
-        {            
+        public ItineraryController(IMediator mediator, IItineraryEditModelValidator itineraryValidator)
+        {
             if (mediator == null)
             {
                 throw new ArgumentNullException(nameof(mediator));
             }
 
-            _mediator = mediator;            
+            if (itineraryValidator == null)
+            {
+                throw new ArgumentNullException(nameof(itineraryValidator));
+            }
+
+            _mediator = mediator;
+            _itineraryValidator = itineraryValidator;
         }
 
         [HttpGet]
         [Route("Admin/Itinerary/Details/{id}")]
         public async Task<IActionResult> Details(int id)
         {
-            var Itinerary = await _mediator.SendAsync(new ItineraryDetailQuery { ItineraryId = id });
+            var itinerary = await _mediator.SendAsync(new ItineraryDetailQuery { ItineraryId = id });
 
-            if (Itinerary == null)
+            if (itinerary == null)
             {
                 return HttpNotFound();
             }
 
-            if (!User.IsOrganizationAdmin(Itinerary.OrganizationId))
+            if (!User.IsOrganizationAdmin(itinerary.OrganizationId))
             {
                 return HttpUnauthorized();
             }
 
-            return View("Details", Itinerary);
+            return View("Details", itinerary);
+        }
+
+        [HttpPost]
+        [Route("Admin/Itinerary/Create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Create(ItineraryEditModel model)
+        {
+            if (model == null)
+            {
+                return HttpBadRequest();
+            }
+
+            var campaignEvent = await _mediator.SendAsync(new EventSummaryQuery { EventId = model.EventId });
+
+            if (campaignEvent == null)
+            {
+                return HttpBadRequest();
+            }
+
+            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            {
+                return HttpUnauthorized();
+            }
+
+            var errors = _itineraryValidator.Validate(model, campaignEvent);
+
+            errors.ToList().ForEach(e => ModelState.AddModelError(e.Key, e.Value));
+
+            if (!ModelState.IsValid)
+            {
+                return HttpBadRequest(ModelState);
+            }
+
+            var result = await _mediator.SendAsync(new EditItineraryCommand() { Itinerary = model });
+
+            if (result > 0)
+            {
+                return Ok(result);
+            }
+
+            return HttpBadRequest();
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventDetailQueryHandler.cs
@@ -1,4 +1,5 @@
-﻿using AllReady.Areas.Admin.Models;
+﻿using System;
+using AllReady.Areas.Admin.Models;
 using AllReady.Models;
 using MediatR;
 using Microsoft.Data.Entity;
@@ -72,6 +73,9 @@ namespace AllReady.Areas.Admin.Features.Events
                         RequestCount = i.Requests.Count
                     }).OrderBy(i => i.Date).ToList()
                 };
+
+                result.NewItinerary.EventId = result.Id;
+                result.NewItinerary.Date = result.StartDateTime.DateTime;
             }
 
             return result;

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventSummaryQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventSummaryQuery.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Areas.Admin.Models;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Events
+{
+    public class EventSummaryQuery : IAsyncRequest<EventSummaryModel>
+    {
+        public int EventId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventSummaryQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventSummaryQueryHandlerAsync.cs
@@ -1,0 +1,58 @@
+﻿using AllReady.Areas.Admin.Models;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Events
+{
+    public class EventSummaryQueryHandlerAsync : IAsyncRequestHandler<EventSummaryQuery, EventSummaryModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public EventSummaryQueryHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<EventSummaryModel> Handle(EventSummaryQuery message)
+        {
+            EventSummaryModel result = null;
+
+            var campaignEvent = await GetEvent(message);
+
+            if (campaignEvent != null)
+            {
+                result = new EventSummaryModel
+                {
+                    Id = campaignEvent.Id,
+                    EventType = campaignEvent.EventType,
+                    CampaignName = campaignEvent.Campaign.Name,
+                    CampaignId = campaignEvent.Campaign.Id,
+                    OrganizationId = campaignEvent.Campaign.ManagingOrganizationId,
+                    OrganizationName = campaignEvent.Campaign.ManagingOrganization.Name,
+                    Name = campaignEvent.Name,
+                    Description = campaignEvent.Description,
+                    TimeZoneId = campaignEvent.Campaign.TimeZoneId,
+                    StartDateTime = campaignEvent.StartDateTime,
+                    EndDateTime = campaignEvent.EndDateTime,
+                    NumberOfVolunteersRequired = campaignEvent.NumberOfVolunteersRequired,
+                    IsLimitVolunteers = campaignEvent.IsLimitVolunteers,
+                    IsAllowWaitList = campaignEvent.IsAllowWaitList,
+                    ImageUrl = campaignEvent.ImageUrl,
+                };
+            }
+
+            return result;
+        }
+
+        private async Task<Event> GetEvent(EventSummaryQuery message)
+        {
+            return await _context.Events
+                .AsNoTracking()
+                .Include(a => a.Campaign).ThenInclude(c => c.ManagingOrganization)
+                .SingleOrDefaultAsync(a => a.Id == message.EventId)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommand.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Areas.Admin.Models.ItineraryModels;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class EditItineraryCommand : IAsyncRequest<int>
+    {
+        public ItineraryEditModel Itinerary { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerAsync.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class EditItineraryCommandHandlerAsync : IAsyncRequestHandler<EditItineraryCommand, int>
+    {
+        private readonly AllReadyContext _context;
+
+        public EditItineraryCommandHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<int> Handle(EditItineraryCommand message)
+        {
+            try
+            {
+                var itinerary = await GetItinerary(message) ?? new Itinerary();
+
+                itinerary.Name = message.Itinerary.Name;
+                itinerary.Date = message.Itinerary.Date;
+                itinerary.EventId = message.Itinerary.EventId;
+
+                _context.Update(itinerary);
+                await _context.SaveChangesAsync().ConfigureAwait(false);
+
+                return itinerary.Id;
+            }
+            catch (Exception ex)
+            {
+                // There was an error somewhere
+                return 0;
+            }
+        }
+
+        private async Task<Itinerary> GetItinerary(EditItineraryCommand message)
+        {
+            return await _context.Itineraries
+                .SingleOrDefaultAsync(c => c.Id == message.Itinerary.Id)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventDetailModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventDetailModel.cs
@@ -18,5 +18,9 @@ namespace AllReady.Areas.Admin.Models
         public IEnumerable<ItineraryListModel> Itineraries { get; set; } = new List<ItineraryListModel>();
 
         public bool DisplayItineraries => EventType == EventType.Itinerary;
+
+        public ItineraryEditModel NewItinerary { get; set; } = new ItineraryEditModel();
+
+        public string ItinerariesDetailsUrl { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/ItineraryEditModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/ItineraryEditModel.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace AllReady.Areas.Admin.Models.ItineraryModels
+{
+    public class ItineraryEditModel
+    {
+        public int Id { get; set; }
+
+        public int EventId { get; set; }
+
+        [Required]
+        public string Name { get; set; }
+
+        [Required]
+        [DataType(DataType.Date)]
+        public DateTime Date { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/ItineraryEditModelValidator.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/ItineraryEditModelValidator.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using AllReady.Areas.Admin.Models.ItineraryModels;
+
+namespace AllReady.Areas.Admin.Models.Validators
+{
+    public class ItineraryEditModelValidator : IItineraryEditModelValidator
+    {
+        public List<KeyValuePair<string, string>> Validate(ItineraryEditModel model, EventSummaryModel eventSummary)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+
+            if (model.Date < eventSummary.StartDateTime.Date)
+            {
+                result.Add(new KeyValuePair<string, string>(nameof(model.Date), "Date cannot be earlier than the event start date " + eventSummary.StartDateTime.Date.ToString("d")));
+            }
+
+            if (model.Date > eventSummary.EndDateTime.Date)
+            {
+                result.Add(new KeyValuePair<string, string>(nameof(model.Date), "Date cannot be later than the event end date " + eventSummary.EndDateTime.Date.ToString("d")));
+            }
+
+            return result;
+        }
+    }
+
+    public interface IItineraryEditModelValidator
+    {
+        List<KeyValuePair<string, string>> Validate(ItineraryEditModel model, EventSummaryModel eventSummary);
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -138,11 +138,44 @@
     <div class="row">
         <div class="col-md-12">
             @*<a asp-controller="TODO" asp-action="TODO" asp-route-eventId="@Model.Id" class="btn btn-default">Create Itinerary</a>*@
-            <a href="#" class="btn btn-default">Create Itinerary (TODO)</a>
+            @*<a href="#" class="btn btn-default">Create Itinerary (TODO)</a>*@
+            <button type="button" class="btn btn-default" data-toggle="modal" data-target="#createItineraryModal">Create Itinerary</button>
         </div>
     </div>
 
     @Html.Partial("~/Areas/Admin/Views/Itinerary/_List.cshtml", Model.Itineraries)
+
+    <!-- Create Itinerary Modal -->
+    <div class="modal fade" id="createItineraryModal" tabindex="-1" role="dialog" aria-labelledby="createItineraryLabel">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h4 class="modal-title" id="createItineraryLabel">Create Itinerary</h4>
+                </div>
+                <input type="hidden" id="itineraryDetailUrl" value="@Model.ItinerariesDetailsUrl"/>
+
+                <form asp-controller="Itinerary" asp-action="Create" method="post" >
+                    <div class="modal-body">
+                        <input type="hidden" asp-for="NewItinerary.EventId" name="@nameof(Model.NewItinerary.EventId)" >
+                        <div class="form-group">
+                            <label for="@nameof(Model.NewItinerary.Name)" class="control-label">Name</label>
+                            <input type="text" class="form-control wide" id="createItineraryModal-name" name="@nameof(Model.NewItinerary.Name)" asp-for="NewItinerary.Name">
+                        </div>
+                        <div class="form-group">
+                            <label for="@nameof(Model.NewItinerary.Date)" class="control-label">Scheduled Date</label>
+                            <input class="form-control" id="createItineraryModal-date" asp-for="NewItinerary.Date" name="@nameof(Model.NewItinerary.Date)" value="@Model.NewItinerary.Date.ToString("yyyy-MM-dd")">
+                        </div>
+                        <div class="alert alert-danger" role="alert"></div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                        <button type="submit" id="createItinerary" class="btn btn-primary">Save</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
 }
 
 @section scripts {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -137,8 +137,6 @@
 
     <div class="row">
         <div class="col-md-12">
-            @*<a asp-controller="TODO" asp-action="TODO" asp-route-eventId="@Model.Id" class="btn btn-default">Create Itinerary</a>*@
-            @*<a href="#" class="btn btn-default">Create Itinerary (TODO)</a>*@
             <button type="button" class="btn btn-default" data-toggle="modal" data-target="#createItineraryModal">Create Itinerary</button>
         </div>
     </div>

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -118,6 +118,7 @@ namespace AllReady
             services.AddTransient<IDetermineIfATaskIsEditable, DetermineIfATaskIsEditable>();
             services.AddTransient<IValidateEventDetailModels, EventDetailModelValidator>();
             services.AddTransient<ITaskSummaryModelValidator, TaskSummaryModelValidator>();
+            services.AddTransient<IItineraryEditModelValidator, ItineraryEditModelValidator>();
             services.AddSingleton<IImageService, ImageService>();
             //services.AddSingleton<GeoService>();
             services.AddTransient<SampleDataGenerator>();

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/eventDetails.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/eventDetails.js
@@ -13,6 +13,13 @@
                 $(".alert-success", modal).hide();
             });
 
+            $("#createItineraryModal").on("show.bs.modal", function (e) {
+                var modal = $(this);
+                $("#createItinerary").removeAttr('disabled');
+                $("#createItineraryModal-name").val("");
+                $(".alert-danger", modal).hide();
+            });
+
             $("#messageVolunteersModal form").submit(function(e){
                 e.preventDefault();
                 $("#sendMessageToVolunteers").attr('disabled', 'disabled');
@@ -51,6 +58,43 @@
                         errorSection.html(errorMessage);
                         errorSection.show();
                         $("#sendMessageToVolunteers").removeAttr('disabled');
+                    }
+                });
+
+                // prevent submitting again
+                return false;
+            });
+
+            $("#createItineraryModal form").submit(function (e) {
+                e.preventDefault();
+                $("#createItinerary").attr('disabled', 'disabled');
+                var form = $(this);
+                $(".alert-error", form).hide();
+                $.ajax({
+                    type: form.attr('method'),
+                    url: form.attr('action'),
+                    data: form.serialize(),
+                    success: function (data) {
+                        window.location = $("#itineraryDetailUrl").val().replace("{id}", data);
+                    },
+                    error: function (error) {
+                        var errorSection = $(".alert-danger", form);
+                        var errorMessage = "";
+                        if (error.responseText) {
+                            var errorInfo = JSON.parse(error.responseText);
+                            if (errorInfo.Name && errorInfo.Name.length > 0) {
+                                errorMessage = errorMessage + errorInfo.Name[0] + "<br/>";
+                            }
+                            if (errorInfo.Date && errorInfo.Date.length > 0) {
+                                errorMessage = errorMessage + errorInfo.Date[0] + "<br/>";
+                            }
+                        }
+                        if (errorMessage === "") {
+                            errorMessage = "An error occurred while attempting to create the Itinerary. Please try again.";
+                        }
+                        errorSection.html(errorMessage);
+                        errorSection.show();
+                        $("#createItinerary").removeAttr('disabled');
                     }
                 });
 


### PR DESCRIPTION
Closes #808

Added a modal on the event details page to create an itinerary.

Validator added to ensure that itinerary date falls within the bounds of the event start and end dates.

Controller action implemented to handle request

Mediator handlers added to support queries and commands required for the creation of a valid itinerary.

Tests included for key functionality - They need a little refactoring to tidy them up in a future PR.

Create Itinerary Modal

![image](https://cloud.githubusercontent.com/assets/3669103/15902905/2a8a37e8-2da2-11e6-9946-7e17a59d6c4d.png)

Validation Feedback

![image](https://cloud.githubusercontent.com/assets/3669103/15902911/32c8a6ec-2da2-11e6-9545-6ecf8bf82f48.png)

On success redirects to the Itinerary details page.