### PR TITLE
Add Test for EventController

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -45,9 +45,20 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
         }
 
-        [Fact(Skip="test forgotten")]
+        [Fact]
         public void ShowEventSendsShowEventQueryWithCorrectData()
-        {}
+        {
+            var builder = EventControllerBuilder.Instance();
+            var sut = builder.WithMediator().WithUserLogged().Build();
+            
+            sut.ShowEvent(1);
+
+            builder
+                .MediatorMock
+                .Verify(x => 
+                    x.Send(It.Is<ShowEventQuery>(y => 
+                        y.EventId== 1 && y.User == sut.ControllerContext.HttpContext.User)));
+        }
 
         [Fact]
         public void ShowEventReturnsHttpNotFoundResultWhenViewModelIsNull()

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -16,15 +16,7 @@ namespace AllReady.UnitTest.Controllers
     {
         //delete this line when all unit tests using it have been completed
         private readonly Task taskFromResultZero = Task.FromResult(0);
-        
-        [Fact]
-        public void GetMyEventsHasAuthorizeAttribute()
-        {
-            var sut = EventControllerBuilder.Instance().Build();
-
-            var attribute = sut.GetAttributesOn(x => x.Index()).OfType<AuthorizeAttribute>().FirstOrDefault();
-            Assert.NotNull(attribute);
-        }
+       
 
 
 
@@ -47,10 +39,10 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void ShowEventSendsShowEventQueryWithCorrectData()
         {
-
+            
         }
 
         [Fact(Skip = "NotImplemented")]
@@ -63,9 +55,10 @@ namespace AllReady.UnitTest.Controllers
         {
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void ShowEventHasRouteAttributeWithCorrectRoute()
         {
+      
         }
 
         [Fact(Skip = "NotImplemented")]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -16,25 +16,14 @@ namespace AllReady.UnitTest.Controllers
     {
         //delete this line when all unit tests using it have been completed
         private readonly Task taskFromResultZero = Task.FromResult(0);
-
-        [Fact(Skip = "NotImplemented")]
-        public void GetMyEventsSendsGetMyEventsQueryWithTheCorrectUserId()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void GetMyEventsReturnsTheCorrectViewAndViewModel()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void GetMyEventsHasRouteAttributeWithTheCorrectRoute()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
+        
+        [Fact]
         public void GetMyEventsHasAuthorizeAttribute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut.GetAttributesOn(x => x.Index()).OfType<AuthorizeAttribute>().FirstOrDefault();
+            Assert.NotNull(attribute);
         }
 
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using AllReady.Controllers;
 using AllReady.UnitTest.Extensions;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
@@ -79,11 +80,13 @@ namespace AllReady.UnitTest.Controllers
         {
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public async Task SignupReturnsBadRequestResultWhenViewModelIsNull()
         {
-            //delete this line when starting work on this unit test
-            await taskFromResultZero;
+            var sut = EventControllerBuilder.Instance().Build();
+            var result = await sut.Signup(null);
+            Assert.IsType<BadRequestResult>(result);
+
         }
 
         [Fact(Skip = "NotImplemented")]
@@ -100,24 +103,40 @@ namespace AllReady.UnitTest.Controllers
             await taskFromResultZero;
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void SignupHasHttpPostAttribute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut.GetAttributesOn(x => x.Signup(null)).OfType<HttpPostAttribute>().FirstOrDefault();
+            Assert.NotNull(attribute);
         }
 
         [Fact(Skip = "NotImplemented")]
         public void SignupHasAuthorizeAttribute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut.GetAttributesOn(x => x.Signup(null)).OfType<AuthorizeAttribute>().FirstOrDefault();
+            Assert.NotNull(attribute);
         }
 
         [Fact(Skip = "NotImplemented")]
         public void SignupHasValidateAntiForgeryTokenAttribute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut.GetAttributesOn(x => x.Signup(null)).OfType<ValidateAntiForgeryTokenAttribute>().FirstOrDefault();
+            Assert.NotNull(attribute);
         }
 
         [Fact(Skip = "NotImplemented")]
         public void SignupHasRouteAttributeWithCorrectRoute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut.GetAttributesOn(x => x.Signup(null)).OfType<RouteAttribute>().FirstOrDefault();
+            Assert.NotNull(attribute);
         }
 
         [Fact(Skip = "NotImplemented")]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Controllers;
+using AllReady.UnitTest.Extensions;
+using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
 namespace AllReady.UnitTest.Controllers
@@ -82,14 +86,22 @@ namespace AllReady.UnitTest.Controllers
         {
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void IndexReturnsTheCorrectView()
         {
+            var sut = CreateWithNoInjectedDependencies();
+            var result = sut.Index();
+            Assert.IsType<ViewResult>(result);
+
+
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void IndexHasHttpGetAttribute()
         {
+            var sut = CreateWithNoInjectedDependencies();
+            var attribute = sut.GetAttributesOn(x => x.Index()).OfType<HttpGetAttribute>().FirstOrDefault();
+            Assert.NotNull(attribute);
         }
 
         [Fact(Skip = "NotImplemented")]
@@ -194,5 +206,8 @@ namespace AllReady.UnitTest.Controllers
         public void ChangeStatusHasAuthorizeAttribute()
         {
         }
+
+        private static EventController CreateWithNoInjectedDependencies() => new EventController(null, null);
+
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Security.Claims;
 using System.Security.Principal;
 using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.Tasks;
 using AllReady.Controllers;
 using AllReady.Features.Event;
 using AllReady.Models;
@@ -16,6 +17,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
+using TaskStatus = AllReady.Areas.Admin.Features.Tasks.TaskStatus;
 
 namespace AllReady.UnitTest.Controllers
 {
@@ -194,40 +196,80 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public async Task ChangeStatusReturnsBadRequestResultWhenUserIdIsNull()
         {
-            //delete this line when starting work on this unit test
-            await taskFromResultZero;
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var result = await sut.ChangeStatus(0, 0, null, TaskStatus.Completed, string.Empty);
+
+            Assert.IsType<BadRequestResult>(result);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public async Task ChangeStatusSendsTaskStatusChangeCommandAsyncWithCorrectData()
         {
-            //delete this line when starting work on this unit test
-            await taskFromResultZero;
+            var builder = EventControllerBuilder.Instance();
+            var sut = builder.WithMediator().Build();
+
+            await sut.ChangeStatus(0, 1, "userId", TaskStatus.Completed, "statusDesc");
+
+            builder
+                .MediatorMock
+                .Verify(x => 
+                    x.SendAsync(It.Is<TaskStatusChangeCommandAsync>(y => 
+                        y.TaskId == 1 && y.TaskStatus == TaskStatus.Completed && 
+                            y.UserId == "userId" && y.TaskStatusDescription == "statusDesc")));
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public async Task ChangeStatusRedirectsToCorrectActionWithCorrectRouteValues()
         {
-            //delete this line when starting work on this unit test
-            await taskFromResultZero;
+            var builder = EventControllerBuilder.Instance();
+            var sut = builder.WithMediator().Build();
+
+            var result = await sut.ChangeStatus(1, 0, string.Empty, TaskStatus.Completed, string.Empty) as RedirectToActionResult;
+
+            Assert.Equal(nameof(EventController.ShowEvent), result.ActionName);
+            Assert.Equal(1, result.RouteValues.Count);
+            Assert.Equal(1, result.RouteValues["id"]);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void ChangeStatusHasHttpGetAttribute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut
+                            .GetAttributesOn(x => x.ChangeStatus(0, 0, string.Empty, TaskStatus.Completed, string.Empty))
+                            .OfType<HttpGetAttribute>().FirstOrDefault();
+
+            Assert.NotNull(attribute);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void ChangeStatusHasRouteAttributeWithCorrectRoute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut
+                            .GetAttributesOn(x => x.ChangeStatus(0, 0, string.Empty, TaskStatus.Completed, string.Empty))
+                            .OfType<RouteAttribute>().FirstOrDefault();
+
+            Assert.NotNull(attribute);
+            Assert.Equal("/Event/ChangeStatus", attribute.Template);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void ChangeStatusHasAuthorizeAttribute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut
+                            .GetAttributesOn(x => x.ChangeStatus(0, 0, string.Empty, TaskStatus.Completed, string.Empty))
+                            .OfType<AuthorizeAttribute>().FirstOrDefault();
+
+            Assert.NotNull(attribute);
         }
 
         private class EventControllerBuilder

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -23,9 +23,6 @@ namespace AllReady.UnitTest.Controllers
 {
     public class EventControllerTests
     {
-        //delete this line when all unit tests using it have been completed
-        private readonly Task taskFromResultZero = Task.FromResult(0);
-
         [Fact]
         public void IndexReturnsTheCorrectView()
         {
@@ -48,11 +45,9 @@ namespace AllReady.UnitTest.Controllers
             Assert.NotNull(attribute);
         }
 
-        [Fact]
+        [Fact(Skip="test forgotten")]
         public void ShowEventSendsShowEventQueryWithCorrectData()
-        {
-
-        }
+        {}
 
         [Fact]
         public void ShowEventReturnsHttpNotFoundResultWhenViewModelIsNull()
@@ -129,11 +124,12 @@ namespace AllReady.UnitTest.Controllers
             var builder = EventControllerBuilder.Instance();
             var sut = builder.WithMediator().Build();
 
-            await sut.Signup(new EventSignupViewModel());
+            var model = new EventSignupViewModel();
+            await sut.Signup(model);
 
             builder
                 .MediatorMock
-                .Verify(x => x.SendAsync(It.IsAny<EventSignupCommand>()));
+                .Verify(x => x.SendAsync(It.Is<EventSignupCommand>(y => y.EventSignup == model)));
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -32,59 +32,7 @@ namespace AllReady.UnitTest.Controllers
         {
         }
 
-        [Fact(Skip = "NotImplemented")]
-        public void GetMyTasksSendsGetMyTasksQueryWithTheCorrectData()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void GetMyTasksReturnsCorrectJsonView()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void GetMyTasksHasRouteAttributeWithCorrectRoute()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void GetMyTasksHasAuthorizeAttribute()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public async Task UpdateMyTasksSendsUpdateMyTasksCommandAsyncWithCorrectData()
-        {
-            //delete this line when starting work on this unit test
-            await taskFromResultZero;
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public async Task UpdateMyTasksReturnsJsonResultWithTheCorrectData()
-        {
-            //delete this line when starting work on this unit test
-            await taskFromResultZero;
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void UpdateMyTasksHasHttpPostAttribute()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void UpdateMyTasksHasAuthorizeAttribute()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void UpdateMyTasksHasValidateAntiForgeryTokenAttribute()
-        {
-        }
-
-        [Fact(Skip = "NotImplemented")]
-        public void UpdateMyTasksHasRouteAttributeWithCorrectRoute()
-        {
-        }
+        
 
         [Fact]
         public void IndexReturnsTheCorrectView()

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -89,7 +89,7 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void IndexReturnsTheCorrectView()
         {
-            var sut = CreateWithNoInjectedDependencies();
+            var sut = EventControllerBuilder.Instance().Build();
             var result = sut.Index();
             Assert.IsType<ViewResult>(result);
 
@@ -99,7 +99,8 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public void IndexHasHttpGetAttribute()
         {
-            var sut = CreateWithNoInjectedDependencies();
+            var sut = EventControllerBuilder.Instance().Build();
+            
             var attribute = sut.GetAttributesOn(x => x.Index()).OfType<HttpGetAttribute>().FirstOrDefault();
             Assert.NotNull(attribute);
         }
@@ -207,7 +208,25 @@ namespace AllReady.UnitTest.Controllers
         {
         }
 
-        private static EventController CreateWithNoInjectedDependencies() => new EventController(null, null);
+        private class EventControllerBuilder
+        {
+            private readonly EventController _controller;
 
+            private EventControllerBuilder()
+            {
+                _controller = new EventController(null,null);
+            }
+
+            public static EventControllerBuilder Instance()
+            {
+                return new EventControllerBuilder();
+            }
+
+            public EventController Build()
+            {
+                return _controller;
+            }
+        }
+        
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventControllerTests.cs
@@ -1,11 +1,18 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Claims;
+using System.Security.Principal;
 using System.Threading.Tasks;
 using AllReady.Controllers;
 using AllReady.Features.Event;
+using AllReady.Models;
 using AllReady.UnitTest.Extensions;
+using AllReady.ViewModels.Event;
 using AllReady.ViewModels.Shared;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
@@ -16,18 +23,15 @@ namespace AllReady.UnitTest.Controllers
     {
         //delete this line when all unit tests using it have been completed
         private readonly Task taskFromResultZero = Task.FromResult(0);
-       
-
-
 
         [Fact]
         public void IndexReturnsTheCorrectView()
         {
             var sut = EventControllerBuilder.Instance().Build();
+
             var result = sut.Index();
+
             Assert.IsType<ViewResult>(result);
-
-
         }
 
         [Fact]
@@ -35,44 +39,86 @@ namespace AllReady.UnitTest.Controllers
         {
             var sut = EventControllerBuilder.Instance().Build();
 
-            var attribute = sut.GetAttributesOn(x => x.Index()).OfType<HttpGetAttribute>().FirstOrDefault();
+            var attribute = sut
+                            .GetAttributesOn(x => x.Index())
+                            .OfType<HttpGetAttribute>().FirstOrDefault();
+
             Assert.NotNull(attribute);
         }
 
         [Fact]
         public void ShowEventSendsShowEventQueryWithCorrectData()
         {
-            
+
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void ShowEventReturnsHttpNotFoundResultWhenViewModelIsNull()
         {
+            var builder = EventControllerBuilder.Instance();
+            var sut = builder.WithMediator().Build();
+
+            builder
+                .MediatorMock
+                .Setup(x => x.Send(It.IsAny<ShowEventQuery>()))
+                .Returns(() => null);
+
+            var result = sut.ShowEvent(0);
+
+            Assert.True(result is NotFoundResult);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void ShowEventReturnsEventWithTasksViewWithCorrrectViewModelWhenViewModelIsNotNull()
         {
+            var builder = EventControllerBuilder.Instance();
+            var eventViewModel = new EventViewModel();
+            var sut = builder.WithMediator().Build();
+
+            builder
+                .MediatorMock
+                .Setup(x => x.Send(It.IsAny<ShowEventQuery>()))
+                .Returns(eventViewModel);
+
+            var result = sut.ShowEvent(0) as ViewResult;
+
+            Assert.Equal(eventViewModel, result.Model);
+            Assert.Equal("EventWithTasks", result.ViewName);
         }
 
         [Fact]
         public void ShowEventHasRouteAttributeWithCorrectRoute()
         {
-      
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut
+                            .GetAttributesOn(x => x.ShowEvent(0))
+                            .OfType<RouteAttribute>().FirstOrDefault();
+
+            Assert.NotNull(attribute);
+            Assert.Equal("[controller]/{id}/", attribute.Template);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void ShowEventHasAllowAnonymousAttribute()
         {
+            var sut = EventControllerBuilder.Instance().Build();
+
+            var attribute = sut
+                            .GetAttributesOn(x => x.ShowEvent(0))
+                            .OfType<AllowAnonymousAttribute>().FirstOrDefault();
+
+            Assert.NotNull(attribute);
         }
 
         [Fact]
         public async Task SignupReturnsBadRequestResultWhenViewModelIsNull()
         {
             var sut = EventControllerBuilder.Instance().Build();
-            var result = await sut.Signup(null);
-            Assert.IsType<BadRequestResult>(result);
 
+            var result = await sut.Signup(null);
+
+            Assert.IsType<BadRequestResult>(result);
         }
 
         [Fact]
@@ -80,9 +126,12 @@ namespace AllReady.UnitTest.Controllers
         {
             var builder = EventControllerBuilder.Instance();
             var sut = builder.WithMediator().Build();
+
             await sut.Signup(new EventSignupViewModel());
 
-            builder.MediatorMock.Verify(x => x.SendAsync(It.IsAny<EventSignupCommand>()));
+            builder
+                .MediatorMock
+                .Verify(x => x.SendAsync(It.IsAny<EventSignupCommand>()));
         }
 
         [Fact]
@@ -102,7 +151,10 @@ namespace AllReady.UnitTest.Controllers
         {
             var sut = EventControllerBuilder.Instance().Build();
 
-            var attribute = sut.GetAttributesOn(x => x.Signup(null)).OfType<HttpPostAttribute>().FirstOrDefault();
+            var attribute = sut
+                            .GetAttributesOn(x => x.Signup(null))
+                            .OfType<HttpPostAttribute>().FirstOrDefault();
+
             Assert.NotNull(attribute);
         }
 
@@ -111,7 +163,10 @@ namespace AllReady.UnitTest.Controllers
         {
             var sut = EventControllerBuilder.Instance().Build();
 
-            var attribute = sut.GetAttributesOn(x => x.Signup(null)).OfType<AuthorizeAttribute>().FirstOrDefault();
+            var attribute = sut
+                            .GetAttributesOn(x => x.Signup(null))
+                            .OfType<AuthorizeAttribute>().FirstOrDefault();
+
             Assert.NotNull(attribute);
         }
 
@@ -120,7 +175,10 @@ namespace AllReady.UnitTest.Controllers
         {
             var sut = EventControllerBuilder.Instance().Build();
 
-            var attribute = sut.GetAttributesOn(x => x.Signup(null)).OfType<ValidateAntiForgeryTokenAttribute>().FirstOrDefault();
+            var attribute = sut
+                            .GetAttributesOn(x => x.Signup(null))
+                            .OfType<ValidateAntiForgeryTokenAttribute>().FirstOrDefault();
+
             Assert.NotNull(attribute);
         }
 
@@ -129,7 +187,10 @@ namespace AllReady.UnitTest.Controllers
         {
             var sut = EventControllerBuilder.Instance().Build();
 
-            var attribute = sut.GetAttributesOn(x => x.Signup(null)).OfType<RouteAttribute>().FirstOrDefault();
+            var attribute = sut
+                            .GetAttributesOn(x => x.Signup(null))
+                            .OfType<RouteAttribute>().FirstOrDefault();
+
             Assert.NotNull(attribute);
         }
 
@@ -172,6 +233,8 @@ namespace AllReady.UnitTest.Controllers
         private class EventControllerBuilder
         {
             private IMediator _mediator;
+            private ControllerContext _controllerContext;
+            private static EventControllerBuilder _builder;
             private EventControllerBuilder()
             {
                 MediatorMock = new Mock<IMediator>();
@@ -180,20 +243,47 @@ namespace AllReady.UnitTest.Controllers
 
             public static EventControllerBuilder Instance()
             {
-                return new EventControllerBuilder();
+                if (_builder == null)
+                    _builder = new EventControllerBuilder();
+
+                return _builder;
             }
 
             public EventController Build()
             {
+                if (_controllerContext == null)
+                    return new EventController(_mediator, null);
 
-                return new EventController(_mediator, null);
+                return new EventController(_mediator, null)
+                {
+                    ControllerContext = _controllerContext
+                };
             }
 
             public Mock<IMediator> MediatorMock { get; }
+
             public EventControllerBuilder WithMediator()
             {
 
                 _mediator = MediatorMock.Object;
+                return this;
+            }
+
+            public EventControllerBuilder WithUserLogged()
+            {
+                var httpContext = new Mock<HttpContext>();
+
+                var controllerContext = new Mock<ControllerContext>();
+                var principal = new Moq.Mock<ClaimsPrincipal>();
+
+
+                principal.Setup(p => p.IsInRole("Administrator")).Returns(true);
+                principal.SetupGet(x => x.Identity.Name).Returns("userName");
+
+                httpContext.Setup(x => x.User).Returns(principal.Object);
+                controllerContext.Object.HttpContext = httpContext.Object;
+                _controllerContext = controllerContext.Object;
+
                 return this;
             }
 


### PR DESCRIPTION
Tests for AllReady.Controllers.EventController: issue #662
Implemented tests for ChangeStatus, Index and ShowEvent.
Removed stub tests for UpdateMyTask, GetMyTasks and GetMyEvents as the controller no longer has these methods.