### PR TITLE
Fix: Edit campaign cannot add contact information

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CampaignDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CampaignDetailQueryHandler.cs
@@ -41,6 +41,7 @@ namespace AllReady.Areas.Admin.Features.Campaigns
                     ExternalUrlText = campaign.ExternalUrlText,
                     OrganizationId = campaign.ManagingOrganizationId,
                     OrganizationName = campaign.ManagingOrganization.Name,
+                    FullDescription = campaign.FullDescription,
                     ImageUrl = campaign.ImageUrl,
                     TimeZoneId = campaign.TimeZoneId,
                     StartDate = campaign.StartDateTime,

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/EditCampaignCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/EditCampaignCommandHandler.cs
@@ -53,16 +53,6 @@ namespace AllReady.Areas.Admin.Features.Campaigns
             campaign.Featured = message.Campaign.Featured;
             campaign.Headline = message.Campaign.Headline;
 
-            if (campaign.CampaignImpact.Id != 0 )
-            {
-                _context.AddOrUpdate(campaign.CampaignImpact);
-            }
-
-            if (campaign.Location != null)
-            {
-                _context.AddOrUpdate(campaign.Location);
-            }
-
             _context.AddOrUpdate(campaign);
 
             await _context.SaveChangesAsync().ConfigureAwait(false);
@@ -113,7 +103,6 @@ namespace AllReady.Areas.Admin.Features.Campaigns
 
                 if (campaign.CampaignContacts == null) campaign.CampaignContacts = new List<CampaignContact>();
                 campaign.CampaignContacts.Add(campaignContact);
-                _context.Add(campaignContact);
             }
         }
     }


### PR DESCRIPTION
EF 7 doens't need adds or updates actions on related entities:

https://ef.readthedocs.io/en/latest/saving/related-data.html

the previous version threw an exception whenever the administrator tried to add contact information to the campaign.

Fixed also the visualization of campaign detail in admin area adding FullDescription