### PR TITLE
Creating EditEventModel to avoid validation failures

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/EventAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/EventAdminControllerTests.cs
@@ -122,7 +122,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             mediator.Setup(x => x.SendAsync(It.IsAny<CampaignSummaryQuery>())).ReturnsAsync(new CampaignSummaryModel());
 
             var eventDetailModelValidator = new Mock<IValidateEventDetailModels>();
-            eventDetailModelValidator.Setup(x => x.Validate(It.IsAny<EventDetailModel>(), It.IsAny<CampaignSummaryModel>()))
+            eventDetailModelValidator.Setup(x => x.Validate(It.IsAny<EventEditModel>(), It.IsAny<CampaignSummaryModel>()))
                 .Returns(new List<KeyValuePair<string, string>>());
 
             var sut = new EventController(imageService.Object, mediator.Object, eventDetailModelValidator.Object);
@@ -133,7 +133,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             });
 
             sut.ModelState.AddModelError("test", "test");
-            var result = (ViewResult)await sut.Create(It.IsAny<int>(), It.IsAny<EventDetailModel>(), null);
+            var result = (ViewResult)await sut.Create(It.IsAny<int>(), It.IsAny<EventEditModel>(), null);
 
             Assert.Equal("Edit", result.ViewName);
         }
@@ -147,7 +147,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             mediator.Setup(x => x.SendAsync(It.IsAny<CampaignSummaryQuery>())).ReturnsAsync(new CampaignSummaryModel());
 
             var eventDetailModelValidator = new Mock<IValidateEventDetailModels>();
-            eventDetailModelValidator.Setup(x => x.Validate(It.IsAny<EventDetailModel>(), It.IsAny<CampaignSummaryModel>()))
+            eventDetailModelValidator.Setup(x => x.Validate(It.IsAny<EventEditModel>(), It.IsAny<CampaignSummaryModel>()))
                 .Returns(new List<KeyValuePair<string, string>> { new KeyValuePair<string, string>("ErrorKey", "ErrorMessage") });
 
             var sut = new EventController(imageService.Object, mediator.Object, eventDetailModelValidator.Object);
@@ -157,7 +157,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
                 new Claim(AllReady.Security.ClaimTypes.Organization, "1")
             });
 
-            var result = (ViewResult)await sut.Create(1, It.IsAny<EventDetailModel>(), null);
+            var result = (ViewResult)await sut.Create(1, It.IsAny<EventEditModel>(), null);
             Assert.Equal("Edit", result.ViewName);
         }
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Events/EditEvent.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Events/EditEvent.cs
@@ -38,7 +38,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Events
             context.Organizations.Add(htb);
             context.SaveChanges();
 
-            var vm = new EventDetailModel
+            var vm = new EventEditModel
             {
                 CampaignId = 1,
                 TimeZoneId = "Central Standard Time"
@@ -95,7 +95,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Events
 
             var startDateTime = new DateTime(2015, 7, 12, 4, 15, 0);
             var endDateTime = new DateTime(2015, 12, 7, 15, 10, 0);
-            var vm = new EventDetailModel
+            var vm = new EventEditModel
             {
                 CampaignId = queenAnne.CampaignId,
                 CampaignName = queenAnne.Campaign.Name,
@@ -108,10 +108,8 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Events
                 RequiredSkills = queenAnne.RequiredSkills,
                 TimeZoneId = "Central Standard Time",
                 StartDateTime = startDateTime,
-                Tasks = null,
                 OrganizationId = queenAnne.Campaign.ManagingOrganizationId,
                 OrganizationName = queenAnne.Campaign.ManagingOrganization.Name,
-                Volunteers = null
             };
             var query = new EditEventCommand { Event = vm };
             var handler = new EditEventCommandHandler(context);
@@ -202,7 +200,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Events
                 PhoneNumber = "New number"
             });
 
-            var locationEdit = new EventDetailModel
+            var locationEdit = new EventEditModel
             {
                 CampaignId = queenAnne.CampaignId,
                 CampaignName = queenAnne.Campaign.Name,
@@ -215,10 +213,8 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Events
                 RequiredSkills = queenAnne.RequiredSkills,
                 TimeZoneId = "Central Standard Time",
                 StartDateTime = queenAnne.StartDateTime,
-                Tasks = null,
                 OrganizationId = queenAnne.Campaign.ManagingOrganizationId,
                 OrganizationName = queenAnne.Campaign.ManagingOrganization.Name,
-                Volunteers = null
             };
 
             var query = new EditEventCommand { Event = locationEdit };

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Events/EditingEvent.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Events/EditingEvent.cs
@@ -20,7 +20,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Events
         public async Task ModelIsCreated()
         {
             var sut = new EditEventCommandHandler(Context);
-            var actual = await sut.Handle(new EditEventCommand {Event = new EventDetailModel {CampaignId = 1, Id = 1, TimeZoneId = "Central Standard Time"}});
+            var actual = await sut.Handle(new EditEventCommand {Event = new EventEditModel { CampaignId = 1, Id = 1, TimeZoneId = "Central Standard Time"}});
             Assert.Equal(1, actual);
         }
     }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Models/Validators/EventDetailModelValidatorShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Models/Validators/EventDetailModelValidatorShould.cs
@@ -10,9 +10,9 @@ namespace AllReady.UnitTest.Areas.Admin.Models.Validators
         [Fact]
         public void ReturnsCorrectErrorWhenEndDateTimeIsLessThanStartDateTime()
         {
-            var validator = new EventDetailModelValidator();
+            var validator = new EventEditModelValidator();
             var parentCampaign = new CampaignSummaryModel { EndDate = new DateTimeOffset(new DateTime(1999, 2, 1)) };
-            var model = new EventDetailModel
+            var model = new EventEditModel
             {
                 StartDateTime = new DateTimeOffset(new DateTime(2000, 1, 1)),
                 EndDateTime = new DateTimeOffset(new DateTime(1999, 1, 1))
@@ -27,14 +27,14 @@ namespace AllReady.UnitTest.Areas.Admin.Models.Validators
         [Fact]
         public void ReturnsCorrectErrorWhenModelsStartDateTimeIsLessThanParentCampaignsStartDate()
         {
-            var validator = new EventDetailModelValidator();
+            var validator = new EventEditModelValidator();
             var parentCampaign = new CampaignSummaryModel
             {
                 StartDate = new DateTimeOffset(new DateTime(2000, 1, 1)),
                 EndDate = new DateTimeOffset(new DateTime(2001, 2, 1))
             };
 
-            var model = new EventDetailModel
+            var model = new EventEditModel
             {
                 EndDateTime = new DateTimeOffset(new DateTime(2001, 1, 1))
             };
@@ -48,13 +48,13 @@ namespace AllReady.UnitTest.Areas.Admin.Models.Validators
         [Fact]
         public void RetrunsCorrectErrorWhenModelsEndDateTimeIsGreaterThanParentCampaignsEndDate()
         {
-            var validator = new EventDetailModelValidator();
+            var validator = new EventEditModelValidator();
             var parentCampaign = new CampaignSummaryModel
             {
                 StartDate = new DateTimeOffset(new DateTime(2000, 1, 1)),
                 EndDate = new DateTimeOffset(new DateTime(2001, 1, 1))
             };
-            var model = new EventDetailModel
+            var model = new EventEditModel
             {
                 StartDateTime = new DateTimeOffset(new DateTime(2001, 1, 1)),
                 EndDateTime = new DateTimeOffset(new DateTime(2001, 2, 1)),

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
@@ -71,7 +71,7 @@ namespace AllReady.Areas.Admin.Controllers
                 return HttpUnauthorized();
             }
 
-            var campaignEvent = new EventDetailModel
+            var campaignEvent = new EventEditModel
             {
                 CampaignId = campaign.Id,
                 CampaignName = campaign.Name,
@@ -89,7 +89,7 @@ namespace AllReady.Areas.Admin.Controllers
         [HttpPost]
         [ValidateAntiForgeryToken]
         [Route("Admin/Event/Create/{campaignId}")]
-        public async Task<IActionResult> Create(int campaignId, EventDetailModel campaignEvent, IFormFile fileUpload)
+        public async Task<IActionResult> Create(int campaignId, EventEditModel campaignEvent, IFormFile fileUpload)
         {
             var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
             if (campaign == null || !User.IsOrganizationAdmin(campaign.OrganizationId))
@@ -99,6 +99,8 @@ namespace AllReady.Areas.Admin.Controllers
 
             var errors = _eventDetailModelValidator.Validate(campaignEvent, campaign);
             errors.ToList().ForEach(e => ModelState.AddModelError(e.Key, e.Value));
+
+            ModelState.Remove("NewItinerary");
 
             //TryValidateModel is called explictly because of MVC 6 behavior that supresses model state validation during model binding when binding to an IFormFile.
             //See #619.
@@ -133,7 +135,7 @@ namespace AllReady.Areas.Admin.Controllers
         // GET: Event/Edit/5
         public async Task<IActionResult> Edit(int id)
         {
-            var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = id });
+            var campaignEvent = await _mediator.SendAsync(new EventEditQuery { EventId = id });
             if (campaignEvent == null)
             {
                 return HttpNotFound();
@@ -150,7 +152,7 @@ namespace AllReady.Areas.Admin.Controllers
         // POST: Event/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> Edit(EventDetailModel campaignEvent, IFormFile fileUpload)
+        public async Task<IActionResult> Edit(EventEditModel campaignEvent, IFormFile fileUpload)
         {
             if (campaignEvent == null)
             {
@@ -216,7 +218,7 @@ namespace AllReady.Areas.Admin.Controllers
             if (!User.IsOrganizationAdmin(organizationId))
                 return HttpUnauthorized();
 
-            var existingEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = model.Id });
+            var existingEvent = await _mediator.SendAsync(new EventEditQuery() { EventId = model.Id });
             var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = existingEvent.CampaignId });
             var newEvent = buildNewEventDetailsModel(existingEvent, model);
 
@@ -233,7 +235,7 @@ namespace AllReady.Areas.Admin.Controllers
             return View(model);
         }
 
-        private EventDetailModel buildNewEventDetailsModel(EventDetailModel existingEvent, DuplicateEventModel newEventDetails)
+        private EventEditModel buildNewEventDetailsModel(EventEditModel existingEvent, DuplicateEventModel newEventDetails)
         {
             existingEvent.Id = 0;
             existingEvent.Name = newEventDetails.Name;

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventEditQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventEditQuery.cs
@@ -3,8 +3,8 @@ using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Events
 {
-    public class EditEventCommand : IAsyncRequest<int>
+    public class EventEditQuery : IAsyncRequest<EventEditModel>
     {
-        public EventEditModel Event {get; set;}
+        public int EventId { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventEditQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventEditQueryHandlerAsync.cs
@@ -1,0 +1,62 @@
+﻿using AllReady.Areas.Admin.Models;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Events
+{
+    public class EventEditQueryHandlerAsync : IAsyncRequestHandler<EventEditQuery, EventEditModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public EventEditQueryHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<EventEditModel> Handle(EventEditQuery message)
+        {
+            EventEditModel result = null;
+
+            var campaignEvent = await GetEvent(message);
+
+            if (campaignEvent != null)
+            {
+                result = new EventEditModel
+                {
+                    Id = campaignEvent.Id,
+                    EventType = campaignEvent.EventType,
+                    CampaignName = campaignEvent.Campaign.Name,
+                    CampaignId = campaignEvent.Campaign.Id,
+                    OrganizationId = campaignEvent.Campaign.ManagingOrganizationId,
+                    OrganizationName = campaignEvent.Campaign.ManagingOrganization.Name,
+                    Name = campaignEvent.Name,
+                    Description = campaignEvent.Description,
+                    TimeZoneId = campaignEvent.Campaign.TimeZoneId,
+                    StartDateTime = campaignEvent.StartDateTime,
+                    EndDateTime = campaignEvent.EndDateTime,
+                    NumberOfVolunteersRequired = campaignEvent.NumberOfVolunteersRequired,
+                    IsLimitVolunteers = campaignEvent.IsLimitVolunteers,
+                    IsAllowWaitList = campaignEvent.IsAllowWaitList,
+                    Location = campaignEvent.Location.ToEditModel(),
+                    RequiredSkills = campaignEvent.RequiredSkills,
+                    ImageUrl = campaignEvent.ImageUrl,
+                };
+            }
+
+            return result;
+        }
+
+        private async Task<Event> GetEvent(EventEditQuery message)
+        {
+            return await _context.Events
+                .AsNoTracking()
+                .Include(a => a.Campaign).ThenInclude(a => a.ManagingOrganization)
+                .Include(a => a.RequiredSkills).ThenInclude(s => s.Skill).ThenInclude(s => s.ParentSkill)
+                .Include(a => a.Location)
+                .SingleOrDefaultAsync(a => a.Id == message.EventId)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventEditModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventEditModel.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using AllReady.Models;
+
+namespace AllReady.Areas.Admin.Models
+{
+    public class EventEditModel : EventSummaryModel
+    {
+        [UIHint("Location")]
+        public LocationEditModel Location { get; set; }
+
+        [Display(Name = "Required Skills")]
+        public IEnumerable<EventSkill> RequiredSkills { get; set; } = new List<EventSkill>();
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/EventEditModelValidator.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/Validators/EventEditModelValidator.cs
@@ -2,9 +2,9 @@
 
 namespace AllReady.Areas.Admin.Models.Validators
 {
-    public class EventDetailModelValidator : IValidateEventDetailModels
+    public class EventEditModelValidator : IValidateEventDetailModels
     {
-        public List<KeyValuePair<string, string>> Validate(EventDetailModel model, CampaignSummaryModel parentCampaign)
+        public List<KeyValuePair<string, string>> Validate(EventEditModel model, CampaignSummaryModel parentCampaign)
         {
             var result = new List<KeyValuePair<string, string>>();
 
@@ -29,6 +29,6 @@ namespace AllReady.Areas.Admin.Models.Validators
 
     public interface IValidateEventDetailModels
     {
-        List<KeyValuePair<string, string>> Validate(EventDetailModel model, CampaignSummaryModel parentCampaign);
+        List<KeyValuePair<string, string>> Validate(EventEditModel model, CampaignSummaryModel parentCampaign);
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Edit.cshtml
@@ -1,5 +1,5 @@
 @using System.Threading.Tasks
-@model  AllReady.Areas.Admin.Models.EventDetailModel
+@model  EventEditModel
 @inject AllReady.Services.ISelectListService SelectListService
 
 

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -116,7 +116,7 @@ namespace AllReady
             services.AddTransient<ISmsSender, AuthMessageSender>();
             services.AddTransient<IAllReadyDataAccess, AllReadyDataAccessEF7>();
             services.AddTransient<IDetermineIfATaskIsEditable, DetermineIfATaskIsEditable>();
-            services.AddTransient<IValidateEventDetailModels, EventDetailModelValidator>();
+            services.AddTransient<IValidateEventDetailModels, EventEditModelValidator>();
             services.AddTransient<ITaskSummaryModelValidator, TaskSummaryModelValidator>();
             services.AddTransient<IItineraryEditModelValidator, ItineraryEditModelValidator>();
             services.AddSingleton<IImageService, ImageService>();


### PR DESCRIPTION
Prior to this commit we were using the EventDetailsModel on the create/edit pages. However this model now contains extra properties, including a new Itinerary model which also have validation attributes. These were getting checked and failing required validation since when creating/editing an event we are not populating these properties.

It is therefore cleaner to have a model responsible for the event edit properties seperated from the more complex details model.

Close #853 