### PR TITLE
Send Email and Sms confirmation messages when authenticating using external providers

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -1165,21 +1165,35 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact(Skip = "NotImplemented")]
-        public async Task ExternalLoginCallbackPopulatesCorrectValuesForFirstNameAndLastNameFromNameClaim__WhenNameClaimIsNotNull_AndExternalLoginInfoIsNotNull()
+        public async Task ExternalLoginCallbackPopulatesCorrectValuesForFirstNameAndLastName_WhenLoginProviderIsGoogle_AndExternalLoginInfoIsNotNull()
         {
             //delete this line when starting work on this unit test
             await taskFromResultZero;
         }
 
         [Fact(Skip = "NotImplemented")]
-        public async Task ExternalLoginCallbackPopulatesStringEmptyForFirstNameAndLastNameFromNameClaim__WhenNameClaimIsNull_AndExternalLoginInfoIsNotNull()
+        public async Task ExternalLoginCallbackPopulatesCorrectValuesForFirstNameAndLastName_WhenLoginProviderIsFacebook_AndExternalLoginInfoIsNotNull()
         {
             //delete this line when starting work on this unit test
             await taskFromResultZero;
         }
 
         [Fact(Skip = "NotImplemented")]
-        public async Task ExternalLoginCallbackSendsApplicationUserQueryAsync_WhenExternalLoginIsSuccessful_AndExternalLoginInfoIsNotNull()
+        public async Task ExternalLoginCallbackPopulatesCorrectValuesForFirstNameAndLastName_WhenLoginProviderIsMicrosoft_AndExternalLoginInfoIsNotNull()
+        {
+            //delete this line when starting work on this unit test
+            await taskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task ExternalLoginCallbackPopulatesCorrectValuesForFirstNameAndLastName_WhenLoginProviderIsTwitter_AndExternalLoginInfoIsNotNull()
+        {
+            //delete this line when starting work on this unit test
+            await taskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task ExternalLoginCallbackSendsApplicationUserQueryAsyncWithCorrectUsername_WhenExternalLoginIsSuccessful_AndExternalLoginInfoIsNotNull()
         {
             //delete this line when starting work on this unit test
             await taskFromResultZero;

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -21,7 +21,7 @@ using AllReady.Areas.Admin.Controllers;
 using System;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using AllReady.ViewModels.Account;
-
+using AllReady.Features.Manage;
 namespace AllReady.UnitTest.Controllers
 {
     public class AccountControllerTests
@@ -271,10 +271,9 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public async Task RegisterPostInvokesSendEmailAsyncWithTheCorrectParameters_WhenModelStateIsValid_AndUserCreationIsSuccessful()
+        public async Task RegisterPostSendsSendConfirmAccountEmailWithTheCorrectParameters_WhenModelStateIsValid_AndUserCreationIsSuccessful()
         {
             const string callbackUrl = "callbackUrl";
-
             var model = new RegisterViewModel { Email = "email" };
 
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
@@ -290,17 +289,14 @@ namespace AllReady.UnitTest.Controllers
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(callbackUrl);
 
-            var emailSenderMock = new Mock<IEmailSender>();
+            var mediator = new Mock<IMediator>();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, mediator.Object);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
 
-            emailSenderMock.Verify(x => x.SendEmailAsync(
-                It.Is<string>(y => y == model.Email),
-                It.IsAny<string>(),
-                It.Is<string>(y => y.Contains(callbackUrl))), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.Is<SendConfirmAccountEmail>(y => y.Email == model.Email && y.CallbackUrl == callbackUrl)), Times.Once);
         }
 
         [Fact(Skip = "NotImplemented")]
@@ -321,7 +317,6 @@ namespace AllReady.UnitTest.Controllers
         public async Task RegisterPostInvokesAddClaimAsyncWithTheCorrectParameters_WhenModelStateIsValid_AndUserCreationIsSuccessful()
         {
             const string defaultTimeZone = "DefaultTimeZone";
-
             var model = new RegisterViewModel { Email = "email" };
 
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
@@ -337,10 +332,7 @@ namespace AllReady.UnitTest.Controllers
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
-            var emailSenderMock = new Mock<IEmailSender>();
-            emailSenderMock.Setup(x => x.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
-
-            var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -371,12 +363,9 @@ namespace AllReady.UnitTest.Controllers
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
-            var emailSenderMock = new Mock<IEmailSender>();
-            emailSenderMock.Setup(x => x.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
-
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -404,13 +393,10 @@ namespace AllReady.UnitTest.Controllers
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
-            var emailSenderMock = new Mock<IEmailSender>();
-            emailSenderMock.Setup(x => x.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
-
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
             signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), null)).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
 
@@ -813,10 +799,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var emailSender = new Mock<IEmailSender>();
-            emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
-
-            var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, Mock.Of<IEmailSender>(), null, null);
             var urlHelper = new Mock<IUrlHelper>();
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             sut.Url = urlHelper.Object;
@@ -1359,7 +1342,49 @@ namespace AllReady.UnitTest.Controllers
                 && ei.ProviderDisplayName == displayName)));
         }
 
-        [Fact(Skip = "RTM Broken Tests")]
+        [Fact(Skip = "NotImplemented")]
+        public async Task ExternalLoginConfirmationInvokesGenerateEmailConfirmationTokenAsyncWithCorrectApplicationUser_WhenUserIsSignedIn_AndModelStateIsValid_AndExternalLoginInfoIsRetreived_AndUserCreationIsSuccessful_AndExternalLoginInfoIsAddedToUser()
+        {
+            //delete this line when starting work on this unit test
+            await taskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task ExternalLoginConfirmationInvokesUrlAction_WithTheCorrectParameters_WhenUserIsSignedIn_AndModelStateIsValid_AndExternalLoginInfoIsRetreived_AndUserCreationIsSuccessful_AndExternalLoginInfoIsAddedToUser()
+        {
+            //delete this line when starting work on this unit test
+            await taskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task ExternalLoginConfirmationSendsSendConfirmAccountEmailWithCorrectParameters_WhenUserIsSignedIn_AndModelStateIsValid_AndExternalLoginInfoIsRetreived_AndUserCreationIsSuccessful_AndExternalLoginInfoIsAddedToUser()
+        {
+            //delete this line when starting work on this unit test
+            await taskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task ExternalLoginConfirmationInvokesGenerateChangePhoneNumberTokenAsyncWithTheCorrectParameters_WhenUserIsSignedIn_AndModelStateIsValid_AndExternalLoginInfoIsRetreived_AndUserCreationIsSuccessful_AndExternalLoginInfoIsAddedToUser()
+        {
+            //delete this line when starting work on this unit test
+            await taskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task ExternalLoginConfirmationSendsSendAccountSecurityTokenSmsWithCorrectParameters_WhenUserIsSignedIn_AndModelStateIsValid_AndExternalLoginInfoIsRetreived_AndUserCreationIsSuccessful_AndExternalLoginInfoIsAddedToUser()
+        {
+            //delete this line when starting work on this unit test
+            await taskFromResultZero;
+        }
+
+        [Fact(Skip = "NotImplemented")]
+        public async Task ExternalLoginConfirmationInvokesSignInAsyncWithCorrectParameters_WhenUserIsSignedIn_AndModelStateIsValid_AndExternalLoginInfoIsRetreived_AndUserCreationIsSuccessful_AndExternalLoginInfoIsAddedToUser()
+        {
+            //delete this line when starting work on this unit test
+            await taskFromResultZero;
+        }
+
+        [Fact]
         public async Task ExternalLoginConfirmationInvokesSignInAsyncWithCorrectParameters_WhenExternalLoginIsAddedSuccessfully()
         {
             var userManager = CreateUserManagerMockWithSucessIdentityResult();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -257,7 +257,6 @@ namespace AllReady.UnitTest.Controllers
             var emailSenderMock = new Mock<IEmailSender>();
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             var urlHelper = new Mock<IUrlHelper>();
             sut.Url = urlHelper.Object;
@@ -294,10 +293,8 @@ namespace AllReady.UnitTest.Controllers
             var emailSenderMock = new Mock<IEmailSender>();
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
-
             await sut.Register(model);
 
             emailSenderMock.Verify(x => x.SendEmailAsync(
@@ -344,17 +341,14 @@ namespace AllReady.UnitTest.Controllers
             emailSenderMock.Setup(x => x.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
-
             await sut.Register(model);
 
             userManager.Verify(x => x.AddClaimAsync(It.Is<ApplicationUser>(au =>
                 au.UserName == model.Email &&
                 au.Email == model.Email &&
-                au.TimeZoneId == defaultTimeZone)
-                , It.IsAny<Claim>()), Times.Once);
+                au.TimeZoneId == defaultTimeZone), It.IsAny<Claim>()), Times.Once);
         }
 
         [Fact]
@@ -383,17 +377,15 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
-
             await sut.Register(model);
 
             signInManager.Verify(x => x.SignInAsync(It.Is<ApplicationUser>(au =>
                 au.UserName == model.Email &&
                 au.Email == model.Email &&
-                au.TimeZoneId == defaultTimeZone)
-                , It.IsAny<bool>(), null), Times.Once);
+                au.TimeZoneId == defaultTimeZone), 
+            It.IsAny<bool>(), null), Times.Once);
         }
 
         [Fact]
@@ -419,7 +411,6 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), null)).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
 
@@ -460,7 +451,6 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
             var sut = new AccountController(userManager.Object, null, null, generalSettings.Object, null);
-
             var result = await sut.Register(model) as ViewResult;
             var modelResult = result.ViewData.Model as RegisterViewModel;
 
@@ -499,8 +489,8 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = CreateSignInManagerMock(CreateUserManagerMock());
 
             var sut = new AccountController(null, signInManager.Object, null, null, null);
-
             await sut.LogOff();
+
             signInManager.Verify(x => x.SignOutAsync(), Times.Once);
         }
 
@@ -511,7 +501,6 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(x => x.SignOutAsync()).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(null, signInManager.Object, null, null, null);
-
             var result = await sut.LogOff() as RedirectToActionResult;
 
             Assert.Equal(result.ActionName, nameof(HomeController.Index));
@@ -522,9 +511,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task ConfirmEmailReturnsErrorView_WhenUserIdIsNull()
         {
             var sut = CreateAccountControllerWithNoInjectedDependencies();
-
             var result = await sut.ConfirmEmail(null, "sometoken") as ViewResult;
-
             Assert.Equal("Error", result.ViewName);
         }
 
@@ -532,19 +519,16 @@ namespace AllReady.UnitTest.Controllers
         public async Task ConfirmEmailReturnsErrorView_WhenTokenIsNull()
         {
             var sut = CreateAccountControllerWithNoInjectedDependencies();
-
             var result = await sut.ConfirmEmail("someuserid", null) as ViewResult;
-
             Assert.Equal("Error", result.ViewName);
         }
 
         [Fact]
         public async Task ConfirmEmailInvokesFindByIdAsyncWithCorrectUserId_WhenUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
-
             var sut = new AccountController(userManager.Object, null, null, null, null);
 
             await sut.ConfirmEmail(userId, token);
@@ -555,14 +539,13 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailReturnsErrorView_WhenUserIsNull_AndUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
-            var userManager = CreateUserManagerMock();
+            const string userId = "userId";
+            const string token = "someToken";
 
+            var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult((ApplicationUser)null));
 
             var sut = new AccountController(userManager.Object, null, null, null, null);
-
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal("Error", result.ViewName);
@@ -571,16 +554,15 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailInvokesConfirmEmailAsyncWithTheCorrectParameters_WhenUserAndUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
- 
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ConfirmEmail(userId, token);
 
             userManager.Verify(x => x.ConfirmEmailAsync(It.Is<ApplicationUser>(y => y == user), It.Is<string>(y => y == token)), Times.Once);
@@ -589,8 +571,8 @@ namespace AllReady.UnitTest.Controllers
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ConfirmEmailInvokesSendAsyncWithTheCorrectParameters_WhenUsersProfileIsComplete_AndUsersEmailIsConfirmed_AndUserAndUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser
@@ -603,7 +585,6 @@ namespace AllReady.UnitTest.Controllers
                 Email = "test@email.com",
                 EmailConfirmed = true
             };
-
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
@@ -612,18 +593,16 @@ namespace AllReady.UnitTest.Controllers
 
             var sut = new AccountController(userManager.Object, null, null, null, mediator.Object);
             sut.SetFakeUser(userId);
-
             await sut.ConfirmEmail(userId, token);
 
             mediator.Verify(x => x.SendAsync(It.Is<RemoveUserProfileIncompleteClaimCommand>(y => y.UserId == userId)), Times.Once);
-
         }
 
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ConfirmEmailInvokesRefreshSignInAsyncWithTheCorrectParameters_WhenUserIsSignedIn_AndUsersProfileIsComplete_AndUsersEmailIsConfirmed_AndUserAndUserIdAndTokenAreNotNull()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser
@@ -636,7 +615,6 @@ namespace AllReady.UnitTest.Controllers
                 Email = "test@email.com",
                 EmailConfirmed = true
             };
-
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
@@ -648,7 +626,6 @@ namespace AllReady.UnitTest.Controllers
 
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, mediator.Object);
             sut.SetFakeUserWithCookieAuthenticationType(userId);
-
             await sut.ConfirmEmail(userId, token);
 
             signInManager.Verify(x => x.RefreshSignInAsync(It.Is<ApplicationUser>(y => y.Id == user.Id)));
@@ -657,16 +634,15 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailReturnsErrorView_WhenUsersEmailCannotBeConfirmed()
         {
-            var userId = "userId";
-            var token = "someToken";
+            const string userId = "userId";
+            const string token = "someToken";
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Failed()));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal(result.ViewName, "Error");
@@ -675,16 +651,15 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ConfirmEmailReturnsConfirmEmailView_WhenUsersEmailCanBeConfirmed()
 		{
-			var userId = "userId";
-			var token = "someToken";
+			const string userId = "userId";
+			const string token = "someToken";
 			var userManager = CreateUserManagerMock();
 
 			var user = new ApplicationUser();
-
 			userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
 			userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
-			var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
 			var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ConfirmEmail");
@@ -733,110 +708,80 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ForgotPasswordPostInvokesFindByNameAsyncWithTheCorrectEmailwhenModelStateIsValid()
 		{
-			var email = "user@domain.tld";
-
-			var vm = new ForgotPasswordViewModel()
-			{
-				Email = email
-			};
+			const string email = "user@domain.tld";
+			var vm = new ForgotPasswordViewModel { Email = email };
 
 			var userManager = CreateUserManagerMock();
-
 			var user = new ApplicationUser();
-
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-			var sut = new AccountController(userManager.Object, null, null, null, null);
-			
+
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ForgotPassword(vm);
 
-			userManager.Verify(m => m.FindByNameAsync(email), Times.Once);
-			
+			userManager.Verify(m => m.FindByNameAsync(email), Times.Once);	
 		}
 
         [Fact]
         public async Task ForgotPasswordPostInvokesIsEmailConfirmedAsyncWithThecorrectUser_WhenModelStateIsValid()
 		{
-			var email = "user@domain.tld";
-
-			var vm = new ForgotPasswordViewModel()
-			{
-				Email = email
-			};
+			const string email = "user@domain.tld";
+			var vm = new ForgotPasswordViewModel { Email = email };
 
 			var userManager = CreateUserManagerMock();
 
 			var user = new ApplicationUser();
-
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user)).Verifiable();
-			var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ForgotPassword(vm);
 
 			userManager.Verify(m => m.IsEmailConfirmedAsync(user), Times.Once);
-
 		}
 
 		[Fact]
         public async Task ForgotPasswordPostReturnsForgotPasswordConfirmationView_WhenModelStateIsValid_AndUserIsNull()
 		{
-			var email = "user@domain.tld";
-			
-			var vm = new ForgotPasswordViewModel()
-			{
-				Email = email
-			};
+			const string email = "user@domain.tld";
+			var vm = new ForgotPasswordViewModel { Email = email }; 
 
 			var userManager = CreateUserManagerMock();
 
 			var user = default(ApplicationUser);
-
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-			var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
 			var result = await sut.ForgotPassword(vm) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
-
 		}
 
 		[Fact]
         public async Task ForgotPasswordPostReturnsForgotPasswordConfirmationView_WhenModelStateIsValid_AndUsersEmailIsUnverified()
 		{
-			var email = "user@domain.tld";
-
-			var vm = new ForgotPasswordViewModel()
-			{
-				Email = email
-			};
+			const string email = "user@domain.tld";
+			var vm = new ForgotPasswordViewModel { Email = email };
 
 			var userManager = CreateUserManagerMock();
 
 			var user = new ApplicationUser();
-
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 			userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(false));
-			var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
 			var result = await sut.ForgotPassword(vm) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
-
 		}
 
 		[Fact]
 		public async Task ForgotPasswordPostInvokesGeneratePasswordResetTokenAsyncWithCorrectUser_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
 		{
-            var email = "user@domain.tld";
-
-            var vm = new ForgotPasswordViewModel()
-            {
-                Email = email
-            };
+            const string email = "user@domain.tld";
+            var vm = new ForgotPasswordViewModel { Email = email };
 
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
@@ -858,17 +803,12 @@ namespace AllReady.UnitTest.Controllers
         public async Task ForgotPasswordPostInvokesUrlActionWithCorrectParameters_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
         {
             const string requestScheme = "requestScheme";
-            var email = "user@domain.tld";
-
-            var vm = new ForgotPasswordViewModel()
-            {
-                Email = email
-            };
+            const string email = "user@domain.tld";
+            var vm = new ForgotPasswordViewModel { Email = email };
 
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
@@ -877,35 +817,28 @@ namespace AllReady.UnitTest.Controllers
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
-
             var urlHelper = new Mock<IUrlHelper>();
-
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             sut.Url = urlHelper.Object;
 
             await sut.ForgotPassword(vm);
 
             urlHelper.Verify(mock => mock.Action(It.Is<UrlActionContext>(uac => 
-                        uac.Action == "ResetPassword" 
-                        && uac.Controller == "Account" 
-                        && uac.Protocol == requestScheme)), Times.Once);
+                uac.Action == "ResetPassword" 
+                && uac.Controller == "Account" 
+                && uac.Protocol == requestScheme)), Times.Once);
         }
 
         [Fact]
         public async Task ForgotPasswordPostInvokesSendEmailAsyncWithCorrectParameters_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
         {
-            var email = "user@domain.tld";
+            const string email = "user@domain.tld";
             const string callbackUrl = "callbackUrl";
 
-            var vm = new ForgotPasswordViewModel()
-            {
-                Email = email
-            };
-
+            var vm = new ForgotPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
@@ -914,10 +847,8 @@ namespace AllReady.UnitTest.Controllers
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
-
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(callbackUrl);
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
 
@@ -930,16 +861,10 @@ namespace AllReady.UnitTest.Controllers
         public async Task ForgotPasswordPostReturnsForgotPasswordConfirmationView_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
         {
             const string email = "user@domain.tld";
-
-            var vm = new ForgotPasswordViewModel()
-            {
-                Email = email
-            };
-
+            var vm = new ForgotPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
@@ -948,14 +873,11 @@ namespace AllReady.UnitTest.Controllers
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
-
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
-
             var result = await sut.ForgotPassword(vm) as ViewResult;
 
             Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
-
         }
 
         [Fact]
@@ -1011,7 +933,7 @@ namespace AllReady.UnitTest.Controllers
         public void ResetPasswordGetReturnsAViewIfCodeIsNotNull()
         {
             var sut = AccountController();
-            var code = "1234";
+            const string code = "1234";
             var result = (ViewResult)sut.ResetPassword(code);
 
             Assert.IsType<ViewResult>(result);
@@ -1040,7 +962,6 @@ namespace AllReady.UnitTest.Controllers
 
             var sut = CreateAccountControllerWithNoInjectedDependencies();
             sut.AddModelStateError();
-
             var result = await sut.ResetPassword(vm) as ViewResult;
             var modelResult = result.ViewData.Model as ResetPasswordViewModel;
 
@@ -1052,21 +973,16 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostInvokesFindByNameAsyncWithTheCorrecEmail_WhenModelStateIsValid()
         {
-            var email = "user@domain.tld";
+            const string email = "user@domain.tld";
 
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
+            var vm = new ResetPasswordViewModel { Email = email };
 
             var userManager = CreateUserManagerMock();
-
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.FindByNameAsync(email), Times.Once);
@@ -1075,18 +991,12 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostRedirectsToCorrectAction_WhenUserIsNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
-
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
-
+            const string email = "user@domain.tld";
+            var vm = new ResetPasswordViewModel{ Email = email };
             var userManager = CreateUserManagerMock();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult((ApplicationUser)null));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             var result = await sut.ResetPassword(vm) as RedirectToActionResult;
 
             Assert.Equal("ResetPasswordConfirmation", result.ActionName);
@@ -1095,9 +1005,9 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostInvokesResetPasswordAsyncWithCorrectParameters_WhenUserIsNotNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
+            const string email = "user@domain.tld";
 
-            var vm = new ResetPasswordViewModel()
+            var vm = new ResetPasswordViewModel
             {
                 Email = email,
                 Password = "pass",
@@ -1105,13 +1015,11 @@ namespace AllReady.UnitTest.Controllers
             };
 
             var userManager = CreateUserManagerMock();
-
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.ResetPasswordAsync(user, It.Is<string>(y => y == vm.Code), It.Is<string>(y => y == vm.Password)), Times.Once);
@@ -1120,17 +1028,11 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostRedirectsToCorrectAction_WhenUsersPasswordResetSucceeded_AndUserIsNotNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
-
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
-
+            const string email = "user@domain.tld";
+            var vm = new ResetPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
 
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
             var sut = new AccountController(userManager.Object, null, null, null, null);
@@ -1143,50 +1045,37 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task ResetPasswordPostAddsIdentityResultErrorsToModelStateErrors_WhenUsersPasswordResetFailed_AndUserIsNotNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
+            const string email = "user@domain.tld";
 
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
-
+            var vm = new ResetPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
             var identityResult = IdentityResult.Failed(new IdentityError { Description = "IdentityErrorDescription" });
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
-            var result = await sut.ResetPassword(vm) as ViewResult;
+            var sut = new AccountController(userManager.Object, null, null, null, null);
+            await sut.ResetPassword(vm);
 
             var errorMessages = sut.ModelState.GetErrorMessages();
             Assert.Equal(identityResult.Errors.Select(x => x.Description).Single(), errorMessages.Single());
-
         }
 
         [Fact]
         public async Task ResetPasswordPostReturnsAView_WhenUsersPasswordResetFailed_AndUserIsNotNull_AndModelStateIsValid()
         {
-            var email = "user@domain.tld";
-
-            var vm = new ResetPasswordViewModel()
-            {
-                Email = email
-            };
-
+            const string email = "user@domain.tld";
+            var vm = new ResetPasswordViewModel { Email = email };
             var userManager = CreateUserManagerMock();
             var user = new ApplicationUser();
-
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
 
+            var sut = new AccountController(userManager.Object, null, null, null, null);
             var result = await sut.ResetPassword(vm) as ViewResult;
 
             Assert.IsType<ViewResult>(result);
             Assert.Null(result.ViewData.Model);
-
         }
 
         [Fact]
@@ -1380,11 +1269,13 @@ namespace AllReady.UnitTest.Controllers
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ExternalLoginConfirmationRedirectsToCorrectActionIfUserIsSignedIn()
         {
+            var identity = new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.NameIdentifier, "test") }, IdentityCookieOptions.ApplicationCookieAuthenticationType);
+
             var sut = AccountController();
-            var identity = new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.NameIdentifier, "test") }, new IdentityCookieOptions().ApplicationCookieAuthenticationScheme);
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
             sut.HttpContext.User.AddIdentity(identity);
             var result = await sut.ExternalLoginConfirmation(new ExternalLoginConfirmationViewModel()) as RedirectToActionResult;
+
             Assert.Equal<string>(result.ControllerName, "Manage");
             Assert.Equal<string>(result.ActionName, nameof(ManageController.Index));
         }
@@ -1396,8 +1287,9 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = CreateSignInManagerMock(userManager);
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
+
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null);
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
             await sut.ExternalLoginConfirmation(viewmodel);
 
             signInManager.Verify(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null)), Times.Once());
@@ -1410,8 +1302,9 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = CreateSignInManagerMock(userManager);
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
+
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null);
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
             var result = await sut.ExternalLoginConfirmation(viewmodel) as ViewResult;
 
             Assert.Equal(result.ViewName, "ExternalLoginFailure");
@@ -1421,14 +1314,14 @@ namespace AllReady.UnitTest.Controllers
         public async Task ExternalLoginConfirmationInvokesCreateAsyncWithCorrectUser_WhenExternalLoginInfoIsSuccessful_AndModelStateIsValid()
         {
             var userManager = CreateUserManagerMock();
-            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult<IdentityResult>(new IdentityResult()));
+            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(new IdentityResult()));
             var signInManager = CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager);
             var viewModel = CreateExternalLoginConfirmationViewModel();
             var generalSettings = CreateGeneralSettingsMockObject();
 
             var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
 
             await sut.ExternalLoginConfirmation(viewModel);
 
@@ -1438,31 +1331,33 @@ namespace AllReady.UnitTest.Controllers
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ExternalLoginConfirmationInvokesAddLoginAsyncWithCorrectParameters_WhenUserIsCreatedSuccessfully()
         {
-            const string defaultTimeZone = "DefaultTimeZone";
+            const string loginProvider = "test";
+            const string providerKey = "test";
+            const string displayName = "testDisplayName";
 
             var userManager = CreateUserManagerMockWithSucessIdentityResult();
             var signInManager = CreateSignInManagerMock(userManager);
-            SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
+            SetupSignInManagerWithTestExternalLoginValue(signInManager, loginProvider, providerKey, displayName);
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnTrueForLocalUrl(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
 
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
-            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
             var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
-            sut.SetFakeUser("test");
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             await sut.ExternalLoginConfirmation(viewModel, "testUrl");
 
             userManager.Verify(u => u.AddLoginAsync(It.Is<ApplicationUser>(au => au.Email == viewModel.Email
-                    && au.FirstName == viewModel.FirstName
-                    && au.LastName == viewModel.LastName
-                    && au.PhoneNumber == viewModel.PhoneNumber),
-                It.Is<ExternalLoginInfo>(ei => ei.LoginProvider == "test"
-                    && ei.ProviderKey == "testKey"
-                    && ei.ProviderDisplayName == "testDisplayName")));
-}
+                && au.FirstName == viewModel.FirstName
+                && au.LastName == viewModel.LastName
+                && au.PhoneNumber == viewModel.PhoneNumber),
+            It.Is<ExternalLoginInfo>(ei => ei.LoginProvider == loginProvider
+                && ei.ProviderKey == providerKey
+                && ei.ProviderDisplayName == displayName)));
+        }
 
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ExternalLoginConfirmationInvokesSignInAsyncWithCorrectParameters_WhenExternalLoginIsAddedSuccessfully()
@@ -1474,10 +1369,12 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnTrueForLocalUrl(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
             await sut.ExternalLoginConfirmation(viewModel, "testUrl");
@@ -1493,6 +1390,8 @@ namespace AllReady.UnitTest.Controllers
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ExternalLoginConfirmationRedirectsToCorrectUrl_WhenUrlIsLocalUrl()
         {
+            const string returnUrl = "localUrl";
+
             var userManager = CreateUserManagerMockWithSucessIdentityResult();
             var signInManager = CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
@@ -1500,15 +1399,17 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
-            var result = await sut.ExternalLoginConfirmation(viewModel, "localUrl") as RedirectResult;
+            var result = await sut.ExternalLoginConfirmation(viewModel, returnUrl) as RedirectResult;
 
-            Assert.Equal(result.Url, "localUrl");
+            Assert.Equal(result.Url, returnUrl);
         }
 
         [Fact(Skip = "RTM Broken Tests")]
@@ -1521,7 +1422,7 @@ namespace AllReady.UnitTest.Controllers
                 .Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Callback<ApplicationUser, bool, string>((appUser, persist, auth) =>
                 {
-                    appUser.Claims.Add(new IdentityUserClaim<string>()
+                    appUser.Claims.Add(new IdentityUserClaim<string>
                     {
                         ClaimType = AllReady.Security.ClaimTypes.UserType,
                         ClaimValue = Enum.GetName(typeof(UserType), UserType.SiteAdmin)
@@ -1531,9 +1432,11 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
 
@@ -1552,7 +1455,7 @@ namespace AllReady.UnitTest.Controllers
                 .Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
                 .Callback<ApplicationUser, bool, string>((appUser, persist, auth) =>
                 {
-                    appUser.Claims.Add(new IdentityUserClaim<string>()
+                    appUser.Claims.Add(new IdentityUserClaim<string>
                     {
                         ClaimType = AllReady.Security.ClaimTypes.UserType,
                         ClaimValue = Enum.GetName(typeof(UserType), UserType.OrgAdmin)
@@ -1562,9 +1465,11 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
 
@@ -1583,9 +1488,11 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
 
@@ -1597,10 +1504,12 @@ namespace AllReady.UnitTest.Controllers
         public async Task ExternalLoginConfirmationAddsIdentityResultErrorsToModelStateError_WhenUserIsCreatedSuccessfully()
         {
             var userManager = CreateUserManagerMock();
-            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>()))
-                .Returns(Task.FromResult<IdentityResult>(IdentityResult.Success));
+            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(IdentityResult.Success));
             userManager.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
-                .Returns(Task.FromResult<IdentityResult>(IdentityResult.Failed(new IdentityError() { Code = "TestCode1", Description = "TestDescription1" }, new IdentityError() { Code = "TestCode2", Description = "TestDescription2" })));
+                .Returns(Task.FromResult(IdentityResult.Failed(
+                    new IdentityError { Code = "TestCode1", Description = "TestDescription1" }, 
+                    new IdentityError { Code = "TestCode2", Description = "TestDescription2" }
+                )));
 
             var signInManager = CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
@@ -1608,9 +1517,11 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
-            sut.SetFakeUser("test");
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as ViewResult;
 
@@ -1627,26 +1538,29 @@ namespace AllReady.UnitTest.Controllers
             const string returnUrlKey = "ReturnUrl";
             const string returnUrlValue = "http:\\test.url.com";
             var model = new ExternalLoginConfirmationViewModel();
+
             var controller = AccountController();
             controller.AddModelStateError();
             controller.SetFakeUser("test");
+
             var result = await controller.ExternalLoginConfirmation(model, returnUrlValue) as ViewResult;
             var viewDataKey = result.ViewData.Keys.FirstOrDefault(k => k == returnUrlKey);
             var viewDataValue = result.ViewData[returnUrlKey] as string;
             Assert.Equal<string>(viewDataValue, returnUrlValue);
             Assert.NotNull(viewDataKey);
-
         }
 
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ExternalLoginConfirmationReturnsCorrectViewModel_WhenModelStateIsInvalid()
         {
             var model = new ExternalLoginConfirmationViewModel();
+
             var controller = AccountController();
             controller.AddModelStateError();
             controller.SetFakeUser("test");
             var result = await controller.ExternalLoginConfirmation(model) as ViewResult;
             var modelResult = result.ViewData.Model as ExternalLoginConfirmationViewModel;
+
             Assert.IsType<ViewResult>(result);
             Assert.IsType<ExternalLoginConfirmationViewModel>(modelResult);
             Assert.Same(modelResult, model);
@@ -1735,9 +1649,9 @@ namespace AllReady.UnitTest.Controllers
         {
             var userManagerMock = CreateUserManagerMock();
             userManagerMock.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>()))
-                .Returns(Task.FromResult<IdentityResult>(IdentityResult.Success));
+                .Returns(Task.FromResult(IdentityResult.Success));
             userManagerMock.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
-                .Returns(Task.FromResult<IdentityResult>(IdentityResult.Success));
+                .Returns(Task.FromResult(IdentityResult.Success));
 
             return userManagerMock;
         }
@@ -1747,7 +1661,7 @@ namespace AllReady.UnitTest.Controllers
         {
             signInManager
                 .Setup(s => s.GetExternalLoginInfoAsync(It.IsAny<string>()))
-                .Returns(Task.FromResult<ExternalLoginInfo>(new ExternalLoginInfo(new ClaimsPrincipal(), loginProvider, providerKey, displayName)));
+                .Returns(Task.FromResult(new ExternalLoginInfo(new ClaimsPrincipal(), loginProvider, providerKey, displayName)));
         }
 
         private static void SetupSignInManagerWithDefaultSignInAsync(Mock<SignInManager<ApplicationUser>> signInManager)
@@ -1759,7 +1673,7 @@ namespace AllReady.UnitTest.Controllers
 
         private static ExternalLoginConfirmationViewModel CreateExternalLoginConfirmationViewModel(string email = "test@test.com", string firstName = "FirstName", string lastName = "LastName", string phoneNumber = "(111)111-11-11")
         {
-            var result = new ExternalLoginConfirmationViewModel()
+            var result = new ExternalLoginConfirmationViewModel
             {
                 Email = email,
                 FirstName = firstName,

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -1438,17 +1438,23 @@ namespace AllReady.UnitTest.Controllers
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ExternalLoginConfirmationInvokesAddLoginAsyncWithCorrectParameters_WhenUserIsCreatedSuccessfully()
         {
+            const string defaultTimeZone = "DefaultTimeZone";
+
             var userManager = CreateUserManagerMockWithSucessIdentityResult();
             var signInManager = CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnTrueForLocalUrl(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
-            var generalSettings = CreateGeneralSettingsMockObject();
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
+
+            var generalSettings = new Mock<IOptions<GeneralSettings>>();
+            generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
+
+            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("test");
             sut.Url = urlHelperMock.Object;
             await sut.ExternalLoginConfirmation(viewModel, "testUrl");
+
             userManager.Verify(u => u.AddLoginAsync(It.Is<ApplicationUser>(au => au.Email == viewModel.Email
                     && au.FirstName == viewModel.FirstName
                     && au.LastName == viewModel.LastName

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -201,7 +201,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, generalSettings.Object, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null);
             await sut.Register(model);
 
             userManager.Verify(x => x.CreateAsync(It.Is<ApplicationUser>(au =>
@@ -226,9 +226,8 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
 
             var signInManager = CreateSignInManagerMock(userManager);
-            var emailSenderMock = new Mock<IEmailSender>();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
 
@@ -254,9 +253,8 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
 
             var signInManager = CreateSignInManagerMock(userManager);
-            var emailSenderMock = new Mock<IEmailSender>();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, emailSenderMock.Object, generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             var urlHelper = new Mock<IUrlHelper>();
             sut.Url = urlHelper.Object;
@@ -291,7 +289,7 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, mediator.Object);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, mediator.Object);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -332,7 +330,7 @@ namespace AllReady.UnitTest.Controllers
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -365,7 +363,7 @@ namespace AllReady.UnitTest.Controllers
 
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -396,7 +394,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
             signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), null)).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object,generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
 
@@ -417,7 +415,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
 
-            var sut = new AccountController(userManager.Object, null, null, generalSettings.Object, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null);
 
             await sut.Register(new RegisterViewModel());
 
@@ -436,7 +434,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, generalSettings.Object, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null);
             var result = await sut.Register(model) as ViewResult;
             var modelResult = result.ViewData.Model as RegisterViewModel;
 
@@ -474,7 +472,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var signInManager = CreateSignInManagerMock(CreateUserManagerMock());
 
-            var sut = new AccountController(null, signInManager.Object, null, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null);
             await sut.LogOff();
 
             signInManager.Verify(x => x.SignOutAsync(), Times.Once);
@@ -486,7 +484,7 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = CreateSignInManagerMock(CreateUserManagerMock());
             signInManager.Setup(x => x.SignOutAsync()).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(null, signInManager.Object, null, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null);
             var result = await sut.LogOff() as RedirectToActionResult;
 
             Assert.Equal(result.ActionName, nameof(HomeController.Index));
@@ -515,7 +513,7 @@ namespace AllReady.UnitTest.Controllers
             const string userId = "userId";
             const string token = "someToken";
             var userManager = CreateUserManagerMock();
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 
             await sut.ConfirmEmail(userId, token);
 
@@ -531,7 +529,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult((ApplicationUser)null));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal("Error", result.ViewName);
@@ -548,7 +546,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ConfirmEmail(userId, token);
 
             userManager.Verify(x => x.ConfirmEmailAsync(It.Is<ApplicationUser>(y => y == user), It.Is<string>(y => y == token)), Times.Once);
@@ -577,7 +575,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).Returns(() => Task.FromResult(It.IsAny<Unit>()));
 
-            var sut = new AccountController(userManager.Object, null, null, null, mediator.Object);
+            var sut = new AccountController(userManager.Object, null, null, mediator.Object);
             sut.SetFakeUser(userId);
             await sut.ConfirmEmail(userId, token);
 
@@ -610,7 +608,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).Returns(() => Task.FromResult(It.IsAny<Unit>()));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, mediator.Object);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, mediator.Object);
             sut.SetFakeUserWithCookieAuthenticationType(userId);
             await sut.ConfirmEmail(userId, token);
 
@@ -628,7 +626,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal(result.ViewName, "Error");
@@ -645,7 +643,7 @@ namespace AllReady.UnitTest.Controllers
 			userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
 			userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 			var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ConfirmEmail");
@@ -701,7 +699,7 @@ namespace AllReady.UnitTest.Controllers
 			var user = new ApplicationUser();
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ForgotPassword(vm);
 
 			userManager.Verify(m => m.FindByNameAsync(email), Times.Once);	
@@ -718,7 +716,7 @@ namespace AllReady.UnitTest.Controllers
 			var user = new ApplicationUser();
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user)).Verifiable();
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ForgotPassword(vm);
 
 			userManager.Verify(m => m.IsEmailConfirmedAsync(user), Times.Once);
@@ -735,7 +733,7 @@ namespace AllReady.UnitTest.Controllers
 			var user = default(ApplicationUser);
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 			var result = await sut.ForgotPassword(vm) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
@@ -753,7 +751,7 @@ namespace AllReady.UnitTest.Controllers
 			userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 			userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(false));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 			var result = await sut.ForgotPassword(vm) as ViewResult;
 
 			Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
@@ -775,7 +773,7 @@ namespace AllReady.UnitTest.Controllers
             var emailSender = new Mock<IEmailSender>();
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>());
 
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
@@ -799,7 +797,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var sut = new AccountController(userManager.Object, null, Mock.Of<IEmailSender>(), null, null);
+            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>());
             var urlHelper = new Mock<IUrlHelper>();
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             sut.Url = urlHelper.Object;
@@ -813,7 +811,7 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public async Task ForgotPasswordPostInvokesSendEmailAsyncWithCorrectParameters_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
+        public async Task ForgotPasswordPostSendsSendResetPasswordEmailWithCorrectParameters_WhenModelStateIsValid_AndUserIsNotNull_AndUsersEmailHasBeenVerified()
         {
             const string email = "user@domain.tld";
             const string callbackUrl = "callbackUrl";
@@ -826,10 +824,9 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var emailSender = new Mock<IEmailSender>();
-            emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
+            var mediator = new Mock<IMediator>();
 
-            var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, null, mediator.Object);
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(callbackUrl);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
@@ -837,7 +834,7 @@ namespace AllReady.UnitTest.Controllers
 
             await sut.ForgotPassword(vm);
 
-            emailSender.Verify(x => x.SendEmailAsync(email, It.IsAny<string>(), It.Is<string>(y => y.Contains(callbackUrl))), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.Is<SendResetPasswordEmail>(y => y.Email == vm.Email && y.CallbackUrl == callbackUrl)), Times.Once);
         }
 
         [Fact]
@@ -852,10 +849,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var emailSender = new Mock<IEmailSender>();
-            emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
-
-            var sut = new AccountController(userManager.Object, null, emailSender.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>());
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
             var result = await sut.ForgotPassword(vm) as ViewResult;
@@ -965,7 +959,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null,null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.FindByNameAsync(email), Times.Once);
@@ -979,7 +973,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMock();
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult((ApplicationUser)null));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             var result = await sut.ResetPassword(vm) as RedirectToActionResult;
 
             Assert.Equal("ResetPasswordConfirmation", result.ActionName);
@@ -1002,7 +996,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.ResetPasswordAsync(user, It.Is<string>(y => y == vm.Code), It.Is<string>(y => y == vm.Password)), Times.Once);
@@ -1018,7 +1012,7 @@ namespace AllReady.UnitTest.Controllers
             var user = new ApplicationUser();
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
 
             var result = await sut.ResetPassword(vm) as RedirectToActionResult;
 
@@ -1037,7 +1031,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null);
             await sut.ResetPassword(vm);
 
             var errorMessages = sut.ModelState.GetErrorMessages();
@@ -1054,7 +1048,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object,null, null, null);
             var result = await sut.ResetPassword(vm) as ViewResult;
 
             Assert.IsType<ViewResult>(result);
@@ -1271,7 +1265,7 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, null);
             sut.SetFakeUser("userId");
             await sut.ExternalLoginConfirmation(viewmodel);
 
@@ -1286,7 +1280,7 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, null);
             sut.SetFakeUser("userId");
             var result = await sut.ExternalLoginConfirmation(viewmodel) as ViewResult;
 
@@ -1303,7 +1297,7 @@ namespace AllReady.UnitTest.Controllers
             var viewModel = CreateExternalLoginConfirmationViewModel();
             var generalSettings = CreateGeneralSettingsMockObject();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, generalSettings.Object, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null);
             sut.SetFakeUser("userId");
 
             await sut.ExternalLoginConfirmation(viewModel);
@@ -1328,7 +1322,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             await sut.ExternalLoginConfirmation(viewModel, "testUrl");
@@ -1398,7 +1392,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
@@ -1428,7 +1422,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
@@ -1460,7 +1454,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
@@ -1493,7 +1487,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
@@ -1516,7 +1510,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as RedirectToActionResult;
@@ -1545,7 +1539,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, Mock.Of<IEmailSender>(), generalSettings.Object, Mock.Of<IMediator>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as ViewResult;
@@ -1618,35 +1612,20 @@ namespace AllReady.UnitTest.Controllers
         private static AccountController AccountController(Microsoft.AspNetCore.Identity.SignInResult signInResult = default(Microsoft.AspNetCore.Identity.SignInResult))
         {
             var userManagerMock = CreateUserManagerMock();
-            var signInManagerMock = CreateSignInManagerMock(userManagerMock);
-            signInManagerMock.Setup(mock => mock
-                .PasswordSignInAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<bool>(),
-                    It.IsAny<bool>()))
-                .ReturnsAsync(signInResult == default(Microsoft.AspNetCore.Identity.SignInResult)
-                            ? Microsoft.AspNetCore.Identity.SignInResult.Success
-                            : signInResult
-                );
-            var emailSenderMock = new Mock<IEmailSender>();
-            var generalSettingsMock = new Mock<IOptions<GeneralSettings>>();
-            var mediatorMock = new Mock<IMediator>();
 
-            var controller = new AccountController(
-                userManagerMock.Object,
-                signInManagerMock.Object,
-                emailSenderMock.Object,
-                generalSettingsMock.Object,
-                mediatorMock.Object);
+            var signInManagerMock = CreateSignInManagerMock(userManagerMock);
+            signInManagerMock.Setup(mock => mock.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
+                .ReturnsAsync(signInResult == default(SignInResult) ? SignInResult.Success : signInResult);
+
             var urlHelperMock = new Mock<IUrlHelper>();
-            urlHelperMock
-                .Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith("http"))))
-                .Returns(false);
-            urlHelperMock
-                .Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith("http"))))
-                .Returns(true);
-            controller.Url = urlHelperMock.Object;
+            urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith("http")))).Returns(false);
+            urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith("http")))).Returns(true);
+
+            var controller = new AccountController(userManagerMock.Object, signInManagerMock.Object, Mock.Of<IOptions<GeneralSettings>>(), Mock.Of<IMediator>())
+            {
+                Url = urlHelperMock.Object
+            };
+
             return controller;
         }
 
@@ -1668,32 +1647,28 @@ namespace AllReady.UnitTest.Controllers
 
             return signInManager;
         }
-        private static AccountController CreateAccountControllerWithNoInjectedDependencies() => new AccountController(null, null, null, null, null);
+        private static AccountController CreateAccountControllerWithNoInjectedDependencies() => new AccountController(null,null, null, null);
 
         private static Mock<UserManager<ApplicationUser>> CreateUserManagerMockWithSucessIdentityResult()
         {
             var userManagerMock = CreateUserManagerMock();
-            userManagerMock.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>()))
-                .Returns(Task.FromResult(IdentityResult.Success));
-            userManagerMock.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
-                .Returns(Task.FromResult(IdentityResult.Success));
+            userManagerMock.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(IdentityResult.Success));
+            userManagerMock.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>())).Returns(Task.FromResult(IdentityResult.Success));
 
             return userManagerMock;
         }
 
-        private static void SetupSignInManagerWithTestExternalLoginValue(Mock<SignInManager<ApplicationUser>> signInManager, 
-            string loginProvider = "test", string providerKey = "test", string displayName = "test")
+        private static void SetupSignInManagerWithTestExternalLoginValue(Mock<SignInManager<ApplicationUser>> signInManager, string loginProvider = "test", string providerKey = "test", 
+            string displayName = "test")
         {
-            signInManager
-                .Setup(s => s.GetExternalLoginInfoAsync(It.IsAny<string>()))
+            signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.IsAny<string>()))
                 .Returns(Task.FromResult(new ExternalLoginInfo(new ClaimsPrincipal(), loginProvider, providerKey, displayName)));
         }
 
         private static void SetupSignInManagerWithDefaultSignInAsync(Mock<SignInManager<ApplicationUser>> signInManager)
         {
-            signInManager
-                .Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
-                    .Returns(Task.FromResult(default(object)));
+            signInManager.Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(default(object)));
         }
 
         private static ExternalLoginConfirmationViewModel CreateExternalLoginConfirmationViewModel(string email = "test@test.com", string firstName = "FirstName", string lastName = "LastName", string phoneNumber = "(111)111-11-11")
@@ -1732,12 +1707,8 @@ namespace AllReady.UnitTest.Controllers
 
         private static void SetupUrlHelperMockToReturnResultBaseOnLineBegining(Mock<IUrlHelper> urlHelperMock, string urlBegining = "http")
         {
-            urlHelperMock
-                .Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith(urlBegining))))
-                .Returns(false);
-            urlHelperMock
-                .Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith(urlBegining))))
-                .Returns(true);
+            urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith(urlBegining)))).Returns(false);
+            urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith(urlBegining)))).Returns(true);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -1260,7 +1260,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact(Skip = "RTM Broken Tests")]
         public async Task ExternalLoginConfirmationRedirectsToCorrectActionIfUserIsSignedIn()
         {
-            var identity = new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.NameIdentifier, "test") }, IdentityCookieOptions.ApplicationCookieAuthenticationType);
+            var identity = new ClaimsIdentity(new List<Claim> { new Claim(ClaimTypes.NameIdentifier, "test") }, new IdentityCookieOptions().ApplicationCookieAuthenticationScheme);
 
             var sut = AccountController();
             sut.SetFakeUser("userId");
@@ -1629,7 +1629,8 @@ namespace AllReady.UnitTest.Controllers
 
             var signInManagerMock = CreateSignInManagerMock(userManagerMock);
             signInManagerMock.Setup(mock => mock.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>()))
-                .ReturnsAsync(signInResult == default(SignInResult) ? SignInResult.Success : signInResult);
+                //.ReturnsAsync(signInResult == default(SignInResult) ? SignInResult.Success : signInResult);
+                .ReturnsAsync(signInResult == default(Microsoft.AspNetCore.Identity.SignInResult) ? Microsoft.AspNetCore.Identity.SignInResult.Success : signInResult);
 
             var urlHelperMock = new Mock<IUrlHelper>();
             urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith("http")))).Returns(false);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SiteAdminController.cs
@@ -153,9 +153,9 @@ namespace AllReady.Areas.Admin.Controllers
                 }
 
                 var code = await _userManager.GeneratePasswordResetTokenAsync(user);
-                //mgmccarthy: there is no ResetPassword action methd on the AdminController. Not too sure what to do here.
+                //TODO: mgmccarthy: there is no ResetPassword action methd on the AdminController. Not too sure what to do here. Waiting for feeback via Issue #659
                 var callbackUrl = Url.Action(new UrlActionContext { Action = "ResetPassword", Controller = "Admin", Values = new { userId = user.Id, code = code }, Protocol = HttpContext.Request.Scheme });
-                await _mediator.SendAsync(new SendResetPasswordEmail { Email = user.Email, CallbackUrl = callbackUrl });
+                await _mediator.SendAsync(new Features.Site.SendResetPasswordEmail { Email = user.Email, CallbackUrl = callbackUrl });
 
                 ViewBag.SuccessMessage = $"Sent password reset email for {user.UserName}.";
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -141,8 +141,6 @@ namespace AllReady.Controllers
           }
           );
 
-                    //await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
-                    //    $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
                     await _mediator.SendAsync(new SendConfirmAccountEmail { Email = user.Email, CallbackUrl = callbackUrl });
 
           var changePhoneNumberToken = await _userManager.GenerateChangePhoneNumberTokenAsync(user, model.PhoneNumber);
@@ -223,16 +221,12 @@ namespace AllReady.Controllers
           return View("ForgotPasswordConfirmation");
         }
 
-        //Send an email with this link
-        var code = await _userManager.GeneratePasswordResetTokenAsync(user);
-        var callbackUrl = Url.Action(new UrlActionContext
-        {
-          Action = nameof(ResetPassword),
-          Controller = "Account",
-          Values = new { userId = user.Id, code = code },
-          Protocol = HttpContext.Request.Scheme
-        });
-        await _emailSender.SendEmailAsync(model.Email, "Reset allReady Password", $"Please reset your allReady password by clicking here: <a href=\"{callbackUrl}\">link</a>");
+                //Send an email with this link
+                var code = await _userManager.GeneratePasswordResetTokenAsync(user);
+                var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ResetPassword), Controller = "Account", Values = new { userId = user.Id, code },
+                    Protocol = HttpContext.Request.Scheme });
+                //await _emailSender.SendEmailAsync(model.Email, "Reset allReady Password", $"Please reset your allReady password by clicking here: <a href=\"{callbackUrl}\">link</a>");
+                await _mediator.SendAsync(new SendResetPasswordEmail { Email = model.Email, CallbackUrl = callbackUrl });
 
         return View("ForgotPasswordConfirmation");
       }
@@ -374,8 +368,6 @@ namespace AllReady.Controllers
                             Protocol = HttpContext.Request.Scheme
                         });
 
-                        //await _emailSender.SendEmailAsync(model.Email, "Confirm your allReady account", 
-                        //    $"Please confirm your allReady account by clicking this link: <a href=\"{callbackUrl}\">link</a>");
                         await _mediator.SendAsync(new SendConfirmAccountEmail { Email = user.Email, CallbackUrl = callbackUrl });
 
                         var changePhoneNumberToken = await _userManager.GenerateChangePhoneNumberTokenAsync(user, model.PhoneNumber);

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -415,13 +415,13 @@ namespace AllReady.Controllers
 
             if (externalLoginInfo.LoginProvider == "Google")
             {
-                firstName = externalLoginInfo.ExternalPrincipal.FindFirstValue(System.Security.Claims.ClaimTypes.GivenName);
-                lastName = externalLoginInfo.ExternalPrincipal.FindFirstValue(System.Security.Claims.ClaimTypes.Surname);
+                firstName = externalLoginInfo.Principal.FindFirstValue(System.Security.Claims.ClaimTypes.GivenName);
+                lastName = externalLoginInfo.Principal.FindFirstValue(System.Security.Claims.ClaimTypes.Surname);
             }
 
             if (externalLoginInfo.LoginProvider == "Facebook" || externalLoginInfo.LoginProvider == "Microsoft")
             {
-                var name = externalLoginInfo.ExternalPrincipal.FindFirstValue(System.Security.Claims.ClaimTypes.Name);
+                var name = externalLoginInfo.Principal.FindFirstValue(System.Security.Claims.ClaimTypes.Name);
                 if (string.IsNullOrEmpty(name))
                     return;
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -5,7 +5,6 @@ using AllReady.Features.Login;
 using AllReady.Features.Manage;
 using AllReady.Models;
 using AllReady.Security;
-using AllReady.Services;
 using AllReady.ViewModels.Account;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -16,29 +15,26 @@ using Microsoft.Extensions.Options;
 
 namespace AllReady.Controllers
 {
-  [Authorize]
-  public class AccountController : Controller
-  {
-    private readonly UserManager<ApplicationUser> _userManager;
-    private readonly SignInManager<ApplicationUser> _signInManager;
-    private readonly IEmailSender _emailSender;
-    private readonly IOptions<GeneralSettings> _generalSettings;
-    private readonly IMediator _mediator;
-
-    public AccountController(
-        UserManager<ApplicationUser> userManager,
-        SignInManager<ApplicationUser> signInManager,
-        IEmailSender emailSender,
-        IOptions<GeneralSettings> generalSettings,
-        IMediator mediator
-        )
+    [Authorize]
+    public class AccountController : Controller
     {
-      _emailSender = emailSender;
-      _userManager = userManager;
-      _signInManager = signInManager;
-      _generalSettings = generalSettings;
-      _mediator = mediator;
-    }
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly IOptions<GeneralSettings> _generalSettings;
+        private readonly IMediator _mediator;
+
+        public AccountController(
+            UserManager<ApplicationUser> userManager,
+            SignInManager<ApplicationUser> signInManager,
+            IOptions<GeneralSettings> generalSettings,
+            IMediator mediator
+            )
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _generalSettings = generalSettings;
+            _mediator = mediator;
+        }
 
     // GET: /Account/Login
     [HttpGet]
@@ -126,11 +122,10 @@ namespace AllReady.Controllers
           TimeZoneId = _generalSettings.Value.DefaultTimeZone
         };
 
-        var result = await _userManager.CreateAsync(user, model.Password);
-        if (result.Succeeded)
-        {
-          // Send an email with this link
-          var emailConfirmationToken = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+                var result = await _userManager.CreateAsync(user, model.Password);
+                if (result.Succeeded)
+                {
+                    var emailConfirmationToken = await _userManager.GenerateEmailConfirmationTokenAsync(user);
 
           var callbackUrl = Url.Action(new UrlActionContext
           {
@@ -206,26 +201,24 @@ namespace AllReady.Controllers
       return View();
     }
 
-    // POST: /Account/ForgotPassword
-    [HttpPost]
-    [AllowAnonymous]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> ForgotPassword(ForgotPasswordViewModel model)
-    {
-      if (ModelState.IsValid)
-      {
-        var user = await _userManager.FindByNameAsync(model.Email);
-        if (user == null || !(await _userManager.IsEmailConfirmedAsync(user)))
+        // POST: /Account/ForgotPassword
+        [HttpPost]
+        [AllowAnonymous]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> ForgotPassword(ForgotPasswordViewModel model)
         {
-          // Don't reveal that the user does not exist or is not confirmed
-          return View("ForgotPasswordConfirmation");
-        }
+            if (ModelState.IsValid)
+            {
+                var user = await _userManager.FindByNameAsync(model.Email);
+                if (user == null || !await _userManager.IsEmailConfirmedAsync(user))
+                {
+                    // Don't reveal that the user does not exist or is not confirmed
+                    return View("ForgotPasswordConfirmation");
+                }
 
-                //Send an email with this link
                 var code = await _userManager.GeneratePasswordResetTokenAsync(user);
                 var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ResetPassword), Controller = "Account", Values = new { userId = user.Id, code },
                     Protocol = HttpContext.Request.Scheme });
-                //await _emailSender.SendEmailAsync(model.Email, "Reset allReady Password", $"Please reset your allReady password by clicking here: <a href=\"{callbackUrl}\">link</a>");
                 await _mediator.SendAsync(new SendResetPasswordEmail { Email = model.Email, CallbackUrl = callbackUrl });
 
         return View("ForgotPasswordConfirmation");

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -408,22 +408,30 @@ namespace AllReady.Controllers
       return RedirectToAction(nameof(HomeController.Index), "Home");
     }
 
-        //TODO: mgmccarthy: this is brittle method and will be revisieted as more and more external auth providers are added. 
-        //Most likely, there will be some type of interface that represents the extracting of available user data based on external
-        //auth provider that will allow us to get at the correct information w/out all these magic string tests. Not to mention this method will grow in complexity and 
-        //make unit testing really tough.
         private static void RetrieveFirstAndLastNameFromExternalPrincipal(ExternalLoginInfo externalLoginInfo, out string firstName, out string lastName)
         {
-            var name = externalLoginInfo.ExternalPrincipal.FindFirstValue(System.Security.Claims.ClaimTypes.Name);
+            firstName = string.Empty;
+            lastName = string.Empty;
 
-      firstName = string.Empty;
-      lastName = string.Empty;
-      if (string.IsNullOrEmpty(name))
-        return;
+            if (externalLoginInfo.LoginProvider == "Google")
+            {
+                firstName = externalLoginInfo.ExternalPrincipal.FindFirstValue(System.Security.Claims.ClaimTypes.GivenName);
+                lastName = externalLoginInfo.ExternalPrincipal.FindFirstValue(System.Security.Claims.ClaimTypes.Surname);
+            }
 
-      var array = name.Split(' ');
-      firstName = array[0];
-      lastName = array[1];
+            if (externalLoginInfo.LoginProvider == "Facebook" || externalLoginInfo.LoginProvider == "Microsoft")
+            {
+                var name = externalLoginInfo.ExternalPrincipal.FindFirstValue(System.Security.Claims.ClaimTypes.Name);
+                if (string.IsNullOrEmpty(name))
+                    return;
+
+                var array = name.Split(' ');
+                if (array.Length < 2)
+                    return;
+
+                firstName = array[0];
+                lastName = array[1];
+            }
+        }
     }
-  }
 }

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -112,7 +112,7 @@ namespace AllReady.Controllers
         {
             var user = await _userManager.GetUserAsync(User);
             var code = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-            var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmNewEmail), Controller = "Account", Values = new { userId = user.Id, code = code },
+            var callbackUrl = Url.Action(new UrlActionContext { Action = nameof(ConfirmNewEmail), Controller = "Account", Values = new { userId = user.Id, code },
                 Protocol = HttpContext.Request.Scheme });
 
             await _mediator.SendAsync(new SendConfirmAccountEmail { Email = user.Email, CallbackUrl = callbackUrl });

--- a/AllReadyApp/Web-App/AllReady/Features/Manage/SendResetPasswordEmail.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Manage/SendResetPasswordEmail.cs
@@ -1,0 +1,10 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Manage
+{
+    public class SendResetPasswordEmail : IAsyncRequest
+    {
+        public string Email { get; set; }
+        public string CallbackUrl { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Manage/SendResetPasswordEmailHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Manage/SendResetPasswordEmailHandlerAsync.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using AllReady.Services;
+using MediatR;
+
+namespace AllReady.Features.Manage
+{
+    public class SendResetPasswordEmailHandlerAsync : AsyncRequestHandler<SendResetPasswordEmail>
+    {
+        private readonly IEmailSender emailSender;
+
+        public SendResetPasswordEmailHandlerAsync(IEmailSender emailSender)
+        {
+            this.emailSender = emailSender;
+        }
+
+        protected override async Task HandleCore(SendResetPasswordEmail message)
+        {
+            await emailSender.SendEmailAsync(message.Email, "Reset allReady Password", 
+                $"Please reset your allReady password by clicking here: <a href=\"{message.CallbackUrl}\">link</a>")
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -14,9 +14,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
-using Microsoft.AspNetCore.Localization;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -25,106 +23,104 @@ using AllReady.Security.Middleware;
 
 namespace AllReady
 {
-  public class Startup
-  {
-    public Startup(IHostingEnvironment env)
+    public class Startup
     {
-      // Setup configuration sources.
-      var builder = new ConfigurationBuilder()
-          .SetBasePath(env.ContentRootPath)
-          .AddJsonFile("version.json")
-          .AddJsonFile("config.json")
-          .AddJsonFile($"config.{env.EnvironmentName}.json", optional: true)
-          .AddEnvironmentVariables();
+        public Startup(IHostingEnvironment env)
+        {
+            // Setup configuration sources.
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("version.json")
+                .AddJsonFile("config.json")
+                .AddJsonFile($"config.{env.EnvironmentName}.json", optional: true)
+                .AddEnvironmentVariables();
 
-      if (env.IsDevelopment())
-      {
-        // This reads the configuration keys from the secret store.
-        // For more details on using the user secret store see http://go.microsoft.com/fwlink/?LinkID=532709
-        builder.AddUserSecrets();
+            if (env.IsDevelopment())
+            {
+            // This reads the configuration keys from the secret store.
+            // For more details on using the user secret store see http://go.microsoft.com/fwlink/?LinkID=532709
+            builder.AddUserSecrets();
 
-        // This will push telemetry data through Application Insights pipeline faster, allowing you to view results immediately.
-        builder.AddApplicationInsightsSettings(developerMode: true);
+            // This will push telemetry data through Application Insights pipeline faster, allowing you to view results immediately.
+            builder.AddApplicationInsightsSettings(developerMode: true);
+            }
 
-      }
+            Configuration = builder.Build();
 
-      Configuration = builder.Build();
+            Configuration["version"] = new ApplicationEnvironment().ApplicationVersion; // version in project.json
+        }
 
-      Configuration["version"] = new ApplicationEnvironment().ApplicationVersion; // version in project.json
-    }
+        public IConfiguration Configuration { get; set; }
 
-    public IConfiguration Configuration { get; set; }
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public IServiceProvider ConfigureServices(IServiceCollection services)
+        {
+            // Add Application Insights data collection services to the services container.
+            services.AddApplicationInsightsTelemetry(Configuration);
 
-    // This method gets called by the runtime. Use this method to add services to the container.
-    public IServiceProvider ConfigureServices(IServiceCollection services)
-    {
-      // Add Application Insights data collection services to the services container.
-      services.AddApplicationInsightsTelemetry(Configuration);
+            // Add Entity Framework services to the services container.
+            var ef = services.AddDbContext<AllReadyContext>(options => options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]));
 
-      // Add Entity Framework services to the services container.
-      var ef = services.AddDbContext<AllReadyContext>(options => options.UseSqlServer(Configuration["Data:DefaultConnection:ConnectionString"]));
+            services.Configure<AzureStorageSettings>(Configuration.GetSection("Data:Storage"));
+            services.Configure<DatabaseSettings>(Configuration.GetSection("Data:DefaultConnection"));
+            services.Configure<EmailSettings>(Configuration.GetSection("Email"));
+            services.Configure<SampleDataSettings>(Configuration.GetSection("SampleData"));
+            services.Configure<GeneralSettings>(Configuration.GetSection("General"));
 
-      services.Configure<AzureStorageSettings>(Configuration.GetSection("Data:Storage"));
-      services.Configure<DatabaseSettings>(Configuration.GetSection("Data:DefaultConnection"));
-      services.Configure<EmailSettings>(Configuration.GetSection("Email"));
-      services.Configure<SampleDataSettings>(Configuration.GetSection("SampleData"));
-      services.Configure<GeneralSettings>(Configuration.GetSection("General"));
+            // Add CORS support
+            services.AddCors(options =>
+            {
+            options.AddPolicy("allReady",
+                builder => builder.AllowAnyOrigin()
+                            .AllowAnyHeader()
+                            .AllowAnyMethod()
+                            .AllowCredentials()
+                );
+            });
 
-      // Add CORS support
-      services.AddCors(options =>
-      {
-        options.AddPolicy("allReady",
-            builder => builder.AllowAnyOrigin()
-                        .AllowAnyHeader()
-                        .AllowAnyMethod()
-                        .AllowCredentials()
-            );
-      });
-
-      // Add Identity services to the services container.
-      services.AddIdentity<ApplicationUser, IdentityRole>(options =>
-              {
+            // Add Identity services to the services container.
+            services.AddIdentity<ApplicationUser, IdentityRole>(options =>
+            {
                 options.Password.RequiredLength = 10;
                 options.Password.RequireNonAlphanumeric = false;
                 options.Password.RequireDigit = true;
                 options.Password.RequireUppercase = false;
                 options.Cookies.ApplicationCookie.AccessDeniedPath = new PathString("/Home/AccessDenied");
-              })
-               .AddEntityFrameworkStores<AllReadyContext>()
-               .AddDefaultTokenProviders();
+            })
+            .AddEntityFrameworkStores<AllReadyContext>()
+            .AddDefaultTokenProviders();
 
-      // Add Authorization rules for the app
-      services.AddAuthorization(options =>
-      {
-        options.AddPolicy("OrgAdmin", b => b.RequireClaim(Security.ClaimTypes.UserType, "OrgAdmin", "SiteAdmin"));
-        options.AddPolicy("SiteAdmin", b => b.RequireClaim(Security.ClaimTypes.UserType, "SiteAdmin"));
-      });
+            // Add Authorization rules for the app
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy("OrgAdmin", b => b.RequireClaim(Security.ClaimTypes.UserType, "OrgAdmin", "SiteAdmin"));
+                options.AddPolicy("SiteAdmin", b => b.RequireClaim(Security.ClaimTypes.UserType, "SiteAdmin"));
+            });
 
-      // Add MVC services to the services container.
-      services.AddMvc();
+            // Add MVC services to the services container.
+            services.AddMvc();
 
-      // configure IoC support
-      var container = CreateIoCContainer(services);
-      return container.Resolve<IServiceProvider>();
+            // configure IoC support
+            var container = CreateIoCContainer(services);
+            return container.Resolve<IServiceProvider>();
+        }
 
-    }
-
-    private IContainer CreateIoCContainer(IServiceCollection services)
-    {
-      // todo: move these to a proper autofac module
-      // Register application services.
-      services.AddSingleton((x) => Configuration);
-      services.AddTransient<IEmailSender, AuthMessageSender>();
-      services.AddTransient<ISmsSender, AuthMessageSender>();
-      services.AddTransient<IAllReadyDataAccess, AllReadyDataAccessEF7>();
-      services.AddTransient<IDetermineIfATaskIsEditable, DetermineIfATaskIsEditable>();
-      services.AddTransient<IValidateEventDetailModels, EventEditModelValidator>();
-      services.AddTransient<ITaskSummaryModelValidator, TaskSummaryModelValidator>();
-      services.AddTransient<IItineraryEditModelValidator, ItineraryEditModelValidator>();
-      services.AddTransient<IOrganizationEditModelValidator, OrganizationEditModelValidator>();
-      services.AddSingleton<IImageService, ImageService>();
-      //services.AddSingleton<GeoService>();
-      services.AddTransient<SampleDataGenerator>();
+        private IContainer CreateIoCContainer(IServiceCollection services)
+        {
+            // todo: move these to a proper autofac module
+            // Register application services.
+            services.AddSingleton((x) => Configuration);
+            services.AddTransient<IEmailSender, AuthMessageSender>();
+            services.AddTransient<ISmsSender, AuthMessageSender>();
+            services.AddTransient<IAllReadyDataAccess, AllReadyDataAccessEF7>();
+            services.AddTransient<IDetermineIfATaskIsEditable, DetermineIfATaskIsEditable>();
+            services.AddTransient<IValidateEventDetailModels, EventEditModelValidator>();
+            services.AddTransient<ITaskSummaryModelValidator, TaskSummaryModelValidator>();
+            services.AddTransient<IItineraryEditModelValidator, ItineraryEditModelValidator>();
+            services.AddTransient<IOrganizationEditModelValidator, OrganizationEditModelValidator>();
+            services.AddSingleton<IImageService, ImageService>();
+            //services.AddSingleton<GeoService>();
+            services.AddTransient<SampleDataGenerator>();
 
             if (Configuration["Data:Storage:EnableAzureQueueService"] == "true")
             {
@@ -138,98 +134,93 @@ namespace AllReady
                 services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
             }
 
-      var containerBuilder = new ContainerBuilder();
+            var containerBuilder = new ContainerBuilder();
 
-      containerBuilder.RegisterSource(new ContravariantRegistrationSource());
-      containerBuilder.RegisterAssemblyTypes(typeof(IMediator).Assembly).AsImplementedInterfaces();
-      containerBuilder.RegisterAssemblyTypes(typeof(Startup).Assembly).AsImplementedInterfaces();
-      containerBuilder.Register<SingleInstanceFactory>(ctx =>
-      {
-        var c = ctx.Resolve<IComponentContext>();
-        return t => c.Resolve(t);
-      });
+            containerBuilder.RegisterSource(new ContravariantRegistrationSource());
+            containerBuilder.RegisterAssemblyTypes(typeof(IMediator).Assembly).AsImplementedInterfaces();
+            containerBuilder.RegisterAssemblyTypes(typeof(Startup).Assembly).AsImplementedInterfaces();
+            containerBuilder.Register<SingleInstanceFactory>(ctx =>
+            {
+                var c = ctx.Resolve<IComponentContext>();
+                return t => c.Resolve(t);
+            });
 
-      containerBuilder.Register<MultiInstanceFactory>(ctx =>
-      {
-        var c = ctx.Resolve<IComponentContext>();
-        return t => (IEnumerable<object>)c.Resolve(typeof(IEnumerable<>).MakeGenericType(t));
-      });
+            containerBuilder.Register<MultiInstanceFactory>(ctx =>
+            {
+                var c = ctx.Resolve<IComponentContext>();
+                return t => (IEnumerable<object>)c.Resolve(typeof(IEnumerable<>).MakeGenericType(t));
+            });
 
-      //Populate the container with services that were previously registered
-      containerBuilder.Populate(services);
+            //Populate the container with services that were previously registered
+            containerBuilder.Populate(services);
 
-      var container = containerBuilder.Build();
-      return container;
-    }
-
-    // Configure is called after ConfigureServices is called.
-    public async void Configure(IApplicationBuilder app,
-      IHostingEnvironment env,
-      ILoggerFactory loggerFactory,
-      SampleDataGenerator sampleData,
-      AllReadyContext context,
-      IConfiguration configuration)
-    {
-      // todo: in RC update we can read from a logging.json config file
-      loggerFactory.AddConsole((category, level) =>
-      {
-        if (category.StartsWith("Microsoft."))
-        {
-          return level >= LogLevel.Information;
+            var container = containerBuilder.Build();
+            return container;
         }
-        return true;
-      });
 
-      if (env.IsDevelopment())
-      {
-        // this will go to the VS output window
-        loggerFactory.AddDebug((category, level) =>
+        // Configure is called after ConfigureServices is called.
+        public async void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory, SampleDataGenerator sampleData, AllReadyContext context, 
+            IConfiguration configuration)
         {
-          if (category.StartsWith("Microsoft."))
-          {
-            return level >= LogLevel.Information;
-          }
-          return true;
-        });
-      }
+            // todo: in RC update we can read from a logging.json config file
+            loggerFactory.AddConsole((category, level) =>
+            {
+                if (category.StartsWith("Microsoft."))
+                {
+                    return level >= LogLevel.Information;
+                }
+                return true;
+            });
 
-      // CORS support
-      app.UseCors("allReady");
+            if (env.IsDevelopment())
+            {
+                // this will go to the VS output window
+                loggerFactory.AddDebug((category, level) =>
+                {
+                    if (category.StartsWith("Microsoft."))
+                    {
+                        return level >= LogLevel.Information;
+                    }
+                    return true;
+                });
+            }
 
-      // Configure the HTTP request pipeline.
+            // CORS support
+            app.UseCors("allReady");
 
-      var usCultureInfo = new CultureInfo("en-US");
-      app.UseRequestLocalization(new RequestLocalizationOptions
-      {
-        SupportedCultures = new List<CultureInfo>(new[] { usCultureInfo }),
-        SupportedUICultures = new List<CultureInfo>(new[] { usCultureInfo })
-      });
+            // Configure the HTTP request pipeline.
+            var usCultureInfo = new CultureInfo("en-US");
+            app.UseRequestLocalization(new RequestLocalizationOptions
+            {
+                SupportedCultures = new List<CultureInfo>(new[] { usCultureInfo }),
+                SupportedUICultures = new List<CultureInfo>(new[] { usCultureInfo })
+            });
 
-      // Add Application Insights to the request pipeline to track HTTP request telemetry data.
-      app.UseApplicationInsightsRequestTelemetry();
+            // Add Application Insights to the request pipeline to track HTTP request telemetry data.
+            app.UseApplicationInsightsRequestTelemetry();
 
-      // Add the following to the request pipeline only in development environment.
-      if (env.IsDevelopment())
-      {
-        app.UseBrowserLink();
-        app.UseDeveloperExceptionPage();
-        app.UseDatabaseErrorPage();
-      }
-      else
-      {
-        // Add Error handling middleware which catches all application specific errors and
-        // sends the request to the following path or controller action.
-        app.UseExceptionHandler("/Home/Error");
-      }
+            // Add the following to the request pipeline only in development environment.
+            if (env.IsDevelopment())
+            {
+                app.UseBrowserLink();
+                app.UseDeveloperExceptionPage();
+                app.UseDatabaseErrorPage();
+            }
+            else
+            {
+                // Add Error handling middleware which catches all application specific errors and
+                // sends the request to the following path or controller action.
+                app.UseExceptionHandler("/Home/Error");
+            }
 
-      // Track data about exceptions from the application. Should be configured after all error handling middleware in the request pipeline.
-      app.UseApplicationInsightsExceptionTelemetry();
+            // Track data about exceptions from the application. Should be configured after all error handling middleware in the request pipeline.
+            app.UseApplicationInsightsExceptionTelemetry();
 
-      // Add static files to the request pipeline.
-      app.UseStaticFiles();
+            // Add static files to the request pipeline.
+            app.UseStaticFiles();
 
-      // Add cookie-based authentication to the request pipeline.
-      app.UseIdentity();
+            // Add cookie-based authentication to the request pipeline.
+            app.UseIdentity();
 
             // Add token-based protection to the request inject pipeline
             app.UseTokenProtection(new TokenProtectedResourceOptions
@@ -242,79 +233,74 @@ namespace AllReady
             // For more information see http://go.microsoft.com/fwlink/?LinkID=532715
             if (Configuration["Authentication:Facebook:AppId"] != null)
             {
-               var options = new FacebookOptions()
-               {
-                 AppId = Configuration["Authentication:Facebook:AppId"],
-                 AppSecret = Configuration["Authentication:Facebook:AppSecret"],
-                 BackchannelHttpHandler = new FacebookBackChannelHandler(),
-                 UserInformationEndpoint = "https://graph.facebook.com/v2.5/me?fields=id,name,email,first_name,last_name"
-               };
-
+                var options = new FacebookOptions
+                {
+                    AppId = Configuration["Authentication:Facebook:AppId"],
+                    AppSecret = Configuration["Authentication:Facebook:AppSecret"],
+                    BackchannelHttpHandler = new FacebookBackChannelHandler(),
+                    UserInformationEndpoint = "https://graph.facebook.com/v2.5/me?fields=id,name,email,first_name,last_name"
+                };
                 options.Scope.Add("email");
-
                 app.UseFacebookAuthentication(options);
             }
+
             if (Configuration["Authentication:MicrosoftAccount:ClientId"] != null)
             {
-                app.UseMicrosoftAccountAuthentication(options =>
+                var options = new MicrosoftAccountOptions
                 {
-                    options.ClientId = Configuration["Authentication:MicrosoftAccount:ClientId"];
-                    options.ClientSecret = Configuration["Authentication:MicrosoftAccount:ClientSecret"];
-                    options.Scope.Add("wl.basic");
-                    options.Scope.Add("wl.signin");
-                    options.Scope.Add("wl.emails");
-                    options.Scope.Add("wl.phone_numbers");
-                });
+                    ClientId = Configuration["Authentication:MicrosoftAccount:ClientId"],
+                    ClientSecret = Configuration["Authentication:MicrosoftAccount:ClientSecret"]
+                };
+                options.Scope.Add("wl.basic");
+                options.Scope.Add("wl.signin");
+                options.Scope.Add("wl.emails");
+                options.Scope.Add("wl.phone_numbers");
+                app.UseMicrosoftAccountAuthentication(options);
             }
-            //TODO: mgmccarthy: working on getting email from Twitter
-            //http://www.bigbrainintelligence.com/Post/get-users-email-address-from-twitter-oauth-ap
+
             if (Configuration["Authentication:Twitter:ConsumerKey"] != null)
             {
-                app.UseTwitterAuthentication(options =>
+                var options = new TwitterOptions
                 {
-                    options.ConsumerKey = Configuration["Authentication:Twitter:ConsumerKey"];
-                    options.ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"];
-                });
+                    ConsumerKey = Configuration["Authentication:Twitter:ConsumerKey"],
+                    ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"]
+                };
+                app.UseTwitterAuthentication(options);
             }
+
             if (Configuration["Authentication:Google:ClientId"] != null)
             {
-                app.UseGoogleAuthentication(options =>
+                var options = new GoogleOptions
                 {
-                    options.ClientId = Configuration["Authentication:Google:ClientId"];
-                    options.ClientSecret = Configuration["Authentication:Google:ClientSecret"];
-                });
+                    ClientId = Configuration["Authentication:Google:ClientId"],
+                    ClientSecret = Configuration["Authentication:Google:ClientSecret"]
+                };
+                app.UseGoogleAuthentication(options);
             }
 
             // Add MVC to the request pipeline.
             app.UseMvc(routes =>
             {
-                routes.MapRoute(
-                     name: "areaRoute",
-                     template: "{area:exists}/{controller}/{action=Index}/{id?}");
+                routes.MapRoute(name: "areaRoute", template: "{area:exists}/{controller}/{action=Index}/{id?}");
+                routes.MapRoute(name: "default", template: "{controller=Home}/{action=Index}/{id?}");
+            });
 
-        routes.MapRoute(
-                  name: "default",
-                  template: "{controller=Home}/{action=Index}/{id?}");
-      });
+            // Add sample data and test admin accounts if specified in Config.Json.
+            // for production applications, this should either be set to false or deleted.
+            if (env.IsDevelopment() || env.IsEnvironment("Staging"))
+            {
+                context.Database.Migrate();
+            }
 
+            if (Configuration["SampleData:InsertSampleData"] == "true")
+            {
+                sampleData.InsertTestData();
+            }
 
-      // Add sample data and test admin accounts if specified in Config.Json.
-      // for production applications, this should either be set to false or deleted.
-      if (env.IsDevelopment() || env.IsEnvironment("Staging"))
-      {
-        context.Database.Migrate();
-      }
-      if (Configuration["SampleData:InsertSampleData"] == "true")
-      {
-        sampleData.InsertTestData();
-      }
-      if (Configuration["SampleData:InsertTestUsers"] == "true")
-      {
-        await sampleData.CreateAdminUser();
-      }
-
+            if (Configuration["SampleData:InsertTestUsers"] == "true")
+            {
+                await sampleData.CreateAdminUser();
+            }
+        }
     }
-
-
-  }
 }

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -241,6 +241,7 @@ namespace AllReady
                     UserInformationEndpoint = "https://graph.facebook.com/v2.5/me?fields=id,name,email,first_name,last_name"
                 };
                 options.Scope.Add("email");
+
                 app.UseFacebookAuthentication(options);
             }
 
@@ -251,10 +252,7 @@ namespace AllReady
                     ClientId = Configuration["Authentication:MicrosoftAccount:ClientId"],
                     ClientSecret = Configuration["Authentication:MicrosoftAccount:ClientSecret"]
                 };
-                options.Scope.Add("wl.basic");
-                options.Scope.Add("wl.signin");
-                options.Scope.Add("wl.emails");
-                options.Scope.Add("wl.phone_numbers");
+
                 app.UseMicrosoftAccountAuthentication(options);
             }
 
@@ -265,6 +263,7 @@ namespace AllReady
                     ConsumerKey = Configuration["Authentication:Twitter:ConsumerKey"],
                     ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"]
                 };
+
                 app.UseTwitterAuthentication(options);
             }
 
@@ -275,6 +274,7 @@ namespace AllReady
                     ClientId = Configuration["Authentication:Google:ClientId"],
                     ClientSecret = Configuration["Authentication:Google:ClientSecret"]
                 };
+
                 app.UseGoogleAuthentication(options);
             }
 

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -126,17 +126,18 @@ namespace AllReady
       //services.AddSingleton<GeoService>();
       services.AddTransient<SampleDataGenerator>();
 
-      if (Configuration["Data:Storage:EnableAzureQueueService"] == "true")
-      {
-        // This setting is false by default. To enable queue processing you will 
-        // need to override the setting in your user secrets or env vars.
-        services.AddTransient<IQueueStorageService, QueueStorageService>();
-      }
-      else
-      {
-        // this writer service will just write to the default logger
-        services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
-      }
+            if (Configuration["Data:Storage:EnableAzureQueueService"] == "true")
+            {
+                // This setting is false by default. To enable queue processing you will 
+                // need to override the setting in your user secrets or env vars.
+                services.AddTransient<IQueueStorageService, QueueStorageService>();
+            }
+            else
+            {
+                // this writer service will just write to the default logger
+                //services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
+                services.AddTransient<IQueueStorageService, SmtpEmailSender>();
+            }
 
       var containerBuilder = new ContainerBuilder();
 

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -254,36 +254,43 @@ namespace AllReady
 
                 app.UseFacebookAuthentication(options);
             }
-            // app.UseGoogleAuthentication();
+            if (Configuration["Authentication:MicrosoftAccount:ClientId"] != null)
+            {
+                app.UseMicrosoftAccountAuthentication(options =>
+                {
+                    options.ClientId = Configuration["Authentication:MicrosoftAccount:ClientId"];
+                    options.ClientSecret = Configuration["Authentication:MicrosoftAccount:ClientSecret"];
+                    options.Scope.Add("wl.basic");
+                    options.Scope.Add("wl.signin");
+                    options.Scope.Add("wl.emails");
+                    options.Scope.Add("wl.phone_numbers");
+                });
+            }
+            //TODO: mgmccarthy: working on getting email from Twitter
+            //http://www.bigbrainintelligence.com/Post/get-users-email-address-from-twitter-oauth-ap
+            if (Configuration["Authentication:Twitter:ConsumerKey"] != null)
+            {
+                app.UseTwitterAuthentication(options =>
+                {
+                    options.ConsumerKey = Configuration["Authentication:Twitter:ConsumerKey"];
+                    options.ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"];
+                });
+            }
+            if (Configuration["Authentication:Google:ClientId"] != null)
+            {
+                app.UseGoogleAuthentication(options =>
+                {
+                    options.ClientId = Configuration["Authentication:Google:ClientId"];
+                    options.ClientSecret = Configuration["Authentication:Google:ClientSecret"];
+                });
+            }
 
-      if (Configuration["Authentication:MicrosoftAccount:ClientId"] != null)
-      {
-        var options = new MicrosoftAccountOptions()
-        {
-          ClientId = Configuration["Authentication:MicrosoftAccount:ClientId"],
-          ClientSecret = Configuration["Authentication:MicrosoftAccount:ClientSecret"]
-        };
-        options.Scope.Add("wl.basic");
-        options.Scope.Add("wl.signin");
-
-        app.UseMicrosoftAccountAuthentication(options);
-      }
-
-      if (Configuration["Authentication:Twitter:ConsumerKey"] != null)
-      {
-        app.UseTwitterAuthentication(new TwitterOptions()
-        {
-          ConsumerKey = Configuration["Authentication:Twitter:ConsumerKey"],
-          ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"]
-        });
-      }
-
-      // Add MVC to the request pipeline.
-      app.UseMvc(routes =>
-      {
-        routes.MapRoute(
-                   name: "areaRoute",
-                   template: "{area:exists}/{controller}/{action=Index}/{id?}");
+            // Add MVC to the request pipeline.
+            app.UseMvc(routes =>
+            {
+                routes.MapRoute(
+                     name: "areaRoute",
+                     template: "{area:exists}/{controller}/{action=Index}/{id?}");
 
         routes.MapRoute(
                   name: "default",

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -135,8 +135,7 @@ namespace AllReady
             else
             {
                 // this writer service will just write to the default logger
-                //services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
-                services.AddTransient<IQueueStorageService, SmtpEmailSender>();
+                services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
             }
 
       var containerBuilder = new ContainerBuilder();

--- a/AllReadyApp/Web-App/AllReady/ViewModels/Account/RegisterViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Account/RegisterViewModel.cs
@@ -28,7 +28,7 @@ namespace AllReady.ViewModels.Account
 
         [DataType(DataType.Password)]
         [Display(Name = "Confirm password")]
-        [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+        [Compare(nameof(Password), ErrorMessage = "The password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Views/Account/ConfirmEmail.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Account/ConfirmEmail.cshtml
@@ -1,5 +1,6 @@
-﻿
-@using System.Security.Claims;
+﻿@using Microsoft.AspNetCore.Identity
+@inject SignInManager<ApplicationUser> SignInManager
+@inject UserManager<ApplicationUser> UserManager
 @{
     ViewData["Title"] = "Confirm Email";
 }
@@ -8,9 +9,9 @@
 <div>
     <p>
         Thank you for confirming your email.
-        @if (!User.IsSignedIn())
+        @if (SignInManager.IsSignedIn(User))
         {
             <span>Please <a asp-controller="Account" asp-action="Login">Click here to Log in</a>.</span>
-         } 
+        } 
     </p>
 </div>

--- a/AllReadyApp/Web-App/AllReady/Views/Account/ConfirmEmail.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Account/ConfirmEmail.cshtml
@@ -9,7 +9,7 @@
 <div>
     <p>
         Thank you for confirming your email.
-        @if (SignInManager.IsSignedIn(User))
+        @if (!SignInManager.IsSignedIn(User))
         {
             <span>Please <a asp-controller="Account" asp-action="Login">Click here to Log in</a>.</span>
         } 

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -34,9 +34,9 @@
   },
   "Authentication": {
     "Facebook": {
-      "AppId": "137164253373251",
-      "AppSecret": "192703d83ae2ced78f109c42c95ca705"
-    },
+        "AppId": "[facebookappId]",
+        "AppSecret": "[facebookappsecret]"
+      },
     "Twitter": {
       "ConsumerKey": "[twitterkey]",
       "ConsumerSecret": "[twittersecret]"

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -34,16 +34,20 @@
   },
   "Authentication": {
     "Facebook": {
-        "AppId": "[facebookappId]",
-        "AppSecret": "[facebookappsecret]"
-      },
+      "AppId": "[facebookappId]",
+      "AppSecret": "[facebookappsecret]"
+    },
     "Twitter": {
-      "ConsumerKey": "[twitterkey]",
-      "ConsumerSecret": "[twittersecret]"
+      "ConsumerKey": "[twitterconsumerkey]",
+      "ConsumerSecret": "[twitterconsumersecret]"
     },
     "MicrosoftAccount": {
-      "ClientId": "[twitterclient]",
-      "ClientSecret": "[twittersecret]"
+      "ClientId": "[microsoftclientid]",
+      "ClientSecret": "[microsoftclientsecret]"
+    },
+    "Google": {
+      "ClientId": "[googleclientid]",
+      "ClientSecret": "[googleclientsecret]"
     },
     "SendGrid": {
       "UserName": "[sendgriduser]",

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -34,8 +34,8 @@
   },
   "Authentication": {
     "Facebook": {
-      "AppId": "[facebookappId]",
-      "AppSecret": "[facebookappsecret]"
+      "AppId": "137164253373251",
+      "AppSecret": "192703d83ae2ced78f109c42c95ca705"
     },
     "Twitter": {
       "ConsumerKey": "[twitterkey]",


### PR DESCRIPTION
First, lousy name for my local branch name. Ignore it.

Fixes #840, #955, #976, #950, #949, #948

High level of what's included in this fix.

AccountController.ExternalLoginConfirmation now:

- sends email confirmation
- sends sms confirmation
- adds Security.ClaimTypes.ProfileIncomplete to user
- all three of the above steps were already been done in AccountController.Register

AccountController.ForgotPassword

- added new AllReady.Features.Manage.SendResetPassword message/handler
- ForgotPassword now sends this message instead of invoking email sender
- this is temporary code that can be consolidated once a decision is made on #967
- all unit tests have been updated to reflect changes and stubs have been added for additional code added to ExternalLoginConfirmation