### PR TITLE
Removing unnecessary update command in LockUnlockCampaignCommandHandler

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/LockUnlockCampaignCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/LockUnlockCampaignCommandHandler.cs
@@ -16,13 +16,13 @@ namespace AllReady.Areas.Admin.Features.Campaigns
         }
         protected override async Task HandleCore(LockUnlockCampaignCommand message)
         {
-            var campaign = await _context.Campaigns.SingleOrDefaultAsync(c => c.Id == message.CampaignId).ConfigureAwait(false);
+            var campaign = await _context.Campaigns
+                .SingleOrDefaultAsync(c => c.Id == message.CampaignId)
+                .ConfigureAwait(false);
 
             if (campaign != null)
             {
                 campaign.Locked = !campaign.Locked;
-
-                _context.Update(campaign);
                 await _context.SaveChangesAsync().ConfigureAwait(false);
             }
         }


### PR DESCRIPTION
This is not needed since the change tracker is already tracking the campaign we retrieved from the database.

Fixes #1052