### PR TITLE
Add team member to itinerary

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ItineraryAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ItineraryAdminControllerTests.cs
@@ -344,6 +344,68 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             Assert.IsType<BadRequestResult>(result);
         }
 
+        [Fact]
+        public void AddTeamMemberHasHttpPostAttribute()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var attribute = sut.GetAttributesOn(x => x.AddTeamMember(It.IsAny<int>(), It.IsAny<int>())).OfType<HttpPostAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void AddTeamMemberHasRouteAttributeWithCorrectRoute()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var routeAttribute = sut.GetAttributesOn(x => x.AddTeamMember(It.IsAny<int>(), It.IsAny<int>())).OfType<RouteAttribute>().SingleOrDefault();
+            Assert.NotNull(routeAttribute);
+            Assert.Equal(routeAttribute.Template, "Admin/Itinerary/AddTeamMember");
+        }
+
+        [Fact]
+        public void AddTeamMemberHasValidateAntiForgeryAttribute()
+        {
+            var sut = new ItineraryController(Mock.Of<IMediator>(), MockSuccessValidation().Object);
+            var routeAttribute = sut.GetAttributesOn(x => x.AddTeamMember(It.IsAny<int>(), It.IsAny<int>())).OfType<ValidateAntiForgeryTokenAttribute>().SingleOrDefault();
+            Assert.NotNull(routeAttribute);
+        }
+
+        [Fact]
+        public async Task AddTeamMemberCallsAddTeamMemberCommand()
+        {
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AddTeamMemberCommand>())).ReturnsAsync(true);
+
+            var sut = new ItineraryController(mockMediator.Object, MockSuccessValidation().Object);
+            await sut.AddTeamMember(1, 1);
+
+            mockMediator.Verify(x => x.SendAsync(It.IsAny<AddTeamMemberCommand>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task AddTeamMemberDoesNotCallAddTeamMemberCommand_WhenIdIsZero()
+        {
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AddTeamMemberCommand>())).ReturnsAsync(true);
+
+            var sut = new ItineraryController(mockMediator.Object, MockSuccessValidation().Object);
+            await sut.AddTeamMember(0, 1);
+
+            mockMediator.Verify(x => x.SendAsync(It.IsAny<AddTeamMemberCommand>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AddTeamMemberDoesNotCallAddTeamMemberCommand_WhenSelectedTeamMemberIsZero()
+        {
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AddTeamMemberCommand>())).ReturnsAsync(true);
+
+            var sut = new ItineraryController(mockMediator.Object, MockSuccessValidation().Object);
+            await sut.AddTeamMember(1, 0);
+
+            mockMediator.Verify(x => x.SendAsync(It.IsAny<AddTeamMemberCommand>()), Times.Never);
+        }
+
+
         #region Helper Methods
 
         private static Mock<IMediator> MockMediatorItineraryDetailQuery(out ItineraryController controller)

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsyncTests.cs
@@ -1,5 +1,7 @@
 ﻿using AllReady.Areas.Admin.Features.Itineraries;
 using AllReady.Models;
+using MediatR;
+using Moq;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -84,7 +86,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
         public async Task ItineraryExists_ReturnsItinerary()
         {           
             var query = new ItineraryDetailQuery { ItineraryId = 1 };
-            var handler = new ItineraryDetailQueryHandlerAsync(Context);
+            var handler = new ItineraryDetailQueryHandlerAsync(Context, Mock.Of<IMediator>());
             var result = await handler.Handle(query);
             Assert.NotNull(result);
         }
@@ -93,7 +95,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
         public async Task ItineraryDoesNotExist_ReturnsNull()
         {        
             var query = new ItineraryDetailQuery();
-            var handler = new ItineraryDetailQueryHandlerAsync(Context);
+            var handler = new ItineraryDetailQueryHandlerAsync(Context, Mock.Of<IMediator>());
             var result = await handler.Handle(query);
             Assert.Null(result);
         }
@@ -102,7 +104,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
         public async Task ItineraryQueryLoadsItineraryDetails()
         {
             var query = new ItineraryDetailQuery { ItineraryId = 1 };
-            var handler = new ItineraryDetailQueryHandlerAsync(Context);
+            var handler = new ItineraryDetailQueryHandlerAsync(Context, Mock.Of<IMediator>());
             var result = await handler.Handle(query);
             Assert.Equal(1, result.Id);
             Assert.Equal("1st Itinerary", result.Name);
@@ -113,7 +115,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
         public async Task ItineraryQueryLoadsEventDetails()
         {
             var query = new ItineraryDetailQuery { ItineraryId = 1 };
-            var handler = new ItineraryDetailQueryHandlerAsync(Context);
+            var handler = new ItineraryDetailQueryHandlerAsync(Context, Mock.Of<IMediator>());
             var result = await handler.Handle(query);
             Assert.Equal("Queen Anne Fire Prevention Day", result.EventName);
         }
@@ -122,7 +124,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
         public async Task ItineraryQueryLoadsOrganizationId()
         {
             var query = new ItineraryDetailQuery { ItineraryId = 1 };
-            var handler = new ItineraryDetailQueryHandlerAsync(Context);
+            var handler = new ItineraryDetailQueryHandlerAsync(Context, Mock.Of<IMediator>());
             var result = await handler.Handle(query);
             Assert.Equal(1, result.OrganizationId);
         }
@@ -131,7 +133,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
         public async Task ItineraryQueryLoadsTeamMembers()
         {
             var query = new ItineraryDetailQuery { ItineraryId = 1 };
-            var handler = new ItineraryDetailQueryHandlerAsync(Context);
+            var handler = new ItineraryDetailQueryHandlerAsync(Context, Mock.Of<IMediator>());
             var result = await handler.Handle(query);
             Assert.Equal(1, result.TeamMembers.Count);
             Assert.Equal("text@example.com", result.TeamMembers[0].VolunteerEmail);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -94,5 +94,24 @@ namespace AllReady.Areas.Admin.Controllers
 
             return HttpBadRequest();
         }
+
+        [HttpPost]
+        [Route("Admin/Itinerary/AddTeamMember")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> AddTeamMember(int id, int selectedTeamMember)
+        {
+            // todo: sgordon: This is not a very elegant at the moment as a failure would redirect without any feedback to the user
+            // this flow should be reviews and enhanced in a future PR using knockout to send and handle the error messaging on the details page
+            // for the purpose of the upcoming red cross testing I chose to leave this since a failure here would be an edge case
+
+            if (id == 0 || selectedTeamMember == 0)
+            {
+                return RedirectToAction("Details", new { id = id });
+            }
+
+            var isSuccess = await _mediator.SendAsync(new AddTeamMemberCommand { ItineraryId = id, TaskSignupId = selectedTeamMember });
+
+            return RedirectToAction("Details", new { id = id });
+        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddTeamMemberCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddTeamMemberCommand.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class AddTeamMemberCommand : IAsyncRequest<bool>
+    {
+        public int ItineraryId { get; set; }
+        public int TaskSignupId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddTeamMemberCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddTeamMemberCommandHandlerAsync.cs
@@ -1,0 +1,66 @@
+﻿using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+using System.Linq;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class AddTeamMemberCommandHandlerAsync : IAsyncRequestHandler<AddTeamMemberCommand, bool>
+    {
+        private readonly AllReadyContext _context;
+        private readonly IMediator _mediator;
+
+        public AddTeamMemberCommandHandlerAsync(AllReadyContext context, IMediator mediator)
+        {
+            _context = context;
+            _mediator = mediator;
+        }
+
+        public async Task<bool> Handle(AddTeamMemberCommand message)
+        {
+            var itinerary = await _context.Itineraries
+                .Where(x => x.Id == message.ItineraryId)
+                .Select(x => new
+                {
+                    EventId = x.EventId,
+                    Date = x.Date
+                }).SingleOrDefaultAsync();
+
+            if (itinerary == null)
+            {
+                // todo: sgordon: enhance this with a error message so the controller can better respond to the issue
+                return false;
+            }
+
+            // We requery for potential team members in case something has changed or the task signup id was modified before posting
+            var potentialTaskSignups = await _mediator.SendAsync(new PotentialItineraryTeamMembersQuery { EventId = itinerary.EventId, Date = itinerary.Date });
+
+            var matchedSignup = false;
+            foreach(var signup in potentialTaskSignups)
+            {
+                var id = int.Parse(signup.Value);
+                if (id == message.TaskSignupId)
+                {
+                    matchedSignup = true;
+                    break;
+                }
+            }
+                        
+            if(matchedSignup)
+            {
+                var taskSignup = new TaskSignup
+                {
+                    Id = message.TaskSignupId,
+                    ItineraryId = message.ItineraryId
+                };
+
+                _context.TaskSignups.Attach(taskSignup);
+                _context.Entry(taskSignup).Property(x => x.ItineraryId).IsModified = true;
+                await _context.SaveChangesAsync();
+            }
+            
+            return true;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/PotentialItineraryTeamMembersQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/PotentialItineraryTeamMembersQuery.cs
@@ -1,0 +1,14 @@
+﻿using AllReady.Areas.Admin.Models.ItineraryModels;
+using MediatR;
+using Microsoft.AspNet.Mvc.Rendering;
+using System;
+using System.Collections.Generic;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class PotentialItineraryTeamMembersQuery : IAsyncRequest<IEnumerable<SelectListItem>>
+    {
+        public int EventId { get; set; }
+        public DateTime Date { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/PotentialItineraryTeamMembersQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/PotentialItineraryTeamMembersQueryHandlerAsync.cs
@@ -1,0 +1,38 @@
+﻿using AllReady.Models;
+using MediatR;
+using Microsoft.AspNet.Mvc.Rendering;
+using Microsoft.Data.Entity;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class PotentialItineraryTeamMembersQueryHandlerAsync : IAsyncRequestHandler<PotentialItineraryTeamMembersQuery, IEnumerable<SelectListItem>>
+    {
+        private readonly AllReadyContext _context;
+
+        public PotentialItineraryTeamMembersQueryHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<SelectListItem>> Handle(PotentialItineraryTeamMembersQuery message)
+        {
+            return await _context.TaskSignups
+                .AsNoTracking()
+                .Include(x => x.Task).ThenInclude(x => x.Event)
+                .Include(x => x.User)
+                .Include(x => x.Itinerary)
+                .Where(x => x.Task.Event.Id == message.EventId)
+                .Where(x => x.Status == Tasks.TaskStatus.Accepted.ToString())
+                .Where(x => x.Itinerary == null)
+                .Where(x => x.Task.StartDateTime.HasValue && x.Task.StartDateTime.Value.Date == message.Date)
+                .Select(x => new SelectListItem
+                {
+                    Text = string.Concat(x.User.Email, " : ", x.Task.Name),
+                    Value = x.Id.ToString()
+                }).ToListAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/ItineraryDetailsModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/ItineraryDetailsModel.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿using Microsoft.AspNet.Mvc;
+using Microsoft.AspNet.Mvc.Rendering;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace AllReady.Areas.Admin.Models.ItineraryModels
 {
@@ -11,6 +14,10 @@ namespace AllReady.Areas.Admin.Models.ItineraryModels
         public int OrganizationId { get; set; }
         public int EventId { get; set; }
         public string EventName { get; set; }
+
+        public int SelectedTeamMember { get; set; }
+        public IEnumerable<SelectListItem> PotentialTeamMembers { get; set; } = new List<SelectListItem>();
+        public bool HasPotentialTeamMembers { get; set; }
 
         public List<TeamListModel> TeamMembers { get; set; } = new List<TeamListModel>();
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -18,7 +18,7 @@
         <h2>
             @Model.Name
             @*<a asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
-                <a asp-controller="Itinerary" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>*@
+            <a asp-controller="Itinerary" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>*@
         </h2>
         <p>Scheduled for @Model.DisplayDate</p>
     </div>
@@ -31,6 +31,26 @@
         </h3>
     </div>
 </div>
+
+
+@if (Model.HasPotentialTeamMembers)
+{
+    <div class="row">
+        <div class="col-md-12">
+            <form asp-controller="Itinerary" asp-action="AddTeamMember" method="post">
+                <input type="hidden" asp-for="Id" />
+                Add team member:
+                <select asp-for="SelectedTeamMember"
+                        asp-items="Model.PotentialTeamMembers" required></select>
+                <button type="submit" class="btn btn-default submit-form">Add</button>
+            </form>
+        </div>
+    </div>
+}
+else
+{
+    <p>There are no potential team members to add to this itinerary</p>
+}
 
 <div class="row">
     <div class="col-md-5">


### PR DESCRIPTION
Closes #835 

Added the ability to quick add a team member to an itinerary from a list of potential team members.
To make adding a team member a quick process (less clicks) this is done from a form directly on the Itinerary Details page.

If any potential team members exist they are shown in a dropdown list above the list of assigned team members.

![image](https://cloud.githubusercontent.com/assets/3669103/15941015/613ed954-2e76-11e6-9438-877325919f03.png)

If no potential team members exist the form is not shown

![image](https://cloud.githubusercontent.com/assets/3669103/15941030/6df4d40a-2e76-11e6-9b67-a3395cb6fd02.png)

**A potential team member is defined as follows:**
A person signed up to (and with accepted status) a task from the same event which is scheduled for the same date as the itinerary. We only show task signups that are not already linked to an itinerary. This assumes that the task signup and assignment logic will restrict a user from being assigned to two tasks within the same timeframe.

@tonysurma - The point above warrants some consideration and review as I'm not sure this rule is fully enforced? *Q1* For an itinerary event it would seem sensible to restrict signups by a user to a single task on a given date. However I'm not sure how that may affect all use cases.

What if we have an AM and PM session and want to assign a user to both? Since an itinerary is date bound only I'm not sure how we might want to handle the business rules. *Q2*

It feels better that would should check assignment to tasks for conflicts since in an edge case someone may try to volunteer for tasks from two different events/campaigns on the same day and time which we should also try to prevent by calculating their existing busy times. But that route opens further questions from me!!

cc/ @OhMcGoo 

NOTE:
The action handling this post is a little basic at the moment. If it fails for any reason it simple reloads the Itinerary details currently. There is an edge case where someone may be assigned by a different organizer to another itinerary between the list of potential team members being created and the user adding them. In that case our Mediator handler will catch and prevent a double assignment, however there will be no feedback on the UI. I have left a todo for this and will open an issue to enhance with knockout and improved messaging.

NOTE: No tests added for the AddTeamMemberCommandHandlerAsync at this point due to time. I will raise an issue for this to be addressed in a future PR.