### PR TITLE
Showing number of volunteers required for tasks

### DIFF
--- a/AllReadyApp/Web-App/AllReady/ViewModels/Task/TaskViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Task/TaskViewModel.cs
@@ -130,6 +130,20 @@ namespace AllReady.ViewModels.Task
         public bool IsAllowWaitList { get; set; } = true;
         public int NumberOfUsersSignedUp { get; set; }
         public bool IsFull => NumberOfUsersSignedUp >= NumberOfVolunteersRequired;
+        public int AmountOfVolunteersNeeded => NumberOfVolunteersRequired - NumberOfUsersSignedUp;
+
+        public string VolunteersRequiredText
+        {
+            get
+            {
+                if (IsFull) return "No more volunteers currently required";
+
+                var pluralisation = AmountOfVolunteersNeeded == 1 ? " volunteer " : " volunteers ";
+
+                return string.Concat(AmountOfVolunteersNeeded, pluralisation, "still needed");
+            }
+        }
+
         public bool IsAllowSignups => !IsLimitVolunteers || !IsFull || IsAllowWaitList;
         public string DisplayDateTime => GetDisplayDate();
         public string VolunteerLimitDisplay => $"Volunteer Limit: {NumberOfVolunteersRequired}, Spots Remaining: {NumberOfVolunteersRequired - NumberOfUsersSignedUp}";
@@ -142,7 +156,7 @@ namespace AllReady.ViewModels.Task
             {
                 return $"{StartDateTime:dddd, MMMM dd, yyyy} from {StartDateTime:t} - {EndDateTime:t}";
             }
-            return $"{StartDateTime:dddd, MMMM dd, yyyy} at {StartDateTime:t} to<br>{EndDateTime:dddd, MMMM dd, yyyy} at {EndDateTime:t}";
+            return $"{StartDateTime:dddd, MMMM dd, yyyy} at {StartDateTime:t} to {EndDateTime:dddd, MMMM dd, yyyy} at {EndDateTime:t}";
         }
 
         public TaskViewModel(AllReadyTask task, bool isUserSignedupForTask)

--- a/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
@@ -240,7 +240,9 @@
                                             <span class="fa fa-question-circle" data-bind="visible: Description, tooltip: { title: Description, placement: 'top' }" aria-hidden="true"></span>
                                             <span class="label label-success" data-bind="visible: hasAllMatchingSkills, tooltip: { title: 'You have all of the required skills needed for this task!', placement: 'top' }">Match</span>
                                             <span class="label label-warning" data-bind="visible: !hasAllMatchingSkills() && hasAtLeastOneMatchingSkill(), tooltip: { title: 'You have at least one of the required skills needed for this task!', placement: 'top' }">Match</span>
-                                            <br />
+                                            <br/>
+                                            <span data-bind="text: VolunteersRequiredText"></span>
+                                            <br/>
                                             <span class="task-datetime" data-bind="html: DisplayDateTime"></span><br />
                                         </div>
                                         <div class="btn-group">


### PR DESCRIPTION
Adding a display on the task items (on the event details page) which indicates how many volunteers are needed.

Closes #915 

![image](https://cloud.githubusercontent.com/assets/3669103/16338563/76b3a45e-3a15-11e6-8055-b3515a27307e.png)
