### PR TITLE
Adding short route for volunteer dashboard

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Controllers/VolunteerController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/VolunteerController.cs
@@ -18,6 +18,13 @@ namespace AllReady.Controllers
         }
 
         [HttpGet]
+        [Route("~/v")]
+        public async Task<IActionResult> DashboardShortUrl()
+        {
+            return RedirectToAction("Dashboard");
+        }
+
+        [HttpGet]
         [Route("~/Volunteers/Dashboard")]
         public async Task<IActionResult> Dashboard()
         {


### PR DESCRIPTION
Closes #896 

Added a single route for ~/v which redirects to the Volunteer dashboard action.