### PR TITLE
Adding Support for API Key Generation

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Api/TokenApiControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Api/TokenApiControllerShould.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Api
+{
+    public class TokenApiControllerShould
+    {
+        [Fact]
+        public void ReturnATokenGivenASetOfCredentials()
+        {
+            // todo
+        }
+
+        [Fact]
+        public void ExpireTokensWhenExpireIsInvoked()
+        {
+            // todo
+        }
+
+
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -350,6 +350,20 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             mediator.Verify(m => m.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)), Times.Once);
         }
 
+        [Fact]
+        public async Task AssignApiRoleQueriesForCorrectId()
+        {
+            var mediator = new Mock<IMediator>();
+            var logger = new Mock<ILogger<SiteController>>();
+
+            string userId = Guid.NewGuid().ToString();
+            mediator.Setup(x => x.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId))).Returns(new ApplicationUser());
+            var controller = new SiteController(null, logger.Object, mediator.Object);
+
+            await controller.AssignApiAccessRole(userId);
+            mediator.Verify(m => m.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)), Times.Once);
+        }
+
         [Fact(Skip = "NotImplemented")]
         public async Task AssignSiteAdminInvokesAddClaimAsyncWithCorrrectParameters()
         {

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -366,7 +366,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task SearchForCorrectUserWhenManagingApiKeys()
+        public void SearchForCorrectUserWhenManagingApiKeys()
         {
             var mediator = new Mock<IMediator>();
             var logger = new Mock<ILogger<SiteController>>();
@@ -375,10 +375,24 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             mediator.Setup(x => x.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId))).Returns(new ApplicationUser());
             var controller = new SiteController(null, logger.Object, mediator.Object);
 
-            await controller.ManageApiKeys(userId);
+            controller.ManageApiKeys(userId);
             mediator.Verify(m => m.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)), Times.Once);
         }
 
+
+        [Fact]
+        public async Task SearchForCorrectUserWhenGeneratingApiKeys()
+        {
+            var mediator = new Mock<IMediator>();
+            var logger = new Mock<ILogger<SiteController>>();
+
+            string userId = Guid.NewGuid().ToString();
+            mediator.Setup(x => x.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId))).Returns(new ApplicationUser());
+            var controller = new SiteController(null, logger.Object, mediator.Object);
+
+            await controller.GenerateToken(userId);
+            mediator.Verify(m => m.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)), Times.Once);
+        }
 
         [Fact(Skip = "NotImplemented")]
         public async Task AssignSiteAdminInvokesAddClaimAsyncWithCorrrectParameters()

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerShould.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.Mvc;
 using Microsoft.Extensions.Logging;
 using Moq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -363,6 +364,21 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             await controller.AssignApiAccessRole(userId);
             mediator.Verify(m => m.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)), Times.Once);
         }
+
+        [Fact]
+        public async Task SearchForCorrectUserWhenManagingApiKeys()
+        {
+            var mediator = new Mock<IMediator>();
+            var logger = new Mock<ILogger<SiteController>>();
+
+            string userId = Guid.NewGuid().ToString();
+            mediator.Setup(x => x.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId))).Returns(new ApplicationUser());
+            var controller = new SiteController(null, logger.Object, mediator.Object);
+
+            await controller.ManageApiKeys(userId);
+            mediator.Verify(m => m.Send(It.Is<UserByUserIdQuery>(q => q.UserId == userId)), Times.Once);
+        }
+
 
         [Fact(Skip = "NotImplemented")]
         public async Task AssignSiteAdminInvokesAddClaimAsyncWithCorrrectParameters()

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -188,6 +188,21 @@ namespace AllReady.Areas.Admin.Controllers
         }
 
         [HttpGet]
+        public async Task<IActionResult> AssignApiAccessRole(string userId)
+        {
+            try
+            {
+                var user = GetUser(userId);
+                await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.UserType, UserType.ApiAccess.ToName()));
+                return RedirectToAction(nameof(Index));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(@"Failed to assign API role for {userId}", ex);
+                ViewBag.ErrorMessage = $"Failed to assign API role for {userId}. Exception thrown.";
+                return View();
+            }
+        }
         public IActionResult AssignOrganizationAdmin(string userId)
         {
             var user = GetUser(userId);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -203,6 +203,17 @@ namespace AllReady.Areas.Admin.Controllers
                 return View();
             }
         }
+
+        [HttpGet]
+        public async Task<IActionResult> ManageApiKeys(string userId)
+        {
+            var user = GetUser(userId);
+            
+
+            return View();
+        }
+
+        [HttpGet]
         public IActionResult AssignOrganizationAdmin(string userId)
         {
             var user = GetUser(userId);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -205,12 +205,19 @@ namespace AllReady.Areas.Admin.Controllers
         }
 
         [HttpGet]
-        public async Task<IActionResult> ManageApiKeys(string userId)
+        public IActionResult ManageApiKeys(string userId)
         {
             var user = GetUser(userId);
             
+            if(user.IsUserType(UserType.ApiAccess))
+            {
+                return View(user);
+            }
+            else
+            {
+                return HttpBadRequest("Can't manage keys for a user without the API role.");
+            }
 
-            return View();
         }
 
         [HttpGet]

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -198,7 +198,7 @@ namespace AllReady.Areas.Admin.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(@"Failed to assign API role for {userId}", ex);
+                _logger.LogError($"Failed to assign API role for {userId}", ex);
                 ViewBag.ErrorMessage = $"Failed to assign API role for {userId}. Exception thrown.";
                 return View();
             }
@@ -216,6 +216,25 @@ namespace AllReady.Areas.Admin.Controllers
             else
             {
                 return HttpBadRequest("Can't manage keys for a user without the API role.");
+            }
+
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GenerateToken(string userId)
+        {
+            var user = GetUser(userId);
+            try
+            {
+                var token = await _userManager.GenerateUserTokenAsync(user, "Default", TokenTypes.ApiKey);
+                ViewBag.ApiToken = token;
+                return View();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to create API key for {userId}", ex);
+                ViewBag.ErrorMessage = $"Failed to assign API role for {userId}. Exception thrown.";
+                return View();
             }
 
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/AssignApiRole.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/AssignApiRole.cshtml
@@ -1,0 +1,11 @@
+﻿@{
+    ViewBag.Title = "Assigning Site Admin";
+}
+<h2>Assigning Site Admin</h2>
+@if (ViewBag.ErrorMessage != null)
+{
+    <div class="alert alert-danger">
+        <div>@ViewBag.ErrorMessage</div>
+    </div>
+}
+<a asp-controller="Site" asp-action="Index" class="btn btn-default btn-sm">Back to List</a>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/GenerateToken.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/GenerateToken.cshtml
@@ -1,0 +1,23 @@
+﻿@{
+    ViewBag.Title = "API Key Generated";
+}
+<h2>Managing User API Access Key</h2>
+
+<h2>You have generated a new API Key</h2>
+
+<pre>
+    @ViewBag.ApiToken
+</pre>
+
+<h2>Warning</h2>
+
+<p>
+    This is your only opportunity to note the key, and you will not be able to reveal the key 
+    again. If you lose the key, you'll need to regenerate the API key used by the.
+</p>
+
+<p>
+    <a asp-controller="Site" asp-action="Index" class="btn btn-default">Back to Admin home</a>
+</p>
+
+

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
@@ -25,13 +25,25 @@
                         <div class="btn-group btn-group-sm row-btn-margin">
                             <a data-toggle="tooltip" data-placement="top" title="Edit" asp-action="EditUser" asp-controller="Site" asp-route-area="Admin" asp-route-userId="@item.Id" class="btn btn-success"><span class="fa fa-edit"></span></a>
                             <a data-toggle="tooltip" data-placement="top" title="Reset Password" asp-action="ResetPassword" asp-controller="Site" asp-route-area="Admin" asp-route-userId="@item.Id" class="btn btn-success"><span class="fa fa-recycle"></span></a>
-                            @if (!item.IsUserType(UserType.SiteAdmin) && !item.IsUserType(UserType.OrgAdmin)) {
+                            @if (!item.IsUserType(UserType.SiteAdmin) && !item.IsUserType(UserType.OrgAdmin))
+                            {
                                 <a data-toggle="tooltip" data-placement="top" title="Make Site Admin" asp-action="AssignSiteAdmin" asp-controller="Site" asp-route-area="Admin" asp-route-userId="@item.Id" class="btn btn-success"><span class="fa fa-user-secret"></span></a>
                                 <a data-toggle="tooltip" data-placement="top" title="Make Org Admin" asp-action="AssignOrganizationAdmin" asp-controller="Site" asp-route-area="Admin" asp-route-userId="@item.Id" class="btn btn-success"><span class="fa fa-group"></span></a>
                             } else if (item.IsUserType(UserType.SiteAdmin)) {
                                 <a data-toggle="tooltip" data-placement="top" title="Revoke Site Admin" asp-action="RevokeSiteAdmin" asp-controller="Site" asp-route-area="Admin" asp-route-userId="@item.Id" class="btn btn-success"><span class="fa fa-user-secret"></span></a>
                             } else if (item.IsUserType(UserType.OrgAdmin)) {
                                 <a data-toggle="tooltip" data-placement="top" title="Revoke Org Admin" asp-action="RevokeOrganizationAdmin" asp-controller="Site" asp-route-area="Admin" asp-route-userId="@item.Id" class="btn btn-success"><span class="fa fa-group"></span></a>
+                            }
+                            @if (!item.IsUserType(UserType.ApiAccess))
+                            {
+                                <a data-toggle="tooltip" data-placement="top" title="Allow API Access" asp-action="AssignApiAccessRole" asp-controller="Site" asp-route-area="Admin" asp-route-userId="@item.Id" class="btn btn-success"><span class="fa fa-exchange"></span></a>
+                            }
+
+                        </div>
+                        <div class="btn-group btn-group-sm row-btn-margin">
+                            @if (item.IsUserType(UserType.ApiAccess))
+                            {
+                                <a data-toggle="tooltip" data-placement="top" title="Manage Keys" asp-action="ManageApiKeys" asp-controller="Site" asp-route-area="Admin" asp-route-userId="@item.Id" class="btn btn-warning"><span class="fa fa-key"></span></a>
                             }
                         </div>
                     </td>
@@ -48,6 +60,10 @@
                         @if (item.IsUserType(UserType.OrgAdmin))
                         {
                             <span class="label label-default"><span class="fa fa-users"></span> Org</span>
+                        }
+                        @if (item.IsUserType(UserType.ApiAccess))
+                        {
+                            <span class="label label-default"><span class="fa fa-exchange"></span> API</span>
                         }
                         @if(!item.EmailConfirmed)
                         {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
@@ -1,8 +1,17 @@
-﻿@{
-    ViewBag.Title = "Managing API Keys";
+﻿@model ApplicationUser
+@{
+    ViewBag.Title = "Managing API Key";
 }
-<h2>Managing API Keys</h2>
+<h2>Managing User API Access Key for @Model.UserName</h2>
 
+<p>
+    Generating an API key irrevocably destroys the previous key that the user may have
+    been using. <b>Only</b> create a new key if the user has requested one or you suspect
+    that the key has been compromised.
+</p>
 
+<h2>Warning</h2>
+<p>Are you sure you want to create a new API key?</p>
+<a asp-controller="Site" asp-action ="GenerateToken" asp-route-userId="@Model.Id" class="btn btn-sm btn-warning" >Generate New API Key <span class="fa fa-key"></span></a>
 
-<a asp-controller="Site" asp-action="Index" class="btn btn-default btn-sm">Back to Site Admin List</a>
+<a asp-controller="Site" asp-action="Index" class="btn btn-default btn-lg">Back to Safety <span class="fa fa-life-saver"></span></a>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
@@ -12,6 +12,13 @@
 
 <h2>Warning</h2>
 <p>Are you sure you want to create a new API key?</p>
+
+<p>
+    Once you create the API key you will see it displayed on the screen. This will be 
+    your only opportunity to note it, and you will not be able to reveal the key again. If 
+    you lose the key, you'll need to regenerate it.
+</p>
+
 <a asp-controller="Site" asp-action ="GenerateToken" asp-route-userId="@Model.Id" class="btn btn-sm btn-warning" >Generate New API Key <span class="fa fa-key"></span></a>
 
 <a asp-controller="Site" asp-action="Index" class="btn btn-default btn-lg">Back to Safety <span class="fa fa-life-saver"></span></a>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
@@ -19,6 +19,12 @@
     you lose the key, you'll need to regenerate it.
 </p>
 
-<a asp-controller="Site" asp-action ="GenerateToken" asp-route-userId="@Model.Id" class="btn btn-sm btn-danger" >Generate New API Key <span class="fa fa-key"></span></a>
+<p>
+    <a asp-controller="Site" asp-action="GenerateToken" asp-route-userId="@Model.Id" class="btn btn-sm btn-danger">Generate New API Key <span class="fa fa-key"></span></a>
+</p>
 
-<a asp-controller="Site" asp-action="Index" class="btn btn-default btn-lg">Back to Safety <span class="fa fa-life-saver"></span></a>
+<p>
+    <a asp-controller="Site" asp-action="Index" class="btn btn-default">Back to Safety <span class="fa fa-life-saver"></span></a>
+</p>
+
+

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
@@ -1,0 +1,8 @@
+﻿@{
+    ViewBag.Title = "Managing API Keys";
+}
+<h2>Managing API Keys</h2>
+
+
+
+<a asp-controller="Site" asp-action="Index" class="btn btn-default btn-sm">Back to Site Admin List</a>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/ManageApiKeys.cshtml
@@ -19,6 +19,6 @@
     you lose the key, you'll need to regenerate it.
 </p>
 
-<a asp-controller="Site" asp-action ="GenerateToken" asp-route-userId="@Model.Id" class="btn btn-sm btn-warning" >Generate New API Key <span class="fa fa-key"></span></a>
+<a asp-controller="Site" asp-action ="GenerateToken" asp-route-userId="@Model.Id" class="btn btn-sm btn-danger" >Generate New API Key <span class="fa fa-key"></span></a>
 
 <a asp-controller="Site" asp-action="Index" class="btn btn-default btn-lg">Back to Safety <span class="fa fa-life-saver"></span></a>

--- a/AllReadyApp/Web-App/AllReady/Controllers/TokenApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TokenApiController.cs
@@ -6,6 +6,12 @@ using System.Threading.Tasks;
 
 namespace AllReady.Controllers
 {
+    /// <summary>
+    /// The token controller for the API is to allow third-party services
+    /// with the proper claim to generate transient tokens on-demand to 
+    /// access other services within AllReady.
+    /// </summary>
+
     [Route("api/token")]
     public class TokenApiController : Controller
     {

--- a/AllReadyApp/Web-App/AllReady/Controllers/TokenApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/TokenApiController.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNet.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Controllers
+{
+    [Route("api/token")]
+    public class TokenApiController : Controller
+    {
+
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Models/Security.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Security.cs
@@ -7,4 +7,8 @@
     SiteAdmin,
     ApiAccess
   }
+    public class TokenTypes
+    {
+        public const string ApiKey = "api-key";
+    }
 }

--- a/AllReadyApp/Web-App/AllReady/Models/Security.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Security.cs
@@ -4,6 +4,7 @@
   {
     BasicUser,
     OrgAdmin,
-    SiteAdmin
+    SiteAdmin,
+    ApiAccess
   }
 }


### PR DESCRIPTION
This PR allows administrators to promote an account to enable access to the system via (to be implemented) APIs.

The first step is to enable API access on the account, which will enable the ability to manage the API key.

![image](https://cloud.githubusercontent.com/assets/1197383/16367453/3bc80c7e-3be9-11e6-968c-22ceea619d00.png)

Once the account carries the correct role type, the administrator can then click on the key management button, which will take them to the key generation screen.

![image](https://cloud.githubusercontent.com/assets/1197383/16367472/6c82b0c6-3be9-11e6-9c1e-c0026b301e66.png)

A proper warning is displayed - there is only one chance to note the token, and generating a token will invalidate previous tokens in the system. A confirmation is displayed once generated.

![image](https://cloud.githubusercontent.com/assets/1197383/16367492/90b49874-3be9-11e6-9352-ffd219c8e7bf.png)
