### PR TITLE
Request completion from itinerary admin page

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/RequestStatusChangeCommandHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/RequestStatusChangeCommandHandlerTests.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Linq;
+using AllReady.Areas.Admin.Features.Requests;
+using AllReady.Models;
+using Microsoft.Data.Entity;
+using Shouldly;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.Requests
+{
+    public class RequestStatusChangeCommandHandlerTests : InMemoryContextTest
+    {
+        private readonly Guid _existingRequestId1 = new Guid("b0efa33c-082f-4287-b641-c96994e96c9e");
+        private readonly Guid _existingRequestId2 = new Guid("9e60ede8-229a-4827-b8b7-0b13e22ab435");
+
+        protected override void LoadTestData()
+        {
+            var req1 = new Request
+            {
+                RequestId = _existingRequestId1,
+                Name = "New Request 1",
+                Status = RequestStatus.Assigned
+            };
+
+            var req2= new Request
+            {
+                RequestId = _existingRequestId2,
+                Name = "New Request 2",
+                Status = RequestStatus.Completed
+            };
+
+            Context.Requests.Add(req1);
+            Context.Requests.Add(req2);
+            Context.SaveChanges();
+
+            // We must do this so that the context change tracker is not already tracking the item when we come to attach it from out subject under test
+            Context.Entry(req1).State = EntityState.Detached;
+            Context.Entry(req2).State = EntityState.Detached;
+        }
+
+        [Fact]
+        public async void Handle_WithNewStatusCompletedInMessage_UpdatesRequest()
+        {
+            var query = new RequestStatusChangeCommand
+            {
+                RequestId = _existingRequestId1,
+                NewStatus = RequestStatus.Completed
+            };
+            
+            var handler = new RequestStatusChangeCommandHandlerAsync(Context);
+
+            var result = await handler.Handle(query);
+
+            var requestToValidate = Context.Requests.First(rec => rec.RequestId == _existingRequestId1);
+            
+            requestToValidate.Status.ShouldBe(RequestStatus.Completed);
+            result.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async void Handle_WithNewStatusAssignedInMessage_UpdatesRequest()
+        {
+            var query = new RequestStatusChangeCommand
+            {
+                RequestId = _existingRequestId2,
+                NewStatus = RequestStatus.Assigned
+            };
+
+            var handler = new RequestStatusChangeCommandHandlerAsync(Context);
+
+            var result = await handler.Handle(query);
+
+            var requestToValidate = Context.Requests.First(rec => rec.RequestId == _existingRequestId2);
+
+            requestToValidate.Status.ShouldBe(RequestStatus.Assigned);
+            result.ShouldBeTrue();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -11,7 +11,9 @@ using AllReady.Areas.Admin.Models.Validators;
 using System.Linq;
 using AllReady.Areas.Admin.Models.RequestModels;
 using AllReady.Areas.Admin.Features.Organizations;
+using AllReady.Areas.Admin.Features.Requests;
 using AllReady.Areas.Admin.Features.TaskSignups;
+using AllReady.Models;
 
 namespace AllReady.Areas.Admin.Controllers
 {
@@ -290,6 +292,44 @@ namespace AllReady.Areas.Admin.Controllers
             }
 
             var result = await _mediator.SendAsync(new ReorderRequestCommand { RequestId = requestId, ItineraryId = itineraryId, ReOrderDirection = ReorderRequestCommand.Direction.Down });
+
+            return RedirectToAction("Details", new { id = itineraryId });
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Route("Admin/Itinerary/{itineraryId}/[Action]/{requestId}")]
+        public async Task<IActionResult> MarkComplete(int itineraryId, Guid requestId)
+        {
+            var orgId = await GetOrganizationIdBy(itineraryId);
+
+            if (orgId == 0 || !User.IsOrganizationAdmin(orgId))
+            {
+                return HttpUnauthorized();
+            }
+
+            // todo: sgordon - Extend this to return success / failure message to the user
+
+            await _mediator.SendAsync(new RequestStatusChangeCommand() { RequestId = requestId, NewStatus = RequestStatus.Completed});
+
+            return RedirectToAction("Details", new { id = itineraryId });
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Route("Admin/Itinerary/{itineraryId}/[Action]/{requestId}")]
+        public async Task<IActionResult> MarkIncomplete(int itineraryId, Guid requestId)
+        {
+            var orgId = await GetOrganizationIdBy(itineraryId);
+
+            if (orgId == 0 || !User.IsOrganizationAdmin(orgId))
+            {
+                return HttpUnauthorized();
+            }
+
+            // todo: sgordon - Extend this to return success / failure message to the user
+
+            await _mediator.SendAsync(new RequestStatusChangeCommand() { RequestId = requestId, NewStatus = RequestStatus.Assigned });
 
             return RedirectToAction("Details", new { id = itineraryId });
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQuery.cs
@@ -3,7 +3,7 @@ using AllReady.Areas.Admin.Models.RequestModels;
 using MediatR;
 using System.Collections.Generic;
 
-namespace AllReady.Areas.Admin.Features.Itineraries
+namespace AllReady.Areas.Admin.Features.Requests
 {
     public class RequestListItemsQuery : IAsyncRequest<List<RequestListModel>>
     {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQueryHandlerAsync.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace AllReady.Areas.Admin.Features.Itineraries
+namespace AllReady.Areas.Admin.Features.Requests
 {
     public class RequestListItemsQueryHandlerAsync : IAsyncRequestHandler<RequestListItemsQuery, List<RequestListModel>>
     {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestStatusChangeCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestStatusChangeCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Requests
+{
+    public class RequestStatusChangeCommand : IAsyncRequest<bool>
+    {
+        public Guid RequestId { get; set; }
+        public RequestStatus NewStatus { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestStatusChangeCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestStatusChangeCommandHandlerAsync.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Requests
+{
+    public class RequestStatusChangeCommandHandlerAsync : IAsyncRequestHandler<RequestStatusChangeCommand, bool>
+    {
+        private readonly AllReadyContext _context;
+
+        public RequestStatusChangeCommandHandlerAsync(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<bool> Handle(RequestStatusChangeCommand message)
+        {
+            var req = new Request
+            {
+                RequestId = message.RequestId,
+                Status = message.NewStatus
+            };
+
+            _context.Requests.Attach(req);
+            _context.Entry(req).Property(x => x.Status).IsModified = true;
+            var changedCount = await _context.SaveChangesAsync().ConfigureAwait(false);
+
+            return changedCount > 0;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestSummaryQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestSummaryQuery.cs
@@ -2,7 +2,7 @@
 using MediatR;
 using System;
 
-namespace AllReady.Areas.Admin.Features.TaskSignups
+namespace AllReady.Areas.Admin.Features.Requests
 {
     public class RequestSummaryQuery : IAsyncRequest<RequestSummaryModel>
     {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestSummaryQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestSummaryQueryHandlerAsync.cs
@@ -5,7 +5,7 @@ using MediatR;
 using Microsoft.Data.Entity;
 using AllReady.Areas.Admin.Models.RequestModels;
 
-namespace AllReady.Areas.Admin.Features.TaskSignups
+namespace AllReady.Areas.Admin.Features.Requests
 {
     public class RequestSummaryQueryHandlerAsync : IAsyncRequestHandler<RequestSummaryQuery, RequestSummaryModel>
     {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -117,28 +117,17 @@ else
         {
             <table class="table">
                 <tr>
-                    <th>
-                        Name
-                    </th>
-                    <th>
-                        Status
-                    </th>
-                    <th>
-                        Address
-                    </th>
-                    <th>
-                        City
-                    </th>
-                    <th></th>
+                    <th>Name</th>
+                    <th>Address</th>
+                    <th>City</th>
+                    <th>Manage</th>
+                    <th>Status</th>
                 </tr>
                 @foreach (var request in Model.Requests)
                 {
                     <tr>
                         <td>
                             <p>@request.Name</p>
-                        </td>
-                        <td>
-                            <p>@request.Status</p>
                         </td>
                         <td>
                             <p>@request.Address</p>
@@ -149,11 +138,32 @@ else
                         <td>
                             <form asp-action="MoveRequestUp" asp-controller="Itinerary" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn"><button type="submit" class="btn btn-default submit-form" @if (@request.IsFirst)
                                                                                                                                                                                                                                                {
-                                                                                                                                                                                                                                                   <text>disabled</text> }><span class="fa fa-arrow-up"></span></button></form>
-                            <form asp-action="MoveRequestDown" asp-controller="Itinerary" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn"><button type="submit" class="btn btn-default submit-form" @if (@request.IsLast)
-                                                                                                                                                                                                                                               {
-                                                                                                                                                                                                                                                   <text>disabled</text> }><span class="fa fa-arrow-down"></span></button></form>
-                            <a data-toggle="tooltip" data-placement="top" title="Remove" asp-action="ConfirmRemoveRequest" asp-controller="Itinerary" asp-route-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="btn btn-danger right-action-btn"><span class="fa fa-remove"></span></a>
+                                                                                                                                                                                                                                                   <text>disabled</text>
+                                                                                                                                                                                                                                               }><span class="fa fa-arrow-up"></span></button>
+                            </form>
+                            <form asp-action="MoveRequestDown" asp-controller="Itinerary" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                                <button type="submit" class="btn btn-default submit-form" @if (@request.IsLast)
+                                                                                          {
+                                                                                              <text>disabled</text>
+                                                                                          }><span class="fa fa-arrow-down"></span></button>
+                            </form>
+
+                            <a data-toggle="tooltip" data-placement="top" title="Remove" asp-action="ConfirmRemoveRequest" asp-controller="Itinerary" asp-route-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="btn btn-danger right-action-btn"><span class="fa fa-trash"></span></a>
+                        </td>
+                        <td>
+                         @request.Status
+                            @if(request.Status == RequestStatus.Assigned)
+                            { 
+                                <form asp-action="MarkComplete" asp-controller="Itinerary" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                                    <button type="submit" class="btn btn-success submit-form" title="Mark this request as complete"><span class="fa fa-check"></span></button>
+                                </form>
+                            }
+                            else
+                            {
+                                <form asp-action="MarkIncomplete" asp-controller="Itinerary" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                                    <button type="submit" class="btn btn-warning submit-form" title="Reset this request to incomplete"><span class="fa fa-ban"></span></button>
+                                </form>
+                            }
                         </td>
                     </tr> 
                 }

--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -66,7 +66,7 @@ footer {
 }
 
 .btn {
-    border-radius: 0;
+    border-radius: 6px;
 }
 
     .btn.btn-default, a.btn.btn-default {
@@ -403,13 +403,12 @@ Navigation
     margin-left: -10px;
 }
 
-.task-panel .panel-title .toggle-accordion-icon, #CampaignInfo .toggle-accordion-icon
-{
-    width: 25px;
-    float: left;
-    font-size: 24px;
-    color: hsl(28.6, 62.9%, 41.2%);
-}
+    .task-panel .panel-title .toggle-accordion-icon, #CampaignInfo .toggle-accordion-icon {
+        width: 25px;
+        float: left;
+        font-size: 24px;
+        color: hsl(28.6, 62.9%, 41.2%);
+    }
 
 #CampaignInfo h3 {
     margin-top: 1px;
@@ -430,9 +429,10 @@ Navigation
 .task-panel .task-name {
     font-weight: bold;
 }
-.task-panel .task-name.isFull {
-    font-weight: normal;
-}
+
+    .task-panel .task-name.isFull {
+        font-weight: normal;
+    }
 
 .task-panel .task-datetime {
     font-size: 13px;
@@ -446,13 +446,13 @@ Navigation
     margin-top: -32px;
 }
 
-.task-panel .btn-group > .btn {
-    margin-top: -3px;
-}
+    .task-panel .btn-group > .btn {
+        margin-top: -3px;
+    }
 
-.task-panel .btn-group > .btn-sm {
-    margin-top: -2px;
-}
+    .task-panel .btn-group > .btn-sm {
+        margin-top: -2px;
+    }
 
 .task-list {
     width: 80%;
@@ -468,10 +468,10 @@ Navigation
     margin: 0 auto;
 }
 
-#UserTasksAccordion .task-panel .task-button-container.twoButtons {
-    width: 46%;
-    margin: 0 auto;
-}
+    #UserTasksAccordion .task-panel .task-button-container.twoButtons {
+        width: 46%;
+        margin: 0 auto;
+    }
 
 /* Event Edit Page */
 
@@ -492,30 +492,30 @@ Navigation
     margin-left: 3px;
 }
 
-a .myevents-block  {
+a .myevents-block {
     color: #000;
 }
 
-a:hover .myevents-block  {
+a:hover .myevents-block {
     background: #f5eae1;
 }
 
 .myevents-block h5 {
-    font-size:15px;
+    font-size: 15px;
     margin-top: 3px;
 }
 
 .myevents-block h4 {
-    font-size:18px;
-    font-weight:bold;
+    font-size: 18px;
+    font-weight: bold;
 }
 
 .myevents-block h6 {
-    font-size:14px;
+    font-size: 14px;
 }
 
 .myevents-block p {
-    font-size:14px;
+    font-size: 14px;
 }
 
 .lister-logo {
@@ -544,13 +544,12 @@ a:hover .myevents-block  {
     color: black;
 }
 
-.org-tile  img {
-    max-height: 140px;
-}
+    .org-tile img {
+        max-height: 140px;
+    }
 
-.org-tile h2 {
-    margin-top: 0;
-    margin-bottom: 25px;
-    font-size: 20px;
-}
-
+    .org-tile h2 {
+        margin-top: 0;
+        margin-bottom: 25px;
+        font-size: 20px;
+    }


### PR DESCRIPTION
Closes #991 

Initial functionality to enable a request to be marked as completed from the itinerary details page (org or site admin).

![image](https://cloud.githubusercontent.com/assets/3669103/16592197/65533966-42d7-11e6-8de1-a19498b32e20.png)

I've added a button next to the current status allowing this to be toggled between completed and assigned.