### PR TITLE
Geocoded requests: display requests on map as pins

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -177,6 +177,8 @@ namespace AllReady.Areas.Admin.Controllers
                     DateAdded = request.DateAdded,
                     City = request.City,
                     Address = request.Address,
+                    Latitude = request.Latitude,
+                    Longitude = request.Longitude,
                     Postcode = request.Postcode
                 };
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQueryHandlerAsync.cs
@@ -59,6 +59,8 @@ namespace AllReady.Areas.Admin.Features.Requests
                 Id = r.RequestId,
                 Name = r.Name,
                 Address = r.Address,
+                Latitude = r.Latitude,
+                Longitude = r.Longitude,
                 City = r.City,
                 Postcode = r.Zip,
                 Status = r.Status,

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/RequestListModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/RequestListModel.cs
@@ -10,6 +10,8 @@ namespace AllReady.Areas.Admin.Models.ItineraryModels
         public string Address { get; set; }
         public string City { get; set; }
         public string Postcode { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
         public DateTime DateAdded { get; set; }
         public RequestStatus Status { get; set; }
         public bool IsFirst { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/SelectRequests.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/SelectRequests.cshtml
@@ -19,69 +19,92 @@
         </ol>
     </div>
 </div>
-
 <div class="row">
-    <div class="col-md-12">
-        <h2>Select Requests</h2>
-        <p>Please choose the requests you would like to add to your itinerary.</p>
+    <div class="col-xs-12 col-md-6">
+        <div>
+            <h2>Select Requests</h2>
+            <p>Please choose the requests you would like to add to your itinerary.</p>
+        </div>
+        <div class="request-filter-section">
+            <h3>Filter results</h3>
+            <p>Please enter a keyword on which to filter the requests.</p>
+            <form asp-action="SelectRequests" asp-controller="Itinerary" asp-area="Admin">
+                <input asp-for="KeywordsFilter" />
+                <button type="submit" class="btn btn-default submit-form">Filter</button>
+            </form>
+        </div>
+        <div>
+            <form asp-area="Admin" asp-controller="Itinerary" asp-action="AddRequests">
+                <div class="row">
+                    <div class="col-12">
+                        <button type="submit" class="btn btn-primary submit-form">Add Selected Requests</button>
+                        <a asp-action="Details" asp-controller="Itinerary" asp-area="Admin" class="btn btn-default">Cancel</a>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-12">
+                        @if (Model.Requests.Count > 0)
+                        {
+                            <table class="table">
+                                <tr>
+                                    <th></th>
+                                    <th>Request Name</th>
+                                    <th>Address</th>
+                                    <th>City</th>
+                                    <th>Postcode</th>
+                                    <th>Date Added</th>
+                                </tr>
+                                @foreach (var req in Model.Requests)
+                                {
+                                    <tr>
+                                        <td>
+                                            <input type="checkbox" name="selectedRequests" value="@req.Id" @Html.Raw(req.IsSelected) ? "checked" : "" ) />
+                                        </td>
+                                        <td>@req.Name</td>
+                                        <td>@req.Address</td>
+                                        <td>@req.City</td>
+                                        <td>@req.Postcode</td>
+                                        <td>@req.DateAdded</td>
+                                    </tr>
+                                }
+                            </table>
+                        }
+                        else
+                        {
+                            <br />
+                            <p>There are no new requests which can be added</p>
+                        }
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+    <div class="col-xs-12 col-md-6">
+        <h3>Map</h3>
+        <div id="bingMap"></div>
     </div>
 </div>
 
-<div class="row">
-    <div class="col-md-12 request-filter-section">
-        <h3>Filter results</h3>
-        <p>Please enter a keyword on which to filter the requests.</p>
-        <form asp-action="SelectRequests" asp-controller="Itinerary" asp-area="Admin">
-            <input asp-for="KeywordsFilter"/>
-            <button type="submit" class="btn btn-default submit-form">Filter</button>
-        </form>
-    </div>
-</div>
+@section scripts {
+    <script type="text/javascript" src="http://ecn.dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=7.0"></script>
+    <script type="text/javascript">
+        ///<reference path="~/wwwroot/js/site.js" />
+        $(document).ready(function () {
+            setBingMapHeight();
+            renderBingMap("bingMap", getLocationsFromModelRequests());
+        });
 
-<form asp-area="Admin" asp-controller="Itinerary" asp-action="AddRequests">
+        function setBingMapHeight(){
+            $("#bingMap").height(($(window).height() * 0.6));
+        }
 
-    <div class="row">
-        <div class="col-12">
-            <button type="submit" class="btn btn-primary submit-form">Add Selected Requests</button>
-            <a asp-action="Details" asp-controller="Itinerary" asp-area="Admin" class="btn btn-default">Cancel</a>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-12">
-            @if (Model.Requests.Count > 0)
-            {
-                <table class="table">
-                    <tr>
-                        <th></th>
-                        <th>Request Name</th>
-                        <th>Address</th>
-                        <th>City</th>
-                        <th>Postcode</th>
-                        <th>Date Added</th>
-                    </tr>
-                    @foreach (var req in Model.Requests)
-                {
-                        <tr>
-                            <td>
-                                <input type="checkbox" name="selectedRequests" value="@req.Id" @Html.Raw(req.IsSelected) ? "checked" : "" ) />
-                            </td>
-                            <td>@req.Name</td>
-                            <td>@req.Address</td>
-                            <td>@req.City</td>
-                            <td>@req.Postcode</td>
-                            <td>@req.DateAdded</td>
-                        </tr>
-                    }
-                </table>
+        function getLocationsFromModelRequests() {
+            var locations = [];
+            @foreach (var request in Model.Requests){
+                @:locations.push({ latitude: @request.Latitude, longitude: @request.Longitude });
             }
-            else
-            {
-                <br />
-                        <p>There are no new requests which can be added</p>
-            }
-
-        </div>
-    </div>
-
-</form>
+            return locations;
+        }
+    </script>
+}

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/site.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/site.js
@@ -9,22 +9,10 @@
 var BingMapKey = "ArclGe51CDYUCjW2tcjeuCSxXDg0z4_NFRCmVMpnpMY0qGUvPBazQIp9AjDgm2kv";
 
 var renderBingMap = function (divIdForMap, positionCoordsList) {
-    var bingMap = new Microsoft.Maps.Map(
-                    document.getElementById(divIdForMap),
-                    {
-                        credentials: BingMapKey
-                    });
-    if (positionCoordsList != undefined && positionCoordsList != null) {
-        $.each(positionCoordsList, function (index, LocationData) {
-            var pushpin = new Microsoft.Maps.Pushpin(bingMap.getCenter(), null);
-            pushpin.setLocation(new Microsoft.Maps.Location(
-                LocationData.latitude,
-                LocationData.longitude));
-            bingMap.entities.push(pushpin);
-            bingMap.setView({
-                zoom: 10, center: new Microsoft.Maps.Location(LocationData.latitude, LocationData.longitude)
-            });
-        });
+    if (positionCoordsList) {
+        var bingMap = createBingMap(divIdForMap);
+        var microsoftMapsLocations = createMapLocationsAndAddPushPinsToMap(bingMap, positionCoordsList);
+        setMapCenterAndZoom(bingMap, microsoftMapsLocations);
     }
 }
 
@@ -58,4 +46,35 @@ var getGeoCoordinates = function (address1, address2, city, state, postalCode, c
             alert(e.statusText);
         }
     });
+}
+
+function createBingMap(divIdForMap) {
+    return new Microsoft.Maps.Map(
+        document.getElementById(divIdForMap), {
+        credentials: BingMapKey
+    });
+}
+
+function createMapLocationsAndAddPushPinsToMap(bingMap, positionCoordsList) {
+    var microsoftMapsLocations = [];
+    $.each(positionCoordsList, function (index, LocationData) {
+        var microsoftMapsLocation = new Microsoft.Maps.Location(LocationData.latitude, LocationData.longitude);
+        microsoftMapsLocations.push(microsoftMapsLocation);
+        var pushpin = new Microsoft.Maps.Pushpin();
+        pushpin.setLocation(microsoftMapsLocation);
+        bingMap.entities.push(pushpin);
+    });
+    return microsoftMapsLocations;
+}
+
+function setMapCenterAndZoom(bingMap, microsoftMapsLocations) {
+    var options = bingMap.getOptions();
+    options.zoom = 10;
+    if (microsoftMapsLocations.length === 1) {
+        options.center = microsoftMapsLocations[0];
+    } else {
+        options.bounds = Microsoft.Maps.LocationRect.fromLocations(microsoftMapsLocations);
+        options.padding = 50;
+    }
+    bingMap.setView(options);
 }


### PR DESCRIPTION
Closes #1098. Added a Bing Map to right half of the Itinerary/SelectRequests page, which uses the existing Bing API found in site.js. Also updated the renderBingMap function of site.js so that the map center is the defined by the bounding rectangle of all locations given (instead of re-centering for every location given). Refactored renderBingMap function for readability.