### PR TITLE
Unassign request from an itinerary

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -219,6 +219,44 @@ namespace AllReady.Areas.Admin.Controllers
             return RedirectToAction("Details", new {id = itineraryId });
         }
 
+        [HttpGet]
+        [Route("Admin/Itinerary/{itineraryId}/[Action]/{requestId}")]
+        public async Task<IActionResult> ConfirmRemoveRequest(int itineraryId, Guid requestId)
+        {
+            var orgId = await GetOrganizationIdBy(itineraryId);
+
+            if (orgId == 0 || !User.IsOrganizationAdmin(orgId))
+            {
+                return HttpUnauthorized();
+            }
+
+            var model = await _mediator.SendAsync(new RequestSummaryQuery { RequestId = requestId });
+
+            if (model == null)
+            {
+                return HttpNotFound();
+            }
+
+            return View("ConfirmRemoveRequest", model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Route("Admin/Itinerary/{itineraryId}/[Action]/{requestId}")]
+        public async Task<IActionResult> RemoveRequest(int itineraryId, Guid requestId)
+        {
+            var orgId = await GetOrganizationIdBy(itineraryId);
+
+            if (orgId == 0 || !User.IsOrganizationAdmin(orgId))
+            {
+                return HttpUnauthorized();
+            }
+
+            var result = await _mediator.SendAsync(new RemoveRequestCommand { RequestId = requestId, ItineraryId = itineraryId });
+
+            return RedirectToAction("Details", new { id = itineraryId });
+        }
+
         private async Task<int> GetOrganizationIdBy(int intinerayId)
         {
             return await _mediator.SendAsync(new OrganizationIdQuery { ItineraryId = intinerayId });

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandlerAsync.cs
@@ -47,6 +47,7 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                     }).ToList(),
                     Requests = i.Requests.Select(r => new RequestListModel
                     {
+                        Id = r.Request.RequestId,
                         Name = r.Request.Name,
                         Address = r.Request.Address,
                         City = r.Request.City,

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveRequestCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveRequestCommand.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+using System;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class RemoveRequestCommand : IAsyncRequest<bool>
+    {
+        public Guid RequestId { get; set; }
+        public int ItineraryId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveRequestCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveRequestCommandHandlerAsync.cs
@@ -1,0 +1,51 @@
+﻿using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+using System.Linq;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class RemoveRequestCommandHandlerAsync : IAsyncRequestHandler<RemoveRequestCommand, bool>
+    {
+        private readonly AllReadyContext _context;
+
+        public RemoveRequestCommandHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<bool> Handle(RemoveRequestCommand message)
+        {
+            var itineraryRequests = await _context.ItineraryRequests
+                .Include(r => r.Itinerary)
+                .Include(r => r.Request)
+                .Where(r => r.ItineraryId == message.ItineraryId)
+                .ToListAsync().ConfigureAwait(false);
+
+            var requestToRemove = itineraryRequests.FirstOrDefault(r => r.RequestId == message.RequestId);
+
+            if (requestToRemove == null || requestToRemove.Request.Status == RequestStatus.Completed)
+            {
+                return false;
+            }
+
+            // Update the request status
+            requestToRemove.Request.Status = RequestStatus.UnAssigned;        
+
+            // remove the request to itinerary assignment
+            _context.ItineraryRequests.Remove(requestToRemove);
+
+            var requestsToMoveUp = itineraryRequests.Where(r => r.ItineraryId == message.ItineraryId && r.OrderIndex > requestToRemove.OrderIndex);
+
+            foreach(var requestToMoveUp in requestsToMoveUp)
+            {
+                requestToMoveUp.OrderIndex--;
+            }
+
+            await _context.SaveChangesAsync().ConfigureAwait(false);
+
+            return true;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestSummaryQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestSummaryQuery.cs
@@ -1,0 +1,11 @@
+﻿using AllReady.Areas.Admin.Models.RequestModels;
+using MediatR;
+using System;
+
+namespace AllReady.Areas.Admin.Features.TaskSignups
+{
+    public class RequestSummaryQuery : IAsyncRequest<RequestSummaryModel>
+    {
+        public Guid RequestId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestSummaryQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestSummaryQueryHandlerAsync.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Data.Entity;
+using AllReady.Areas.Admin.Models.RequestModels;
+
+namespace AllReady.Areas.Admin.Features.TaskSignups
+{
+    public class RequestSummaryQueryHandlerAsync : IAsyncRequestHandler<RequestSummaryQuery, RequestSummaryModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public RequestSummaryQueryHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<RequestSummaryModel> Handle(RequestSummaryQuery message)
+        {
+            return await _context.Requests.AsNoTracking()
+                .Where(x => x.RequestId == message.RequestId)
+                .Select(
+                    x =>
+                        new RequestSummaryModel
+                        {
+                            Id = x.RequestId,
+                            Name = x.Name,
+                            Address = x.Address,
+                            City = x.City,
+                            State = x.State,
+                            Status = x.Status
+                        })
+                .FirstOrDefaultAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/RequestModels/RequestSummaryModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/RequestModels/RequestSummaryModel.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Areas.Admin.Models.ItineraryModels;
+
+namespace AllReady.Areas.Admin.Models.RequestModels
+{
+    public class RequestSummaryModel : RequestListModel
+    {
+        public string State { get; set; }
+        public string Zip { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/ConfirmRemoveRequest.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/ConfirmRemoveRequest.cshtml
@@ -1,0 +1,32 @@
+﻿@model AllReady.Areas.Admin.Models.RequestModels.RequestSummaryModel
+
+@{  ViewData["Title"] = "Remove request:  " + Model.Name; }
+
+<div class="row">
+    <div class="col-md-12">
+        <h3>Are you sure you want to remove this request?</h3>
+        <h4>@ViewData["Title"]</h4>
+
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <h5>Request Address</h5>
+        <p>
+            @Html.DisplayFor(model => model.Address) <br />
+            @Html.DisplayNameFor(model => model.City) <br />
+            @Html.DisplayFor(model => model.State) <br />
+            @Html.DisplayFor(model => model.Zip) <br />
+
+            Status: @Html.DisplayFor(model => model.Status)
+        </p>
+
+        <form asp-controller="Itinerary" asp-action="RemoveRequest" asp-route-itineraryId="@ViewContext.RouteData.Values["itineraryId"]?.ToString()" asp-route-requestId="@Model.Id">
+            <input type="hidden" asp-for="@Model.Id" />
+            <div class="form-actions no-color">
+                <button type="submit" class="btn btn-primary">Delete</button>
+                <a asp-controller="Itinerary" asp-action="Details" asp-route-area="Admin" asp-route-id="@ViewContext.RouteData.Values["itineraryId"]?.ToString()" class="btn btn-default">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -129,6 +129,9 @@ else
                     <th>
                         City
                     </th>
+                    <th>
+
+                    </th>
                 </tr>
                 @foreach (var request in Model.Requests)
                 {
@@ -144,6 +147,9 @@ else
                         </td>
                         <td>
                             <p>@request.City</p>
+                        </td>
+                        <td>
+                            <a data-toggle="tooltip" data-placement="top" title="Remove" asp-action="ConfirmRemoveRequest" asp-controller="Itinerary" asp-route-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="btn btn-danger"><span class="fa fa-remove"></span></a>
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
Added basic v1 functionality to allow requests to be unassigned from an itinerary.

@tonysurma Need to review the business rules as we may need to further enhance this. At the moment unless a request is marked completed I allow it to be removed from an itinerary. We may want to prevent removal if the itinerary date has passed but I'm not sure if that would be correct in all use cases.

Closes #877 

NOTE: No tests in the interests of getting functionality into the site for testing