### PR TITLE
WIP: Fix Date and DateTime pickers

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
@@ -153,11 +153,17 @@
                 showClose: false,
                 toolbarPlacement: 'bottom'
             });
+            $(".datepicker").each(function (index, element) {
+                $(element).data("DateTimePicker").date(moment($(element).attr("value")));
+            });
             $(".datetimepicker").datetimepicker({
                 format: 'L LT',
                 showClose: false,
                 sideBySide: true,
                 toolbarPlacement: 'bottom'
+            });
+            $(".datetimepicker").each(function (index, element) {
+                $(element).data("DateTimePicker").date(moment($(element).attr("value")));
             });
             tinymce.init({
                 selector: '.wysiwyg',


### PR DESCRIPTION
Had a quick look into this and it seems when initialising the datetime picker plugin, it clears the existing date.
I assumed this issue was new post dotnet core RTM update but that now seems unlikely.
The plugin has been used since Nov 2015 I think.

I dont have the dotnet core rc1 tooling installed any more so i'd appreciate if someone can check if this work before the update.

The fix currently works for Events and Tasks dates because they use ".datetimepicker" but not Campaigns because it uses ".datepicker".

Seems like for a ".datetimepicker" we serialise the date using the default formatter, however ".datepicker" uses a custom formatter. I'm not currently sure how all this works across different locales.

Hopefully will have some time to continue looking at it over the weekend.