### PR TITLE
List itinerary team members

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsyncTests.cs
@@ -47,10 +47,36 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
                 Date = new DateTime(2016, 07, 01)
             };
 
+            var task = new AllReadyTask
+            {
+                Id = 1,
+                Event = queenAnne,
+                Name = "A Task",
+                StartDateTime = new DateTime(2015, 7, 4, 10, 0, 0).ToUniversalTime(),
+                EndDateTime = new DateTime(2015, 7, 4, 18, 0, 0).ToUniversalTime()
+            };
+
+            var user = new ApplicationUser
+            {
+                Id = Guid.NewGuid().ToString(),
+                Email = "text@example.com"
+            };
+
+            var taskSignup = new TaskSignup
+            {
+                Id = 1,
+                User = user,
+                Task = task,
+                Itinerary = itinerary
+            };
+            
             Context.Organizations.Add(htb);
             Context.Campaigns.Add(firePrev);
             Context.Events.Add(queenAnne);
             Context.Itineraries.Add(itinerary);
+            Context.Tasks.Add(task);
+            Context.Users.Add(user);
+            Context.TaskSignups.Add(taskSignup);
             Context.SaveChanges();
         }
 
@@ -99,6 +125,16 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
             var handler = new ItineraryDetailQueryHandlerAsync(Context);
             var result = await handler.Handle(query);
             Assert.Equal(1, result.OrganizationId);
+        }
+
+        [Fact]
+        public async Task ItineraryQueryLoadsTeamMembers()
+        {
+            var query = new ItineraryDetailQuery { ItineraryId = 1 };
+            var handler = new ItineraryDetailQueryHandlerAsync(Context);
+            var result = await handler.Handle(query);
+            Assert.Equal(1, result.TeamMembers.Count);
+            Assert.Equal("text@example.com", result.TeamMembers[0].VolunteerEmail);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
@@ -2,6 +2,7 @@
 using AllReady.Models;
 using MediatR;
 using Microsoft.Data.Entity;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace AllReady.Areas.Admin.Features.Itineraries
@@ -17,31 +18,39 @@ namespace AllReady.Areas.Admin.Features.Itineraries
 
         public async Task<ItineraryDetailsModel> Handle(ItineraryDetailQuery message)
         {
-            ItineraryDetailsModel result = null;
+            var itineraryDetails = await _context.Itineraries
+                .AsNoTracking()
+                .Include(x => x.Event)
+                .Include(x => x.Event.Campaign.ManagingOrganization)
+                .Include(x => x.TeamMembers).ThenInclude(x => x.Task)
+                .Where(a => a.Id == message.ItineraryId)
+                .Select(i => new ItineraryDetailsModel {
+                    Id = i.Id,
+                    Name = i.Name,
+                    Date = i.Date,
+                    EventId = i.EventId,
+                    EventName = i.Event.Name,
+                    OrganizationId = i.Event.Campaign.ManagingOrganizationId,
+                    TeamMembers = i.TeamMembers.Select(tm => new TeamListModel
+                    {
+                        VolunteerEmail = tm.User.Email,
+                        TaskName = tm.Task.Name
+                    }).ToList()
+                })
+                .SingleOrDefaultAsync().ConfigureAwait(false);                
 
-            var itinerary = await GetItinerary(message);
-
-            if (itinerary != null)
-            {
-                result = new ItineraryDetailsModel();
-
-                result.Id = itinerary.Id;
-                result.Name = itinerary.Name;
-                result.Date = itinerary.Date;
-                result.EventId = itinerary.EventId;
-                result.EventName = itinerary.Event.Name;
-                result.OrganizationId = itinerary.Event.Campaign.ManagingOrganization.Id;
-            }
-
-            return result;
+            return itineraryDetails;
         }
 
+        // todo: sgordon: this could be more efficient, if we select only the fields we need from the query
         private async Task<Itinerary> GetItinerary(ItineraryDetailQuery message)
         {
             return await _context.Itineraries
                 .AsNoTracking()    
                 .Include(x => x.Event)           
                 .Include(x => x.Event.Campaign.ManagingOrganization)
+                .Include(x => x.TeamMembers).ThenInclude(x => x.Task)
+                .Include(x => x.TeamMembers).ThenInclude(x => x.User)
                 .SingleOrDefaultAsync(a => a.Id == message.ItineraryId)
                 .ConfigureAwait(false);
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
@@ -41,18 +41,5 @@ namespace AllReady.Areas.Admin.Features.Itineraries
 
             return itineraryDetails;
         }
-
-        // todo: sgordon: this could be more efficient, if we select only the fields we need from the query
-        private async Task<Itinerary> GetItinerary(ItineraryDetailQuery message)
-        {
-            return await _context.Itineraries
-                .AsNoTracking()    
-                .Include(x => x.Event)           
-                .Include(x => x.Event.Campaign.ManagingOrganization)
-                .Include(x => x.TeamMembers).ThenInclude(x => x.Task)
-                .Include(x => x.TeamMembers).ThenInclude(x => x.User)
-                .SingleOrDefaultAsync(a => a.Id == message.ItineraryId)
-                .ConfigureAwait(false);
-        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/ItineraryDetailsModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/ItineraryDetailsModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace AllReady.Areas.Admin.Models.ItineraryModels
 {
@@ -10,6 +11,8 @@ namespace AllReady.Areas.Admin.Models.ItineraryModels
         public int OrganizationId { get; set; }
         public int EventId { get; set; }
         public string EventName { get; set; }
+
+        public List<TeamListModel> TeamMembers { get; set; } = new List<TeamListModel>();
 
         public string DisplayDate => Date.ToLongDateString();
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/TeamListModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/TeamListModel.cs
@@ -1,0 +1,8 @@
+﻿namespace AllReady.Areas.Admin.Models.ItineraryModels
+{
+    public class TeamListModel
+    {
+        public string VolunteerEmail { get; set; }
+        public string TaskName { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -18,18 +18,52 @@
         <h2>
             @Model.Name
             @*<a asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
-            <a asp-controller="Itinerary" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>*@
+                <a asp-controller="Itinerary" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>*@
         </h2>
-        <p>Scheduled for @Model.DisplayDate</p>       
+        <p>Scheduled for @Model.DisplayDate</p>
     </div>
 </div>
 
 <div class="row">
     <div class="col-md-12">
         <h3>
-          Team
+            Team
         </h3>
-        <p>TODO</p>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-5">
+        @if (Model.TeamMembers.Any())
+        {
+            <table class="table">
+                <tr>
+                    <th>
+                        Email
+                    </th>
+                    <th>
+                        Assigned Task
+                    </th>
+                </tr>
+                @foreach (var teamMember in Model.TeamMembers)
+                {
+                    <tr>
+                        <td>
+                            <p>@teamMember.VolunteerEmail</p>
+                        </td>
+                        <td>
+                            <p>@teamMember.TaskName</p>
+                        </td>
+                    </tr>
+                }
+            </table>
+
+        }
+        else
+        {
+            <br />
+            <p>There are currently no assigned team members for this itinerary</p>
+        }
     </div>
 </div>
 


### PR DESCRIPTION
Closes #830 

Added a basic list showing any assigned team members on the itinerary details page. Currently just a user email and the name of the task they signed up for.

![image](https://cloud.githubusercontent.com/assets/3669103/15906543/38b35a52-2db1-11e6-8fbf-b23d468f70aa.png)

**Future improvements**
Once collected display the team member's full name as well as the email
Ability to remove a team member
Ability to link to task / hover over for more details
