### PR TITLE
Add token protection middleware

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
@@ -2,8 +2,6 @@
 using Microsoft.AspNet.Builder;
 using Microsoft.AspNet.Http;
 using Microsoft.AspNet.Identity;
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
@@ -9,7 +9,15 @@ using System.Threading.Tasks;
 
 namespace AllReady.Security.Middleware
 {
-
+    public static class TokenProtectedResourceExtensions
+    {
+        // extension method for easy wiring of middleware
+        public static IApplicationBuilder UseTokenProtection(
+            this IApplicationBuilder builder, TokenProtectedResourceOptions options)
+        {
+            return builder.UseMiddleware<TokenProtectedResource>(options);
+        }
+    }
 
     public class TokenProtectedResource
     {

--- a/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
@@ -1,0 +1,53 @@
+﻿using AllReady.Models;
+using Microsoft.AspNet.Builder;
+using Microsoft.AspNet.Http;
+using Microsoft.AspNet.Identity;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Security.Middleware
+{
+
+
+    public class TokenProtectedResource
+    {
+        private RequestDelegate _next;
+        private TokenProtectedResourceOptions _options;
+
+        public TokenProtectedResource(RequestDelegate next, TokenProtectedResourceOptions options)
+        {
+            _next = next;
+            _options = options;
+        }
+
+        public async Task Invoke(HttpContext httpContext, UserManager<ApplicationUser> manager)
+        {
+            if (httpContext.Request.Path.StartsWithSegments(_options.Path))
+            {
+                var headers = httpContext.Request.Headers;
+                if (!(headers.ContainsKey("ApiUser") && headers.ContainsKey("ApiToken")))
+                {
+                    await httpContext.Authentication.ChallengeAsync();
+                    return;
+                }
+
+                var apiUser = headers.FirstOrDefault(h => h.Key == "ApiUser").Value;
+                var token = headers.FirstOrDefault(h => h.Key == "ApiToken").Value;
+
+                var user = manager.FindByNameAsync(apiUser).ConfigureAwait(false).GetAwaiter().GetResult();
+                var authorized = manager.VerifyUserTokenAsync(user, "Default", "api-access", token).ConfigureAwait(false).GetAwaiter().GetResult();
+
+                if (!authorized)
+                {
+                    await httpContext.Authentication.ChallengeAsync();
+                    return;
+                }
+            }
+
+            await _next(httpContext);
+        }
+
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
@@ -44,8 +44,8 @@ namespace AllReady.Security.Middleware
                 var apiUser = headers.FirstOrDefault(h => h.Key == "ApiUser").Value;
                 var token = headers.FirstOrDefault(h => h.Key == "ApiToken").Value;
 
-                var user = manager.FindByNameAsync(apiUser).ConfigureAwait(false).GetAwaiter().GetResult();
-                var authorized = manager.VerifyUserTokenAsync(user, "Default", "api-access", token).ConfigureAwait(false).GetAwaiter().GetResult();
+                var user = await manager.FindByNameAsync(apiUser).ConfigureAwait(false);
+                var authorized = await manager.VerifyUserTokenAsync(user, "Default", "api-request-injest", token).ConfigureAwait(false);
 
                 if (!authorized)
                 {

--- a/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResourceOptions.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResourceOptions.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.AspNet.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Security.Middleware
+{
+    public class TokenProtectedResourceOptions
+    {
+        public PathString Path { get; set; }
+        public string PolicyName { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResourceOptions.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResourceOptions.cs
@@ -1,8 +1,4 @@
 ﻿using Microsoft.AspNet.Http;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace AllReady.Security.Middleware
 {

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -241,7 +241,7 @@ namespace AllReady
             app.UseTokenProtection(new TokenProtectedResourceOptions
             {
                 Path = "api/request",
-                PolicyName = "request-injest"
+                PolicyName = "api-request-injest"
             });
 
             // Add authentication middleware to the request pipeline. You can configure options such as Id and Secret in the ConfigureServices method.

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.PlatformAbstractions;
+using AllReady.Security.Middleware;
 
 namespace AllReady
 {
@@ -235,6 +236,13 @@ namespace AllReady
 
             // Add cookie-based authentication to the request pipeline.
             app.UseIdentity();
+
+            // Add token-based protection to the request inject pipeline
+            app.UseTokenProtection(new TokenProtectedResourceOptions
+            {
+                Path = "api/request",
+                PolicyName = "request-injest"
+            });
 
             // Add authentication middleware to the request pipeline. You can configure options such as Id and Secret in the ConfigureServices method.
             // For more information see http://go.microsoft.com/fwlink/?LinkID=532715


### PR DESCRIPTION
This PR gives us a protected endpoint (api/request) that will require calling parties to provide a username and valid API token corresponding to their account.

The `api/request` endpoint is not yet complete, but the wiring is now here for the security side of things.