### PR TITLE
Allow removal of an assigned team member from an itinerary

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
@@ -40,6 +40,7 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                     OrganizationId = i.Event.Campaign.ManagingOrganizationId,
                     TeamMembers = i.TeamMembers.Select(tm => new TeamListModel
                     {
+                        TaskSignupId = tm.Id,
                         VolunteerEmail = tm.User.Email,
                         TaskName = tm.Task.Name,
                         FullName = tm.User.Name

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveTeamMemberCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveTeamMemberCommand.cs
@@ -1,0 +1,9 @@
+﻿using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class RemoveTeamMemberCommand : IAsyncRequest<bool>
+    {
+        public int TaskSignupId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveTeamMemberCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveTeamMemberCommandHandlerAsync.cs
@@ -1,0 +1,33 @@
+﻿using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class RemoveTeamMemberCommandHandlerAsync : IAsyncRequestHandler<RemoveTeamMemberCommand, bool>
+    {
+        private readonly AllReadyContext _context;
+
+        public RemoveTeamMemberCommandHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<bool> Handle(RemoveTeamMemberCommand message)
+        {
+            var taskSignup = await _context.TaskSignups
+                .FirstOrDefaultAsync(x => x.Id == message.TaskSignupId);
+
+            if (taskSignup == null)
+            {
+                return false;
+            }
+
+            taskSignup.ItineraryId = null;
+            await _context.SaveChangesAsync();
+            
+            return true;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveTeamMemberCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveTeamMemberCommandHandlerAsync.cs
@@ -17,7 +17,7 @@ namespace AllReady.Areas.Admin.Features.Itineraries
         public async Task<bool> Handle(RemoveTeamMemberCommand message)
         {
             var taskSignup = await _context.TaskSignups
-                .FirstOrDefaultAsync(x => x.Id == message.TaskSignupId);
+                .FirstOrDefaultAsync(x => x.Id == message.TaskSignupId).ConfigureAwait(false);
 
             if (taskSignup == null)
             {
@@ -25,7 +25,7 @@ namespace AllReady.Areas.Admin.Features.Itineraries
             }
 
             taskSignup.ItineraryId = null;
-            await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync().ConfigureAwait(false);
             
             return true;
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/TaskSignups/TaskSignupSummaryQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/TaskSignups/TaskSignupSummaryQuery.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Areas.Admin.Models.TaskSignupModels;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.TaskSignups
+{
+    public class TaskSignupSummaryQuery : IAsyncRequest<TaskSignupSummaryModel>
+    {
+        public int TaskSignupId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/TaskSignups/TaskSignupSummaryQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/TaskSignups/TaskSignupSummaryQueryHandlerAsync.cs
@@ -29,7 +29,7 @@ namespace AllReady.Areas.Admin.Features.TaskSignups
                             VolunteerName = x.User.Name,
                             VolunteerEmail = x.PreferredEmail ?? x.User.Email
                         })
-                .FirstOrDefaultAsync();
+                .FirstOrDefaultAsync().ConfigureAwait(false);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/TaskSignups/TaskSignupSummaryQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/TaskSignups/TaskSignupSummaryQueryHandlerAsync.cs
@@ -1,0 +1,35 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Areas.Admin.Models.TaskSignupModels;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+
+namespace AllReady.Areas.Admin.Features.TaskSignups
+{
+    public class TaskSignupSummaryQueryHandlerAsync : IAsyncRequestHandler<TaskSignupSummaryQuery, TaskSignupSummaryModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public TaskSignupSummaryQueryHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<TaskSignupSummaryModel> Handle(TaskSignupSummaryQuery message)
+        {
+            return await _context.TaskSignups.AsNoTracking()
+                .Include(x => x.User)
+                .Where(x => x.Id == message.TaskSignupId)
+                .Select(
+                    x =>
+                        new TaskSignupSummaryModel
+                        {
+                            TaskSignupId = x.Id,
+                            VolunteerName = x.User.Name,
+                            VolunteerEmail = x.PreferredEmail ?? x.User.Email
+                        })
+                .FirstOrDefaultAsync();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/TeamListModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/TeamListModel.cs
@@ -2,6 +2,7 @@
 {
     public class TeamListModel
     {
+        public int TaskSignupId { get; set; }
         public string VolunteerEmail { get; set; }
         public string TaskName { get; set; }
         public string FullName { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/TaskSignupModels/TaskSignupSummaryModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/TaskSignupModels/TaskSignupSummaryModel.cs
@@ -1,0 +1,9 @@
+﻿namespace AllReady.Areas.Admin.Models.TaskSignupModels
+{
+    public class TaskSignupSummaryModel
+    {
+        public int TaskSignupId { get; set; }
+        public string VolunteerName { get; set; }
+        public string VolunteerEmail { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/ConfirmRemoveTeamMember.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/ConfirmRemoveTeamMember.cshtml
@@ -1,0 +1,31 @@
+﻿@model AllReady.Areas.Admin.Models.TaskSignupModels.TaskSignupSummaryModel
+
+@{  ViewData["Title"] = "Remove team member:  " + Model.VolunteerName; }
+
+<div class="row">
+    <div class="col-md-12">
+        <h3>Are you sure you want to remove this team member?</h3>
+        <h4>@ViewData["Title"]</h4>
+
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <dl class="dl-horizontal">
+            <dt>
+                @Html.DisplayNameFor(model => model.VolunteerName)
+            </dt>
+            <dd>
+                @Html.DisplayFor(model => model.VolunteerEmail)
+            </dd>
+        </dl>
+
+        <form asp-controller="Itinerary" asp-action="RemoveTeamMember" asp-route-itineraryId="@ViewContext.RouteData.Values["itineraryId"]?.ToString()" asp-route-taskSignupId="@Model.TaskSignupId">
+            <input type="hidden" asp-for="@Model.TaskSignupId" />
+            <div class="form-actions no-color">
+                <button type="submit" class="btn btn-primary">Delete</button>
+                <a asp-controller="Itinerary" asp-action="Details" asp-route-area="Admin" asp-route-id="@ViewContext.RouteData.Values["itineraryId"]?.ToString()" class="btn btn-default">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -69,6 +69,7 @@ else
                     <th>
                         Assigned Task
                     </th>
+                    <th></th>
                 </tr>
                 @foreach (var teamMember in Model.TeamMembers)
                 {
@@ -81,6 +82,9 @@ else
                         </td>
                         <td>
                             <p>@teamMember.TaskName</p>
+                        </td>
+                        <td>
+                            <a data-toggle="tooltip" data-placement="top" title="Remove" asp-action="ConfirmRemoveTeamMember" asp-controller="Itinerary" asp-route-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-taskSignupId="@teamMember.TaskSignupId" class="btn btn-danger"><span class="fa fa-remove"></span></a>
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
Basic v1 functionality to allow assigned team members to be removed via the itinerary management screen.

Note this does not include any tests which will need to follow.

This also does not include un-assignment notifications as this is a feature @mgmccarthy is working on.