### PR TITLE
Fix compatibility issues introducing by the move to MVC 1.0.0

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.PlatformAbstractions;
 using AllReady.Security.Middleware;
+using Newtonsoft.Json.Serialization;
 
 namespace AllReady
 {
@@ -99,7 +100,9 @@ namespace AllReady
             });
 
             // Add MVC services to the services container.
-            services.AddMvc();
+            services.AddMvc().AddJsonOptions(options =>
+                options.SerializerSettings.ContractResolver = new DefaultContractResolver());
+
 
             // configure IoC support
             var container = CreateIoCContainer(services);

--- a/AllReadyApp/Web-App/AllReady/Views/Event/Event.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/Event.cshtml
@@ -28,7 +28,7 @@
                 }
                 <div class="@(string.IsNullOrEmpty(Model.ImageUrl) ? "col-sm-12" : "col-sm-10" )">
                     <h2>@Model.Title</h2>
-                    @if (Model.HasHeadline)
+                    @if (!string.IsNullOrEmpty(Model.Headline))
                     {
                         <h3>@Model.Headline</h3>
                     }
@@ -78,7 +78,7 @@
 
             <div class="row">
                 <div class="col-sm-12">
-                    @if (!User.IsSignedIn())
+                    @if (!User.Identity.IsAuthenticated)
                     {
                         if (Model.IsClosed)
                         {
@@ -125,7 +125,7 @@
     </div>
 </div>
 
-@if (User.IsSignedIn())
+@if (User.Identity.IsAuthenticated)
 {
     @Html.Partial("_VolunteerModal", Model)
 }

--- a/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
@@ -25,7 +25,7 @@
                 }
                 <div class="@(string.IsNullOrEmpty(Model.ImageUrl) ? "col-sm-12" : "col-sm-10" )">
                     <h2>@Model.Title</h2>
-                    @if (Model.HasHeadline)
+                    @if (!string.IsNullOrEmpty(Model.Headline))
                     {
                         <h3>@Model.Headline</h3>
                     }
@@ -82,7 +82,7 @@
             </div>
 
             @*Task Lists*@
-            @if (User.IsSignedIn())
+            @if (User.Identity.IsAuthenticated)
             {
                 @*User Tasks*@
                 <div class="row">
@@ -284,7 +284,7 @@
     </div>
 </div>
 
-@if (User.IsSignedIn())
+@if (User.Identity.IsAuthenticated)
 {
     @Html.Partial("_VolunteerModal", Model)
 

--- a/AllReadyApp/Web-App/AllReady/Views/Event/_EventScripts.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/_EventScripts.cshtml
@@ -30,7 +30,7 @@
                              isVolunteeredForEvent = Model.IsUserVolunteeredForEvent,
                              signupModelSeed = Model.SignupModel,
                              eventTitle = Model.Title,
-                             isSignedIn = User.IsSignedIn(),
+                             isSignedIn = User.Identity.IsAuthenticated,
                              loginUrl = "/Account/Login?ReturnUrl=/Event/" + @Model.Id
                          });
 


### PR DESCRIPTION
These modifications fix two compatibility issues with aspnet 1.0.0:

- in 1.0.0, MVC uses camel case names by default as announced here aspnet/Announcements#194, and so the the knockout bindings on various views stopped working (like for the issue "Home Page shows no Campaigns when there are campaigns seeded #1027")
- User.IsSignedIn() doesn't exists anymore https://github.com/aspnet/Identity/issues/630: the Event.cshtml view wouldn't compile.

Moreover the Event.cshml used the property `Model.HasHeadline` which doesn't exists in EventViewModel, i changed it to `!string.IsNullOrEmpty(Model.Headline)` in order to let Event.cshml compile
