### PR TITLE
Adding ability to add requests to an itinerary

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddRequestsCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddRequestsCommand.cs
@@ -1,0 +1,15 @@
+﻿using AllReady.Areas.Admin.Models.ItineraryModels;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class AddRequestsCommand : IAsyncRequest<bool>
+    {
+        public int ItineraryId { get; set; }
+        public List<string> RequestIdsToAdd { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddRequestsCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddRequestsCommandHandlerAsync.cs
@@ -1,0 +1,87 @@
+﻿using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+using System.Linq;
+using System;
+using System.Collections.Generic;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class AddRequestsCommandHandlerAsync : IAsyncRequestHandler<AddRequestsCommand, bool>
+    {
+        private readonly AllReadyContext _context;
+        private readonly IMediator _mediator;
+
+        public AddRequestsCommandHandlerAsync(AllReadyContext context, IMediator mediator)
+        {
+            _context = context;
+            _mediator = mediator;
+        }
+
+        public async Task<bool> Handle(AddRequestsCommand message)
+        {
+            var itinerary = await _context.Itineraries
+              .Where(x => x.Id == message.ItineraryId)
+              .Select(x => new
+              {
+                  Id = x.Id,
+                  Name = x.Name
+              }).SingleOrDefaultAsync();
+
+            if (itinerary == null)
+            {
+                // todo: sgordon: enhance this with a error message so the controller can better respond to the issue
+                return false;
+            }
+
+            var requestsToUpdate = await _context.Requests
+                .Where(r => message.RequestIdsToAdd.Contains(r.RequestId.ToString()))
+                .ToListAsync();
+
+            HashSet<string> foundRequests = new HashSet<string>(requestsToUpdate.Select(s => s.RequestId.ToString()));
+
+            var notFound = message.RequestIdsToAdd.Where(m => !foundRequests.Contains(m));
+
+            if (notFound.Count() > 0)
+            {
+                // Something went wrong as some of the ids passed in where not matched in the database
+                // todo: sgordon: we should enhance the returned object to include a message so that the controller can provide better feedback to the user
+                return false;
+            }
+
+            if (requestsToUpdate.Count > 0)
+            {
+                var orderIndex = await _context.ItineraryRequests.AsNoTracking()
+                    .Where(i => i.ItineraryId == itinerary.Id)
+                    .OrderByDescending(i => i.OrderIndex)
+                    .Select(i => i.OrderIndex)
+                    .FirstOrDefaultAsync();
+
+                foreach (var request in requestsToUpdate)
+                {
+                    orderIndex++;
+
+                    if (request.Status == RequestStatus.UnAssigned)
+                    {
+                        request.Status = RequestStatus.Assigned;
+
+                        _context.ItineraryRequests.Add(new ItineraryRequest
+                        {
+                            ItineraryId = itinerary.Id,
+                            Request = request,
+                            OrderIndex = orderIndex,
+                            DateAssigned = DateTime.UtcNow // Note, we're storing system event dates as UTC time.
+                        });
+
+                        // todo: sgordon: Add a history record here and include the assigned date in the ItineraryRequest
+                    }
+                }
+
+                await _context.SaveChangesAsync();
+            }        
+
+            return true;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
@@ -49,7 +49,7 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                         Name = r.Request.Name,
                         Address = r.Request.Address,
                         City = r.Request.City,
-                        Status = r.Request.Status.ToString()
+                        Status = r.Request.Status
                     }).ToList()
                 })
                 .SingleOrDefaultAsync().ConfigureAwait(false);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Organizations/OrganizationIdQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Organizations/OrganizationIdQuery.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Organizations
+{
+    public class OrganizationIdQuery : IAsyncRequest<int>
+    {
+        public int? ItineraryId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Organizations/OrganizationIdQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Organizations/OrganizationIdQueryHandlerAsync.cs
@@ -1,0 +1,34 @@
+﻿using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Organizations
+{
+    public class OrganizationIdQueryHandlerAsync : IAsyncRequestHandler<OrganizationIdQuery, int>
+    {
+        private readonly AllReadyContext _context;
+
+        public OrganizationIdQueryHandlerAsync(AllReadyContext context)
+        {
+            this._context = context;
+        }
+
+        public async Task<int> Handle(OrganizationIdQuery message)
+        {
+            if (message.ItineraryId.HasValue)
+            {
+                return await _context.Itineraries.AsNoTracking()
+                    .Include(i => i.Event.Campaign)
+                    .Where(i => i.Id == message.ItineraryId.Value)
+                    .Select(i => i.Event.Campaign.ManagingOrganizationId)
+                    .FirstOrDefaultAsync();
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQuery.cs
@@ -1,0 +1,12 @@
+﻿using AllReady.Areas.Admin.Models.ItineraryModels;
+using AllReady.Areas.Admin.Models.RequestModels;
+using MediatR;
+using System.Collections.Generic;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class RequestListItemsQuery : IAsyncRequest<List<RequestListModel>>
+    {
+        public RequestSearchCriteria criteria { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQueryHandlerAsync.cs
@@ -1,0 +1,47 @@
+﻿using AllReady.Areas.Admin.Models.ItineraryModels;
+using AllReady.Models;
+using AllReady.Services;
+using MediatR;
+using Microsoft.Data.Entity;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class RequestListItemsQueryHandlerAsync : IAsyncRequestHandler<RequestListItemsQuery, List<RequestListModel>>
+    {
+        private readonly AllReadyContext _context;
+
+        public RequestListItemsQueryHandlerAsync(AllReadyContext context, IMediator mediator)
+        {
+            _context = context;
+        }
+
+        public async Task<List<RequestListModel>> Handle(RequestListItemsQuery message)
+        {
+            var results = _context.Requests.AsNoTracking()
+                .Where(r => r.Status == RequestStatus.UnAssigned);
+
+            // Apply filtering based on criteria
+            if (message.criteria.RequestId.HasValue)
+            { 
+            results = results.Where(r => r.RequestId == message.criteria.RequestId.Value);
+            }
+
+            if (message.criteria.IncludeAssigned)
+            {
+                results = results.Where(r => r.Status == RequestStatus.Assigned);
+            }
+
+            if(message.criteria.IncludeCanceled)
+            {
+                results = results.Where(r => r.Status == RequestStatus.Canceled);
+            }
+
+            // todo: sgordon: date added filtering
+
+            return await results.Select(r => new RequestListModel { Id = r.RequestId, Name = r.Name, Address = r.Address, City = r.City, Status = r.Status }).ToListAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/RequestListModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/RequestListModel.cs
@@ -1,10 +1,14 @@
-﻿namespace AllReady.Areas.Admin.Models.ItineraryModels
+﻿using AllReady.Models;
+using System;
+
+namespace AllReady.Areas.Admin.Models.ItineraryModels
 {
     public class RequestListModel
     {
+        public Guid Id { get; set; }
         public string Name { get; set; }
         public string Address { get; set; }
         public string City { get; set; }
-        public string Status { get; set; }
+        public RequestStatus Status { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/RequestSelectModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/RequestSelectModel.cs
@@ -1,0 +1,7 @@
+﻿namespace AllReady.Areas.Admin.Models.ItineraryModels
+{
+    public class RequestSelectModel : RequestListModel
+    {
+        public bool IsSelected { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/SelectItineraryRequestsModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/SelectItineraryRequestsModel.cs
@@ -1,0 +1,20 @@
+﻿using AllReady.Areas.Admin.Models.RequestModels;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Models.ItineraryModels
+{
+    public class SelectItineraryRequestsModel
+    {
+        public string ItineraryName { get; set; }
+        public int EventId { get; set; }
+        public string EventName { get; set; }
+        public int CampaignId { get; set; }
+        public string CampaignName { get; set; }
+
+        public RequestSearchCriteria Criteria { get; set; }
+        public List<RequestSelectModel> Requests { get; set; } = new List<RequestSelectModel>();
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/RequestModels/RequestSearchCriteria.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/RequestModels/RequestSearchCriteria.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace AllReady.Areas.Admin.Models.RequestModels
+{
+    public class RequestSearchCriteria
+    {
+        public Guid? RequestId { get; set; }
+        public bool IncludeAssigned { get; set; } = false;
+        public bool IncludeCanceled { get; set; } = false;
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -102,7 +102,11 @@ else
         </h3>
     </div>
 </div>
-
+<div class="row">
+    <div class="col-md-12">
+        <a asp-action="SelectRequests" asp-controller="Itinerary" asp-route-area="Admin" class="btn btn-default">Add Requests</a>
+    </div>
+</div>
 <div class="row">
     <div class="col-md-12">
         @if (Model.Requests.Any())

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/SelectRequests.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/SelectRequests.cshtml
@@ -1,0 +1,74 @@
+﻿@model AllReady.Areas.Admin.Models.ItineraryModels.SelectItineraryRequestsModel
+
+@{
+    ViewData["Title"] = "Select Requests";
+}
+
+@{
+    ViewData["Title"] = "Select Requests";
+}
+
+<div class="row">
+    <div class="col-12">
+        <ol class="breadcrumb">
+            <li><a asp-controller="Campaign" asp-action="Index" asp-route-area="Admin">Campaigns</a></li>
+            <li><a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.CampaignId" asp-route-area="Admin">@Model.CampaignName</a></li>
+            <li><a asp-controller="Event" asp-action="Details" asp-route-area="Admin" asp-route-id="@Model.EventId">@Model.EventName</a></li>
+            <li><a asp-action="Details" asp-controller="Itinerary" asp-route-area="Admin">@Model.ItineraryName</a></li>
+            <li>Select Requests</li>
+        </ol>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-12">
+        <h2>Select Requests</h2>
+        <p>Please choose the requests you would like to add to your itinerary.</p>
+    </div>
+</div>
+
+<form asp-controller="Itinerary" asp-action="AddRequests">
+
+    <div class="row">
+        <div class="col-12">
+            <button type="submit" class="btn btn-primary submit-form">Add Selected Requests</button>
+            <a asp-action="Details" asp-controller="Itinerary" asp-route-area="Admin" class="btn btn-default">Cancel</a>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            @if (Model.Requests.Count > 0)
+            {
+            <table class="table">
+                <tr>
+                    <th></th>
+                    <th>Request Name</th>
+                    <th>Address</th>
+                    <th>City</th>
+                    <th>Date Added</th>
+                </tr>
+                @foreach (var req in Model.Requests)
+                {
+                    <tr>
+                        <td>
+                            <input type="checkbox" name="selectedRequests" value="@req.Id" @Html.Raw(req.IsSelected) ? "checked" : "" ) />
+                        </td>
+                        <td>@req.Name</td>
+                        <td>@req.Address</td>
+                        <td>@req.City</td>
+                        <td>TODO</td>
+                    </tr>
+                }
+            </table>
+            }
+            else
+            {
+                <br />
+                <p>There are no new requests which can be added</p>
+            }
+
+        </div>
+    </div>
+
+</form>

--- a/AllReadyApp/Web-App/AllReady/Migrations/20160616190604_ItineraryRequestChanges.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20160616190604_ItineraryRequestChanges.Designer.cs
@@ -1,0 +1,802 @@
+using System;
+using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Migrations;
+using AllReady.Models;
+
+namespace AllReady.Migrations
+{
+    [DbContext(typeof(AllReadyContext))]
+    [Migration("20160616190604_ItineraryRequestChanges")]
+    partial class ItineraryRequestChanges
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "7.0.0-rc1-16348")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset?>("EndDateTime");
+
+                    b.Property<int?>("EventId");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<DateTimeOffset?>("StartDateTime");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PendingNewEmail");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasAnnotation("Relational:Name", "EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .HasAnnotation("Relational:Name", "UserNameIndex");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUsers");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignImpactId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<string>("ExternalUrl");
+
+                    b.Property<string>("ExternalUrlText");
+
+                    b.Property<bool>("Featured");
+
+                    b.Property<string>("FullDescription");
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<bool>("Locked");
+
+                    b.Property<int>("ManagingOrganizationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.Property<int>("CampaignId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.HasKey("CampaignId", "ContactId", "ContactType");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignImpact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CurrentImpactLevel");
+
+                    b.Property<bool>("Display");
+
+                    b.Property<int>("ImpactType");
+
+                    b.Property<int>("NumericImpactGoal");
+
+                    b.Property<string>("TextualImpactGoal");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignId");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ClosestLocation", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<double>("Distance");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Contact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Event", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CampaignId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<int>("EventType");
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<DateTime?>("CheckinDateTime");
+
+                    b.Property<int?>("EventId");
+
+                    b.Property<string>("PreferredEmail");
+
+                    b.Property<string>("PreferredPhoneNumber");
+
+                    b.Property<DateTime>("SignupDateTime");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSkill", b =>
+                {
+                    b.Property<int>("EventId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("EventId", "SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Itinerary", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime>("Date");
+
+                    b.Property<int>("EventId");
+
+                    b.Property<string>("Name");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>
+                {
+                    b.Property<int>("ItineraryId");
+
+                    b.Property<Guid>("RequestId");
+
+                    b.Property<DateTime>("DateAssigned");
+
+                    b.Property<int>("OrderIndex");
+
+                    b.HasKey("ItineraryId", "RequestId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Location", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address1");
+
+                    b.Property<string>("Address2");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("Country");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("LogoUrl");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("PrivacyPolicy");
+
+                    b.Property<string>("WebUrl");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.Property<int>("OrganizationId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.HasKey("OrganizationId", "ContactId", "ContactType");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeo", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeoCoordinate", b =>
+                {
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.HasKey("Latitude", "Longitude");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.Property<Guid>("RequestId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address");
+
+                    b.Property<string>("City");
+
+                    b.Property<DateTime>("DateAdded");
+
+                    b.Property<string>("Email");
+
+                    b.Property<int?>("EventId");
+
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("Phone");
+
+                    b.Property<string>("ProviderData");
+
+                    b.Property<string>("ProviderId");
+
+                    b.Property<string>("State");
+
+                    b.Property<int>("Status");
+
+                    b.Property<string>("Zip");
+
+                    b.HasKey("RequestId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Resource", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("CategoryTag");
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("MediaUrl");
+
+                    b.Property<string>("Name");
+
+                    b.Property<DateTime>("PublishDateBegin");
+
+                    b.Property<DateTime>("PublishDateEnd");
+
+                    b.Property<string>("ResourceUrl");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int?>("OwningOrganizationId");
+
+                    b.Property<int?>("ParentSkillId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<int?>("ItineraryId");
+
+                    b.Property<string>("PreferredEmail");
+
+                    b.Property<string>("PreferredPhoneNumber");
+
+                    b.Property<string>("Status");
+
+                    b.Property<DateTime>("StatusDateTimeUtc");
+
+                    b.Property<string>("StatusDescription");
+
+                    b.Property<int?>("TaskId");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.Property<int>("TaskId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("TaskId", "SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("UserId", "SkillId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRole", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Name")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .HasAnnotation("Relational:Name", "RoleNameIndex");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetRoles");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("RoleId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetRoleClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserClaims");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider");
+
+                    b.Property<string>("ProviderKey");
+
+                    b.Property<string>("ProviderDisplayName");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserLogins");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<string>("RoleId");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasAnnotation("Relational:TableName", "AspNetUserRoles");
+                });
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.HasOne("AllReady.Models.CampaignImpact")
+                        .WithMany()
+                        .HasForeignKey("CampaignImpactId");
+
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("ManagingOrganizationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Event", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign")
+                        .WithMany()
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSignup", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Itinerary", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>
+                {
+                    b.HasOne("AllReady.Models.Itinerary")
+                        .WithMany()
+                        .HasForeignKey("ItineraryId");
+
+                    b.HasOne("AllReady.Models.Request")
+                        .WithMany()
+                        .HasForeignKey("RequestId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.HasOne("AllReady.Models.Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId");
+
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.HasOne("AllReady.Models.Event")
+                        .WithMany()
+                        .HasForeignKey("EventId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany()
+                        .HasForeignKey("OwningOrganizationId");
+
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("ParentSkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.HasOne("AllReady.Models.Itinerary")
+                        .WithMany()
+                        .HasForeignKey("ItineraryId");
+
+                    b.HasOne("AllReady.Models.AllReadyTask")
+                        .WithMany()
+                        .HasForeignKey("TaskId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+
+                    b.HasOne("AllReady.Models.AllReadyTask")
+                        .WithMany()
+                        .HasForeignKey("TaskId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNet.Identity.EntityFramework.IdentityRole")
+                        .WithMany()
+                        .HasForeignKey("RoleId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNet.Identity.EntityFramework.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNet.Identity.EntityFramework.IdentityRole")
+                        .WithMany()
+                        .HasForeignKey("RoleId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20160616190604_ItineraryRequestChanges.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20160616190604_ItineraryRequestChanges.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.Data.Entity.Migrations;
+
+namespace AllReady.Migrations
+{
+    public partial class ItineraryRequestChanges : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DateAdded",
+                table: "Request",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DateAssigned",
+                table: "ItineraryRequest",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+            migrationBuilder.AddColumn<int>(
+                name: "OrderIndex",
+                table: "ItineraryRequest",
+                nullable: false,
+                defaultValue: 0);          
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(name: "DateAdded", table: "Request");
+            migrationBuilder.DropColumn(name: "DateAssigned", table: "ItineraryRequest");
+            migrationBuilder.DropColumn(name: "OrderIndex", table: "ItineraryRequest");          
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
@@ -2,6 +2,7 @@ using System;
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Migrations;
 using AllReady.Models;
 
 namespace AllReady.Migrations
@@ -295,6 +296,10 @@ namespace AllReady.Migrations
 
                     b.Property<Guid>("RequestId");
 
+                    b.Property<DateTime>("DateAssigned");
+
+                    b.Property<int>("OrderIndex");
+
                     b.HasKey("ItineraryId", "RequestId");
                 });
 
@@ -380,6 +385,8 @@ namespace AllReady.Migrations
                     b.Property<string>("Address");
 
                     b.Property<string>("City");
+
+                    b.Property<DateTime>("DateAdded");
 
                     b.Property<string>("Email");
 

--- a/AllReadyApp/Web-App/AllReady/Models/ItineraryRequest.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/ItineraryRequest.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace AllReady.Models
 {
@@ -7,9 +11,18 @@ namespace AllReady.Models
     /// </summary>
     public class ItineraryRequest
     {
+        [Required]
         public int ItineraryId { get; set; }
         public Itinerary Itinerary { get; set; }
+
+        [Required]
         public Guid RequestId { get; set; }
         public Request Request { get; set; }
+
+        [Required]
+        public DateTime DateAssigned { get; set; }
+
+        [Required]
+        public int OrderIndex { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Models/Request.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Request.cs
@@ -33,5 +33,7 @@ namespace AllReady.Models
         public Event Event { get; set; }
 
         public ICollection<ItineraryRequest> Itineraries { get; set; }
+
+        public DateTime DateAdded { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Models/RequestStatus.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/RequestStatus.cs
@@ -2,9 +2,9 @@
 {
     public enum RequestStatus
     {
-        New,
-        Assigned,
-        Completed,
-        Canceled
+        UnAssigned = 0,
+        Assigned = 1,
+        Completed = 2,
+        Canceled = 3
     }
 }


### PR DESCRIPTION
Closes #880 

After reverting prior commit this PR includes the intended original functionality to allow selection of requests which can then be added to an itinerary.