### PR TITLE
Send Email and Sms confirmation messages when authenticating using external providers

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -257,7 +257,6 @@ namespace AllReady.UnitTest.Controllers
             var emailSenderMock = new Mock<IEmailSender>();
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             var urlHelper = new Mock<IUrlHelper>();
             sut.Url = urlHelper.Object;
@@ -294,10 +293,8 @@ namespace AllReady.UnitTest.Controllers
             var emailSenderMock = new Mock<IEmailSender>();
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
-
             await sut.Register(model);
 
             emailSenderMock.Verify(x => x.SendEmailAsync(
@@ -344,17 +341,14 @@ namespace AllReady.UnitTest.Controllers
             emailSenderMock.Setup(x => x.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
-
             await sut.Register(model);
 
             userManager.Verify(x => x.AddClaimAsync(It.Is<ApplicationUser>(au =>
                 au.UserName == model.Email &&
                 au.Email == model.Email &&
-                au.TimeZoneId == defaultTimeZone)
-                , It.IsAny<Claim>()), Times.Once);
+                au.TimeZoneId == defaultTimeZone), It.IsAny<Claim>()), Times.Once);
         }
 
         [Fact]
@@ -383,17 +377,15 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
-
             await sut.Register(model);
 
             signInManager.Verify(x => x.SignInAsync(It.Is<ApplicationUser>(au =>
                 au.UserName == model.Email &&
                 au.Email == model.Email &&
-                au.TimeZoneId == defaultTimeZone)
-                , It.IsAny<bool>(), null), Times.Once);
+                au.TimeZoneId == defaultTimeZone), 
+            It.IsAny<bool>(), null), Times.Once);
         }
 
         [Fact]
@@ -419,7 +411,6 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), null)).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
 
@@ -460,7 +451,6 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
             var sut = new AccountController(userManager.Object, null, null, generalSettings.Object, null);
-
             var result = await sut.Register(model) as ViewResult;
             var modelResult = result.ViewData.Model as RegisterViewModel;
 
@@ -499,8 +489,8 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = CreateSignInManagerMock(CreateUserManagerMock());
 
             var sut = new AccountController(null, signInManager.Object, null, null, null);
-
             await sut.LogOff();
+
             signInManager.Verify(x => x.SignOutAsync(), Times.Once);
         }
 
@@ -511,7 +501,6 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(x => x.SignOutAsync()).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(null, signInManager.Object, null, null, null);
-
             var result = await sut.LogOff() as RedirectToActionResult;
 
             Assert.Equal(result.ActionName, nameof(HomeController.Index));
@@ -522,9 +511,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task ConfirmEmailReturnsErrorView_WhenUserIdIsNull()
         {
             var sut = CreateAccountControllerWithNoInjectedDependencies();
-
             var result = await sut.ConfirmEmail(null, "sometoken") as ViewResult;
-
             Assert.Equal("Error", result.ViewName);
         }
 
@@ -532,19 +519,16 @@ namespace AllReady.UnitTest.Controllers
         public async Task ConfirmEmailReturnsErrorView_WhenTokenIsNull()
         {
             var sut = CreateAccountControllerWithNoInjectedDependencies();
-
             var result = await sut.ConfirmEmail("someuserid", null) as ViewResult;
-
             Assert.Equal("Error", result.ViewName);
         }
 
         [Fact]
         public async Task ConfirmEmailInvokesFindByIdAsyncWithCorrectUserId_WhenUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
-
             var sut = new AccountController(userManager.Object, null, null, null, null);
 
             await sut.ConfirmEmail(userId, token);
@@ -555,14 +539,13 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailReturnsErrorView_WhenUserIsNull_AndUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
-            var userManager = CreateUserManagerMock();
+            const string userId = "userId";
+            const string token = "someToken";
 
+            var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult((ApplicationUser)null));
 
             var sut = new AccountController(userManager.Object, null, null, null, null);
-
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal("Error", result.ViewName);
@@ -571,16 +554,15 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailInvokesConfirmEmailAsyncWithTheCorrectParameters_WhenUserAndUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
- 
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ConfirmEmail(userId, token);
 
             userManager.Verify(x => x.ConfirmEmailAsync(It.Is<ApplicationUser>(y => y == user), It.Is<string>(y => y == token)), Times.Once);
@@ -589,8 +571,8 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailInvokesSendAsyncWithTheCorrectParameters_WhenUsersProfileIsComplete_AndUsersEmailIsConfirmed_AndUserAndUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser
@@ -603,7 +585,6 @@ namespace AllReady.UnitTest.Controllers
                 Email = "test@email.com",
                 EmailConfirmed = true
             };
-
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
@@ -612,18 +593,16 @@ namespace AllReady.UnitTest.Controllers
 
             var sut = new AccountController(userManager.Object, null, null, null, mediator.Object);
             sut.SetFakeUser(userId);
-
             await sut.ConfirmEmail(userId, token);
 
             mediator.Verify(x => x.SendAsync(It.Is<RemoveUserProfileIncompleteClaimCommand>(y => y.UserId == userId)), Times.Once);
-
         }
 
         [Fact]
         public async Task ConfirmEmailInvokesRefreshSignInAsyncWithTheCorrectParameters_WhenUserIsSignedIn_AndUsersProfileIsComplete_AndUsersEmailIsConfirmed_AndUserAndUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser
@@ -636,7 +615,6 @@ namespace AllReady.UnitTest.Controllers
                 Email = "test@email.com",
                 EmailConfirmed = true
             };
-
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
@@ -648,7 +626,6 @@ namespace AllReady.UnitTest.Controllers
 
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, mediator.Object);
             sut.SetFakeUserWithCookieAuthenticationType(userId);
-
             await sut.ConfirmEmail(userId, token);
 
             signInManager.Verify(x => x.RefreshSignInAsync(It.Is<ApplicationUser>(y => y.Id == user.Id)));
@@ -657,16 +634,15 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailReturnsErrorView_WhenUsersEmailCannotBeConfirmed()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Failed()));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal(result.ViewName, "Error");
@@ -675,16 +651,15 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailReturnsConfirmEmailView_WhenUsersEmailCanBeConfirmed()
 		{
-			var userId = "userId";
-			var token = "someToken";
+			const string userId = "userId";
+			const string token = "someToken";
 			var userManager = CreateUserManagerMock();
 
 			var user = new ApplicationUser();
-
 			userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
 			userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
-			var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
 			var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ConfirmEmail");
@@ -733,110 +708,80 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ForgotPasswordPostInvokesFindByNameAsyncWithTheCorrectEmailwhenModelStateIsValid()
 		{
-			var email = "user@domain.tld";
-
-			var vm = new ForgotPasswordViewModel()
-			{
-				Email = email
-			};
+			const string email = "user@domain.tld";
+			var vm = new ForgotPasswordViewModel { Email = email };
 
 			var userManager = CreateUserManagerMock();
-
 			var user = new ApplicationUser();
-
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-			var sut = new AccountController(userManager.Object, null, null, null, null);
-			
+
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ForgotPassword(vm);
 
-			userManager.Verify(m => m.FindByNameAsync(email), Times.Once);
-			
+			userManager.Verify(m => m.FindByNameAsync(email), Times.Once);	
 		}
 
         [Fact]
         public async Task ForgotPasswordPostInvokesIsEmailConfirmedAsyncWithThecorrectUser_WhenModelStateIsValid()
 		{
-			var email = "user@domain.tld";
-
-			var vm = new ForgotPasswordViewModel()
-			{
-				Email = email
-			};
+			const string email = "user@domain.tld";
+			var vm = new ForgotPasswordViewModel { Email = email };
 
 			var userManager = CreateUserManagerMock();
 
 			var user = new ApplicationUser();
-
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user)).Verifiable();
-			var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ForgotPassword(vm);
 
 			userManager.Verify(m => m.IsEmailConfirmedAsync(user), Times.Once);
-
 		}
 
 		[Fact]
         public async Task ForgotPasswordPostReturnsForgotPasswordConfirmationView_WhenModelStateIsValid_AndUserIsNull()
 		{
-			var email = "user@domain.tld";
-			
-			var vm = new ForgotPasswordViewModel()
-			{
-				Email = email
-			};
+			const string email = "user@domain.tld";
+			var vm = new ForgotPasswordViewModel { Email = email }; 
 
 			var userManager = CreateUserManagerMock();
 
 			var user = default(ApplicationUser);
-
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-			var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
 			var result = await sut.ForgotPassword(vm) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
-
 		}
 
 		[Fact]
         public async Task ForgotPasswordPostReturnsForgotPasswordConfirmationView_WhenModelStateIsValid_AndUsersEmailIsUnverified()
 		{
-			var email = "user@domain.tld";
-
-			var vm = new ForgotPasswordViewModel()
-			{
-				Email = email
-			};
+			const string email = "user@domain.tld";
+			var vm = new ForgotPasswordViewModel { Email = email };
 
 			var userManager = CreateUserManagerMock();
 
 			var user = new ApplicationUser();
-
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 			userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(false));
-			var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
 			var result = await sut.ForgotPassword(vm) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
-
 		}
 
 		[Fact]
 		public async Task ForgotPasswordPostInvokesGeneratePasswordResetTokenAsyncWithCorrectUser_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
 		{
-            var email = "user@domain.tld";
-
-            var vm = new ForgotPasswordViewModel()
-            {
-                Email = email
-            };
+            const string email = "user@domain.tld";
+            var vm = new ForgotPasswordViewModel { Email = email };
 
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
@@ -858,17 +803,12 @@ namespace AllReady.UnitTest.Controllers
         public async Task ForgotPasswordPostInvokesUrlActionWithCorrectParameters_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
         {
             const string requestScheme = "requestScheme";
-            var email = "user@domain.tld";
-
-            var vm = new ForgotPasswordViewModel()
-            {
-                Email = email
-            };
+            const string email = "user@domain.tld";
+            var vm = new ForgotPasswordViewModel { Email = email };
 
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
@@ -877,35 +817,28 @@ namespace AllReady.UnitTest.Controllers
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
-
             var urlHelper = new Mock<IUrlHelper>();
-
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             sut.Url = urlHelper.Object;
 
             await sut.ForgotPassword(vm);
 
             urlHelper.Verify(mock => mock.Action(It.Is<UrlActionContext>(uac => 
-                        uac.Action == "ResetPassword" 
-                        && uac.Controller == "Account" 
-                        && uac.Protocol == requestScheme)), Times.Once);
+                uac.Action == "ResetPassword" 
+                && uac.Controller == "Account" 
+                && uac.Protocol == requestScheme)), Times.Once);
         }
 
         [Fact]
         public async Task ForgotPasswordPostInvokesSendEmailAsyncWithCorrectParameters_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
         {
-            var email = "user@domain.tld";
+            const string email = "user@domain.tld";
             const string callbackUrl = "callbackUrl";
 
-            var vm = new ForgotPasswordViewModel()
-            {
-                Email = email
-            };
-
+            var vm = new ForgotPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
@@ -914,10 +847,8 @@ namespace AllReady.UnitTest.Controllers
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
-
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(callbackUrl);
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
 
@@ -930,16 +861,10 @@ namespace AllReady.UnitTest.Controllers
         public async Task ForgotPasswordPostReturnsForgotPasswordConfirmationView_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
         {
             const string email = "user@domain.tld";
-
-            var vm = new ForgotPasswordViewModel()
-            {
-                Email = email
-            };
-
+            var vm = new ForgotPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
@@ -948,14 +873,11 @@ namespace AllReady.UnitTest.Controllers
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
-
             var result = await sut.ForgotPassword(vm) as ViewResult;
 
             Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
-
         }
 
         [Fact]
@@ -1011,7 +933,7 @@ namespace AllReady.UnitTest.Controllers
         public void ResetPasswordGetReturnsAViewIfCodeIsNotNull()
         {
             var sut = AccountController();
-            var code = "1234";
+            const string code = "1234";
             var result = (ViewResult)sut.ResetPassword(code);
 
             Assert.IsType<ViewResult>(result);
@@ -1040,7 +962,6 @@ namespace AllReady.UnitTest.Controllers
 
             var sut = CreateAccountControllerWithNoInjectedDependencies();
             sut.AddModelStateError();
-
             var result = await sut.ResetPassword(vm) as ViewResult;
             var modelResult = result.ViewData.Model as ResetPasswordViewModel;
 
@@ -1052,21 +973,16 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostInvokesFindByNameAsyncWithTheCorrecEmail_WhenModelStateIsValid()
         {
-            var email = "user@domain.tld";
+            const string email = "user@domain.tld";
 
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
+            var vm = new ResetPasswordViewModel { Email = email };
 
             var userManager = CreateUserManagerMock();
-
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.FindByNameAsync(email), Times.Once);
@@ -1075,18 +991,12 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostRedirectsToCorrectAction_WhenUserIsNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
-
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
-
+            const string email = "user@domain.tld";
+            var vm = new ResetPasswordViewModel{ Email = email };
             var userManager = CreateUserManagerMock();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult((ApplicationUser)null));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             var result = await sut.ResetPassword(vm) as RedirectToActionResult;
 
             Assert.Equal("ResetPasswordConfirmation", result.ActionName);
@@ -1095,9 +1005,9 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostInvokesResetPasswordAsyncWithCorrectParameters_WhenUserIsNotNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
+            const string email = "user@domain.tld";
 
-            var vm = new ResetPasswordViewModel()
+            var vm = new ResetPasswordViewModel
             {
                 Email = email,
                 Password = "pass",
@@ -1105,13 +1015,11 @@ namespace AllReady.UnitTest.Controllers
             };
 
             var userManager = CreateUserManagerMock();
-
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.ResetPasswordAsync(user, It.Is<string>(y => y == vm.Code), It.Is<string>(y => y == vm.Password)), Times.Once);
@@ -1120,17 +1028,11 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostRedirectsToCorrectAction_WhenUsersPasswordResetSucceeded_AndUserIsNotNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
-
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
-
+            const string email = "user@domain.tld";
+            var vm = new ResetPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
             var sut = new AccountController(userManager.Object, null, null, null, null);
@@ -1143,50 +1045,37 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostAddsIdentityResultErrorsToModelStateErrors_WhenUsersPasswordResetFailed_AndUserIsNotNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
+            const string email = "user@domain.tld";
 
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
-
+            var vm = new ResetPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
             var identityResult = IdentityResult.Failed(new IdentityError { Description = "IdentityErrorDescription" });
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
-            var result = await sut.ResetPassword(vm) as ViewResult;
+            var sut = new AccountController(userManager.Object, null, null, null, null);
+            await sut.ResetPassword(vm);
 
             var errorMessages = sut.ModelState.GetErrorMessages();
             Assert.Equal(identityResult.Errors.Select(x => x.Description).Single(), errorMessages.Single());
-
         }
 
         [Fact]
         public async Task ResetPasswordPostReturnsAView_WhenUsersPasswordResetFailed_AndUserIsNotNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
-
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
-
+            const string email = "user@domain.tld";
+            var vm = new ResetPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             var result = await sut.ResetPassword(vm) as ViewResult;
 
             Assert.IsType<ViewResult>(result);
             Assert.Null(result.ViewData.Model);
-
         }
 
         [Fact]
@@ -1380,11 +1269,13 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ExternalLoginConfirmationRedirectsToCorrectActionIfUserIsSignedIn()
         {
-            var sut = AccountController();
             var identity = new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.NameIdentifier, "test") }, IdentityCookieOptions.ApplicationCookieAuthenticationType);
-            sut.SetFakeUser("test");
+
+            var sut = AccountController();
+            sut.SetFakeUser("userId");
             sut.HttpContext.User.AddIdentity(identity);
             var result = await sut.ExternalLoginConfirmation(new ExternalLoginConfirmationViewModel()) as RedirectToActionResult;
+
             Assert.Equal<string>(result.ControllerName, "Manage");
             Assert.Equal<string>(result.ActionName, nameof(ManageController.Index));
         }
@@ -1396,8 +1287,9 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = CreateSignInManagerMock(userManager);
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
+
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null);
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
             await sut.ExternalLoginConfirmation(viewmodel);
 
             signInManager.Verify(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null)), Times.Once());
@@ -1410,8 +1302,9 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = CreateSignInManagerMock(userManager);
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
+
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null);
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
             var result = await sut.ExternalLoginConfirmation(viewmodel) as ViewResult;
 
             Assert.Equal(result.ViewName, "ExternalLoginFailure");
@@ -1421,14 +1314,14 @@ namespace AllReady.UnitTest.Controllers
         public async Task ExternalLoginConfirmationInvokesCreateAsyncWithCorrectUser_WhenExternalLoginInfoIsSuccessful_AndModelStateIsValid()
         {
             var userManager = CreateUserManagerMock();
-            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult<IdentityResult>(new IdentityResult()));
+            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(new IdentityResult()));
             var signInManager = CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager);
             var viewModel = CreateExternalLoginConfirmationViewModel();
             var generalSettings = CreateGeneralSettingsMockObject();
 
             var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
 
             await sut.ExternalLoginConfirmation(viewModel);
 
@@ -1438,31 +1331,33 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ExternalLoginConfirmationInvokesAddLoginAsyncWithCorrectParameters_WhenUserIsCreatedSuccessfully()
         {
-            const string defaultTimeZone = "DefaultTimeZone";
+            const string loginProvider = "test";
+            const string providerKey = "test";
+            const string displayName = "testDisplayName";
 
             var userManager = CreateUserManagerMockWithSucessIdentityResult();
             var signInManager = CreateSignInManagerMock(userManager);
-            SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
+            SetupSignInManagerWithTestExternalLoginValue(signInManager, loginProvider, providerKey, displayName);
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnTrueForLocalUrl(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
 
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
-            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
             var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             await sut.ExternalLoginConfirmation(viewModel, "testUrl");
 
             userManager.Verify(u => u.AddLoginAsync(It.Is<ApplicationUser>(au => au.Email == viewModel.Email
-                    && au.FirstName == viewModel.FirstName
-                    && au.LastName == viewModel.LastName
-                    && au.PhoneNumber == viewModel.PhoneNumber),
-                It.Is<ExternalLoginInfo>(ei => ei.LoginProvider == "test"
-                    && ei.ProviderKey == "testKey"
-                    && ei.ProviderDisplayName == "testDisplayName")));
-}
+                && au.FirstName == viewModel.FirstName
+                && au.LastName == viewModel.LastName
+                && au.PhoneNumber == viewModel.PhoneNumber),
+            It.Is<ExternalLoginInfo>(ei => ei.LoginProvider == loginProvider
+                && ei.ProviderKey == providerKey
+                && ei.ProviderDisplayName == displayName)));
+        }
 
         [Fact]
         public async Task ExternalLoginConfirmationInvokesSignInAsyncWithCorrectParameters_WhenExternalLoginIsAddedSuccessfully()
@@ -1474,10 +1369,12 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnTrueForLocalUrl(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
             await sut.ExternalLoginConfirmation(viewModel, "testUrl");
@@ -1493,6 +1390,8 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ExternalLoginConfirmationRedirectsToCorrectUrl_WhenUrlIsLocalUrl()
         {
+            const string returnUrl = "localUrl";
+
             var userManager = CreateUserManagerMockWithSucessIdentityResult();
             var signInManager = CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
@@ -1500,15 +1399,17 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
-            var result = await sut.ExternalLoginConfirmation(viewModel, "localUrl") as RedirectResult;
+            var result = await sut.ExternalLoginConfirmation(viewModel, returnUrl) as RedirectResult;
 
-            Assert.Equal(result.Url, "localUrl");
+            Assert.Equal(result.Url, returnUrl);
         }
 
         [Fact]
@@ -1521,7 +1422,7 @@ namespace AllReady.UnitTest.Controllers
                 .Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Callback<ApplicationUser, bool, string>((appUser, persist, auth) =>
                 {
-                    appUser.Claims.Add(new IdentityUserClaim<string>()
+                    appUser.Claims.Add(new IdentityUserClaim<string>
                     {
                         ClaimType = AllReady.Security.ClaimTypes.UserType,
                         ClaimValue = Enum.GetName(typeof(UserType), UserType.SiteAdmin)
@@ -1531,9 +1432,11 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
 
@@ -1552,7 +1455,7 @@ namespace AllReady.UnitTest.Controllers
                 .Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Callback<ApplicationUser, bool, string>((appUser, persist, auth) =>
                 {
-                    appUser.Claims.Add(new IdentityUserClaim<string>()
+                    appUser.Claims.Add(new IdentityUserClaim<string>
                     {
                         ClaimType = AllReady.Security.ClaimTypes.UserType,
                         ClaimValue = Enum.GetName(typeof(UserType), UserType.OrgAdmin)
@@ -1562,9 +1465,11 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
 
@@ -1583,9 +1488,11 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
 
@@ -1597,10 +1504,12 @@ namespace AllReady.UnitTest.Controllers
         public async Task ExternalLoginConfirmationAddsIdentityResultErrorsToModelStateError_WhenUserIsCreatedSuccessfully()
         {
             var userManager = CreateUserManagerMock();
-            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>()))
-                .Returns(Task.FromResult<IdentityResult>(IdentityResult.Success));
+            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(IdentityResult.Success));
             userManager.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
-                .Returns(Task.FromResult<IdentityResult>(IdentityResult.Failed(new IdentityError() { Code = "TestCode1", Description = "TestDescription1" }, new IdentityError() { Code = "TestCode2", Description = "TestDescription2" })));
+                .Returns(Task.FromResult(IdentityResult.Failed(
+                    new IdentityError { Code = "TestCode1", Description = "TestDescription1" }, 
+                    new IdentityError { Code = "TestCode2", Description = "TestDescription2" }
+                )));
 
             var signInManager = CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
@@ -1608,9 +1517,11 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as ViewResult;
 
@@ -1627,26 +1538,29 @@ namespace AllReady.UnitTest.Controllers
             const string returnUrlKey = "ReturnUrl";
             const string returnUrlValue = "http:\\test.url.com";
             var model = new ExternalLoginConfirmationViewModel();
+
             var controller = AccountController();
             controller.AddModelStateError();
             controller.SetFakeUser("test");
+
             var result = await controller.ExternalLoginConfirmation(model, returnUrlValue) as ViewResult;
             var viewDataKey = result.ViewData.Keys.FirstOrDefault(k => k == returnUrlKey);
             var viewDataValue = result.ViewData[returnUrlKey] as string;
             Assert.Equal<string>(viewDataValue, returnUrlValue);
             Assert.NotNull(viewDataKey);
-
         }
 
         [Fact]
         public async Task ExternalLoginConfirmationReturnsCorrectViewModel_WhenModelStateIsInvalid()
         {
             var model = new ExternalLoginConfirmationViewModel();
+
             var controller = AccountController();
             controller.AddModelStateError();
             controller.SetFakeUser("test");
             var result = await controller.ExternalLoginConfirmation(model) as ViewResult;
             var modelResult = result.ViewData.Model as ExternalLoginConfirmationViewModel;
+
             Assert.IsType<ViewResult>(result);
             Assert.IsType<ExternalLoginConfirmationViewModel>(modelResult);
             Assert.Same(modelResult, model);
@@ -1733,9 +1647,9 @@ namespace AllReady.UnitTest.Controllers
         {
             var userManagerMock = CreateUserManagerMock();
             userManagerMock.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>()))
-                .Returns(Task.FromResult<IdentityResult>(IdentityResult.Success));
+                .Returns(Task.FromResult(IdentityResult.Success));
             userManagerMock.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
-                .Returns(Task.FromResult<IdentityResult>(IdentityResult.Success));
+                .Returns(Task.FromResult(IdentityResult.Success));
 
             return userManagerMock;
         }
@@ -1745,7 +1659,7 @@ namespace AllReady.UnitTest.Controllers
         {
             signInManager
                 .Setup(s => s.GetExternalLoginInfoAsync(It.IsAny<string>()))
-                .Returns(Task.FromResult<ExternalLoginInfo>(new ExternalLoginInfo(new ClaimsPrincipal(), loginProvider, providerKey, displayName)));
+                .Returns(Task.FromResult(new ExternalLoginInfo(new ClaimsPrincipal(), loginProvider, providerKey, displayName)));
         }
 
         private static void SetupSignInManagerWithDefaultSignInAsync(Mock<SignInManager<ApplicationUser>> signInManager)
@@ -1757,7 +1671,7 @@ namespace AllReady.UnitTest.Controllers
 
         private static ExternalLoginConfirmationViewModel CreateExternalLoginConfirmationViewModel(string email = "test@test.com", string firstName = "FirstName", string lastName = "LastName", string phoneNumber = "(111)111-11-11")
         {
-            var result = new ExternalLoginConfirmationViewModel()
+            var result = new ExternalLoginConfirmationViewModel
             {
                 Email = email,
                 FirstName = firstName,

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -202,7 +202,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, generalSettings.Object, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null);
             await sut.Register(model);
 
             userManager.Verify(x => x.CreateAsync(It.Is<ApplicationUser>(au =>
@@ -227,9 +227,8 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
 
             var signInManager = CreateSignInManagerMock(userManager);
-            var emailSenderMock = new Mock<IEmailSender>();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
 
@@ -255,9 +254,8 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
 
             var signInManager = CreateSignInManagerMock(userManager);
-            var emailSenderMock = new Mock<IEmailSender>();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             var urlHelper = new Mock<IUrlHelper>();
             sut.Url = urlHelper.Object;
@@ -292,7 +290,7 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, mediator.Object);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, mediator.Object);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -333,7 +331,7 @@ namespace AllReady.UnitTest.Controllers
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -366,7 +364,7 @@ namespace AllReady.UnitTest.Controllers
 
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -397,7 +395,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
             signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), null)).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object,generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
 
@@ -418,7 +416,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
 
-            var sut = new AccountController(userManager.Object, null, null, generalSettings.Object, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null);
 
             await sut.Register(new RegisterViewModel());
 
@@ -437,7 +435,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, generalSettings.Object, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null);
             var result = await sut.Register(model) as ViewResult;
             var modelResult = result.ViewData.Model as RegisterViewModel;
 
@@ -475,7 +473,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var signInManager = CreateSignInManagerMock(CreateUserManagerMock());
 
-            var sut = new AccountController(null, signInManager.Object, null, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null);
             await sut.LogOff();
 
             signInManager.Verify(x => x.SignOutAsync(), Times.Once);
@@ -487,7 +485,7 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = CreateSignInManagerMock(CreateUserManagerMock());
             signInManager.Setup(x => x.SignOutAsync()).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(null, signInManager.Object, null, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null);
             var result = await sut.LogOff() as RedirectToActionResult;
 
             Assert.Equal(result.ActionName, nameof(HomeController.Index));
@@ -516,7 +514,7 @@ namespace AllReady.UnitTest.Controllers
             const string userId = "userId";
             const string token = "someToken";
             var userManager = CreateUserManagerMock();
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 
             await sut.ConfirmEmail(userId, token);
 
@@ -532,7 +530,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult((ApplicationUser)null));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal("Error", result.ViewName);
@@ -549,7 +547,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ConfirmEmail(userId, token);
 
             userManager.Verify(x => x.ConfirmEmailAsync(It.Is<ApplicationUser>(y => y == user), It.Is<string>(y => y == token)), Times.Once);
@@ -578,7 +576,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).Returns(() => Task.FromResult(It.IsAny<Unit>()));
 
-            var sut = new AccountController(userManager.Object, null, null, null, mediator.Object);
+            var sut = new AccountController(userManager.Object, null, null, mediator.Object);
             sut.SetFakeUser(userId);
             await sut.ConfirmEmail(userId, token);
 
@@ -611,7 +609,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).Returns(() => Task.FromResult(It.IsAny<Unit>()));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, mediator.Object);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, mediator.Object);
             sut.SetFakeUserWithCookieAuthenticationType(userId);
             await sut.ConfirmEmail(userId, token);
 
@@ -629,7 +627,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal(result.ViewName, "Error");
@@ -646,7 +644,7 @@ namespace AllReady.UnitTest.Controllers
 			userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
 			userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 			var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ConfirmEmail");
@@ -702,7 +700,7 @@ namespace AllReady.UnitTest.Controllers
 			var user = new ApplicationUser();
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ForgotPassword(vm);
 
 			userManager.Verify(m => m.FindByNameAsync(email), Times.Once);	
@@ -719,7 +717,7 @@ namespace AllReady.UnitTest.Controllers
 			var user = new ApplicationUser();
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user)).Verifiable();
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ForgotPassword(vm);
 
 			userManager.Verify(m => m.IsEmailConfirmedAsync(user), Times.Once);
@@ -736,7 +734,7 @@ namespace AllReady.UnitTest.Controllers
 			var user = default(ApplicationUser);
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 			var result = await sut.ForgotPassword(vm) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
@@ -754,7 +752,7 @@ namespace AllReady.UnitTest.Controllers
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 			userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(false));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 			var result = await sut.ForgotPassword(vm) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
@@ -776,7 +774,7 @@ namespace AllReady.UnitTest.Controllers
             var emailSender = new Mock<IEmailSender>();
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>());
 
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
@@ -800,7 +798,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var sut = new AccountController(userManager.Object, null, Mock.Of<IEmailSender>(), null, null);
+            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>());
             var urlHelper = new Mock<IUrlHelper>();
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             sut.Url = urlHelper.Object;
@@ -814,7 +812,7 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public async Task ForgotPasswordPostInvokesSendEmailAsyncWithCorrectParameters_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
+        public async Task ForgotPasswordPostSendsSendResetPasswordEmailWithCorrectParameters_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
         {
             const string email = "user@domain.tld";
             const string callbackUrl = "callbackUrl";
@@ -827,10 +825,9 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var emailSender = new Mock<IEmailSender>();
-            emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
+            var mediator = new Mock<IMediator>();
 
-            var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, null, mediator.Object);
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(callbackUrl);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
@@ -838,7 +835,7 @@ namespace AllReady.UnitTest.Controllers
 
             await sut.ForgotPassword(vm);
 
-            emailSender.Verify(x => x.SendEmailAsync(email, It.IsAny<string>(), It.Is<string>(y => y.Contains(callbackUrl))), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.Is<SendResetPasswordEmail>(y => y.Email == vm.Email && y.CallbackUrl == callbackUrl)), Times.Once);
         }
 
         [Fact]
@@ -853,10 +850,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var emailSender = new Mock<IEmailSender>();
-            emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
-
-            var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
             var result = await sut.ForgotPassword(vm) as ViewResult;
@@ -966,7 +960,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null,null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.FindByNameAsync(email), Times.Once);
@@ -980,7 +974,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult((ApplicationUser)null));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             var result = await sut.ResetPassword(vm) as RedirectToActionResult;
 
             Assert.Equal("ResetPasswordConfirmation", result.ActionName);
@@ -1003,7 +997,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.ResetPasswordAsync(user, It.Is<string>(y => y == vm.Code), It.Is<string>(y => y == vm.Password)), Times.Once);
@@ -1019,7 +1013,7 @@ namespace AllReady.UnitTest.Controllers
             var user = new ApplicationUser();
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 
             var result = await sut.ResetPassword(vm) as RedirectToActionResult;
 
@@ -1038,7 +1032,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ResetPassword(vm);
 
             var errorMessages = sut.ModelState.GetErrorMessages();
@@ -1055,7 +1049,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object,null, null, null);
             var result = await sut.ResetPassword(vm) as ViewResult;
 
             Assert.IsType<ViewResult>(result);
@@ -1272,7 +1266,7 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, null);
             sut.SetFakeUser("userId");
             await sut.ExternalLoginConfirmation(viewmodel);
 
@@ -1287,7 +1281,7 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, null);
             sut.SetFakeUser("userId");
             var result = await sut.ExternalLoginConfirmation(viewmodel) as ViewResult;
 
@@ -1304,7 +1298,7 @@ namespace AllReady.UnitTest.Controllers
             var viewModel = CreateExternalLoginConfirmationViewModel();
             var generalSettings = CreateGeneralSettingsMockObject();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null);
             sut.SetFakeUser("userId");
 
             await sut.ExternalLoginConfirmation(viewModel);
@@ -1329,7 +1323,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             await sut.ExternalLoginConfirmation(viewModel, "testUrl");
@@ -1399,7 +1393,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
@@ -1429,7 +1423,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
@@ -1461,7 +1455,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
@@ -1494,7 +1488,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
@@ -1517,7 +1511,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
@@ -1546,7 +1540,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as ViewResult;
@@ -1619,33 +1613,20 @@ namespace AllReady.UnitTest.Controllers
         private static AccountController AccountController(SignInResult signInResult = default(SignInResult))
         {
             var userManagerMock = CreateUserManagerMock();
-            var signInManagerMock = CreateSignInManagerMock(userManagerMock);
-            signInManagerMock.Setup(mock => mock
-                .PasswordSignInAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<bool>()))
-                .ReturnsAsync(signInResult == default(SignInResult) ? SignInResult.Success : signInResult
-                );
-            var emailSenderMock = new Mock<IEmailSender>();
-            var generalSettingsMock = new Mock<IOptions<GeneralSettings>>();
-            var mediatorMock = new Mock<IMediator>();
 
-            var controller = new AccountController(
-                userManagerMock.Object,
-                signInManagerMock.Object,
-                emailSenderMock.Object,
-                generalSettingsMock.Object,
-                mediatorMock.Object);
+            var signInManagerMock = CreateSignInManagerMock(userManagerMock);
+            signInManagerMock.Setup(mock => mock.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync(signInResult == default(SignInResult) ? SignInResult.Success : signInResult);
+
             var urlHelperMock = new Mock<IUrlHelper>();
-            urlHelperMock
-                .Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith("http"))))
-                .Returns(false);
-            urlHelperMock
-                .Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith("http"))))
-                .Returns(true);
-            controller.Url = urlHelperMock.Object;
+            urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith("http")))).Returns(false);
+            urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith("http")))).Returns(true);
+
+            var controller = new AccountController(userManagerMock.Object, signInManagerMock.Object, Mock.Of<IOptions<GeneralSettings>>(), Mock.Of<IMediator>())
+            {
+                Url = urlHelperMock.Object
+            };
+
             return controller;
         }
 
@@ -1667,32 +1648,28 @@ namespace AllReady.UnitTest.Controllers
 
             return signInManager;
         }
-        private static AccountController CreateAccountControllerWithNoInjectedDependencies() => new AccountController(null, null, null, null, null);
+        private static AccountController CreateAccountControllerWithNoInjectedDependencies() => new AccountController(null,null, null, null);
 
         private static Mock<UserManager<ApplicationUser>> CreateUserManagerMockWithSucessIdentityResult()
         {
             var userManagerMock = CreateUserManagerMock();
-            userManagerMock.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>()))
-                .Returns(Task.FromResult(IdentityResult.Success));
-            userManagerMock.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
-                .Returns(Task.FromResult(IdentityResult.Success));
+            userManagerMock.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(IdentityResult.Success));
+            userManagerMock.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>())).Returns(Task.FromResult(IdentityResult.Success));
 
             return userManagerMock;
         }
 
-        private static void SetupSignInManagerWithTestExternalLoginValue(Mock<SignInManager<ApplicationUser>> signInManager, 
-            string loginProvider = "test", string providerKey = "test", string displayName = "test")
+        private static void SetupSignInManagerWithTestExternalLoginValue(Mock<SignInManager<ApplicationUser>> signInManager, string loginProvider = "test", string providerKey = "test", 
+            string displayName = "test")
         {
-            signInManager
-                .Setup(s => s.GetExternalLoginInfoAsync(It.IsAny<string>()))
+            signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.IsAny<string>()))
                 .Returns(Task.FromResult(new ExternalLoginInfo(new ClaimsPrincipal(), loginProvider, providerKey, displayName)));
         }
 
         private static void SetupSignInManagerWithDefaultSignInAsync(Mock<SignInManager<ApplicationUser>> signInManager)
         {
-            signInManager
-                .Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
-                    .Returns(Task.FromResult(default(object)));
+            signInManager.Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(default(object)));
         }
 
         private static ExternalLoginConfirmationViewModel CreateExternalLoginConfirmationViewModel(string email = "test@test.com", string firstName = "FirstName", string lastName = "LastName", string phoneNumber = "(111)111-11-11")
@@ -1731,12 +1708,8 @@ namespace AllReady.UnitTest.Controllers
 
         private static void SetupUrlHelperMockToReturnResultBaseOnLineBegining(Mock<IUrlHelper> urlHelperMock, string urlBegining = "http")
         {
-            urlHelperMock
-                .Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith(urlBegining))))
-                .Returns(false);
-            urlHelperMock
-                .Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith(urlBegining))))
-                .Returns(true);
+            urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith(urlBegining)))).Returns(false);
+            urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith(urlBegining)))).Returns(true);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -153,9 +153,9 @@ namespace AllReady.Areas.Admin.Controllers
                 }
 
                 var code = await _userManager.GeneratePasswordResetTokenAsync(user);
-                //mgmccarthy: there is no ResetPassword action methd on the AdminController. Not too sure what to do here.
+                //TODO: mgmccarthy: there is no ResetPassword action methd on the AdminController. Not too sure what to do here. Waiting for feeback via Issue #659
                 var callbackUrl = Url.Action(new UrlActionContext { Action = "ResetPassword", Controller = "Admin", Values = new { userId = user.Id, code = code }, Protocol = HttpContext.Request.Scheme });
-                await _mediator.SendAsync(new SendResetPasswordEmail { Email = user.Email, CallbackUrl = callbackUrl });
+                await _mediator.SendAsync(new Features.Site.SendResetPasswordEmail { Email = user.Email, CallbackUrl = callbackUrl });
 
                 ViewBag.SuccessMessage = $"Sent password reset email for {user.UserName}.";
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -358,6 +358,25 @@ namespace AllReady.Controllers
                     result = await _userManager.AddLoginAsync(user, externalLoginInfo);
                     if (result.Succeeded)
                     {
+                        var emailConfirmationToken = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+                        var callbackUrl = Url.Action(new UrlActionContext
+                        {
+                            Action = nameof(ConfirmEmail),
+                            Controller = "Account",
+                            Values = new { userId = user.Id, token = emailConfirmationToken },
+                            Protocol = HttpContext.Request.Scheme
+                        }
+                        );
+
+                        await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account",
+                            $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
+
+                        var changePhoneNumberToken = await _userManager.GenerateChangePhoneNumberTokenAsync(user, model.PhoneNumber);
+                        await _mediator.SendAsync(new SendAccountSecurityTokenSms { PhoneNumber = model.PhoneNumber, Token = changePhoneNumberToken });
+
+                        //TODO: mgmccarthy: should we add the claim that the user's profile is incomplete for external auth like we're doing in .Register(RegisterViewModel model)?
+                        //await _userManager.AddClaimAsync(user, new Claim(Security.ClaimTypes.ProfileIncomplete, "NewUser"));
+
                         await _signInManager.SignInAsync(user, isPersistent: false);
                         return RedirectToLocal(returnUrl, user);
                     }

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -139,8 +139,6 @@ namespace AllReady.Controllers
                         Protocol = HttpContext.Request.Scheme }
                     );
 
-                    //await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
-                    //    $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
                     await _mediator.SendAsync(new SendConfirmAccountEmail { Email = user.Email, CallbackUrl = callbackUrl });
 
                     var changePhoneNumberToken = await _userManager.GenerateChangePhoneNumberTokenAsync(user, model.PhoneNumber);
@@ -223,9 +221,10 @@ namespace AllReady.Controllers
 
                 //Send an email with this link
                 var code = await _userManager.GeneratePasswordResetTokenAsync(user);
-                var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ResetPassword), Controller = "Account", Values = new { userId = user.Id, code = code },
+                var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ResetPassword), Controller = "Account", Values = new { userId = user.Id, code },
                     Protocol = HttpContext.Request.Scheme });
-                await _emailSender.SendEmailAsync(model.Email, "Reset allReady Password", $"Please reset your allReady password by clicking here: <a href=\"{callbackUrl}\">link</a>");
+                //await _emailSender.SendEmailAsync(model.Email, "Reset allReady Password", $"Please reset your allReady password by clicking here: <a href=\"{callbackUrl}\">link</a>");
+                await _mediator.SendAsync(new SendResetPasswordEmail { Email = model.Email, CallbackUrl = callbackUrl });
 
                 return View("ForgotPasswordConfirmation");
             }
@@ -367,8 +366,6 @@ namespace AllReady.Controllers
                             Protocol = HttpContext.Request.Scheme
                         });
 
-                        //await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
-                        //    $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
                         await _mediator.SendAsync(new SendConfirmAccountEmail { Email = user.Email, CallbackUrl = callbackUrl });
 
                         var changePhoneNumberToken = await _userManager.GenerateChangePhoneNumberTokenAsync(user, model.PhoneNumber);

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -112,7 +112,7 @@ namespace AllReady.Controllers
         {
             var user = await _userManager.FindByIdAsync(User.GetUserId());
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-            var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmNewEmail), Controller = "Account", Values = new { userId = user.Id, code = code },
+            var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmNewEmail), Controller = "Account", Values = new { userId = user.Id, code },
                 Protocol = HttpContext.Request.Scheme });
 
             await _mediator.SendAsync(new SendConfirmAccountEmail { Email = user.Email, CallbackUrl = callbackUrl });

--- a/AllReadyApp/Web-App/AllReady/Features/Manage/SendResetPasswordEmail.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Manage/SendResetPasswordEmail.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Manage
+{
+    public class SendResetPasswordEmail : IAsyncRequest
+    {
+        public string Email { get; set; }
+        public string CallbackUrl { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Manage/SendResetPasswordEmailHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Manage/SendResetPasswordEmailHandlerAsync.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using AllReady.Services;
+using MediatR;
+
+namespace AllReady.Features.Manage
+{
+    public class SendResetPasswordEmailHandlerAsync : AsyncRequestHandler<SendResetPasswordEmail>
+    {
+        private readonly IEmailSender emailSender;
+
+        public SendResetPasswordEmailHandlerAsync(IEmailSender emailSender)
+        {
+            this.emailSender = emailSender;
+        }
+
+        protected override async Task HandleCore(SendResetPasswordEmail message)
+        {
+            await emailSender.SendEmailAsync(message.Email, "Reset allReady Password", 
+                $"Please reset your allReady password by clicking here: <a href=\"{message.CallbackUrl}\">link</a>")
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -132,7 +132,8 @@ namespace AllReady
             else
             {
                 // this writer service will just write to the default logger
-                services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
+                //services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
+                services.AddTransient<IQueueStorageService, SmtpEmailSender>();
             }
 
             var containerBuilder = new ContainerBuilder();

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -132,8 +132,7 @@ namespace AllReady
             else
             {
                 // this writer service will just write to the default logger
-                //services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
-                services.AddTransient<IQueueStorageService, SmtpEmailSender>();
+                services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
             }
 
             var containerBuilder = new ContainerBuilder();

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -34,9 +34,9 @@
   },
   "Authentication": {
     "Facebook": {
-      "AppId": "137164253373251",
-      "AppSecret": "192703d83ae2ced78f109c42c95ca705"
-    },
+        "AppId": "[facebookappId]",
+        "AppSecret": "[facebookappsecret]"
+      },
     "Twitter": {
       "ConsumerKey": "[twitterkey]",
       "ConsumerSecret": "[twittersecret]"

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -34,8 +34,8 @@
   },
   "Authentication": {
     "Facebook": {
-      "AppId": "[facebookappId]",
-      "AppSecret": "[facebookappsecret]"
+      "AppId": "137164253373251",
+      "AppSecret": "192703d83ae2ced78f109c42c95ca705"
     },
     "Twitter": {
       "ConsumerKey": "[twitterkey]",


### PR DESCRIPTION
First, lousy name for my local branch name. Ignore it.

Fixes #955. high level of what's included in this fix.

AccountController.ExternalLoginConfirmation now:
- sends email confirmation
- sends sms confirmation
- adds `Security.ClaimTypes.ProfileIncomplete` to user
- all three of the above steps were already been done in AccountController.Register

AccountController.ForgotPassword
- added new AllReady.Features.Manage.SendResetPassword message/handler
- ForgotPassword now sends this message instead of invoking email sender
- **this is temporary code that can be consolidated once a decision is made on #967**

all unit tests have been updated to reflect changes and stubs have been added for additional code added to ExternalLoginConfirmation