### PR TITLE
Fixing Itinerary Creation Failure Since RTM update

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerAsync.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using AllReady.Extensions;
 using AllReady.Models;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -25,7 +26,8 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                 itinerary.Date = message.Itinerary.Date;
                 itinerary.EventId = message.Itinerary.EventId;
 
-                _context.Update(itinerary);
+                _context.AddOrUpdate(itinerary);
+                
                 await _context.SaveChangesAsync().ConfigureAwait(false);
 
                 return itinerary.Id;

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerAsync.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Threading.Tasks;
-using AllReady.Extensions;
 using AllReady.Models;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -20,13 +19,11 @@ namespace AllReady.Areas.Admin.Features.Itineraries
         {
             try
             {
-                var itinerary = await GetItinerary(message) ?? new Itinerary();
+                var itinerary = await GetItinerary(message) ?? _context.Add(new Itinerary()).Entity;
 
                 itinerary.Name = message.Itinerary.Name;
                 itinerary.Date = message.Itinerary.Date;
                 itinerary.EventId = message.Itinerary.EventId;
-
-                _context.AddOrUpdate(itinerary);
                 
                 await _context.SaveChangesAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
We can no longer call Update when we are trying to add a new untracked object in the context. Updated to use the AddOrUpdate extension for the time being as it is safe to do so in this case.

Fixes #1038 

Note: Tests not yet updated as rely on InMem Db service provider changes from #1005 