### PR TITLE
Listing of requests for Event

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/EventAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/EventAdminControllerTests.cs
@@ -20,11 +20,10 @@ using AllReady.Areas.Admin.Models.ItineraryModels;
 using AllReady.Areas.Admin.Models.Validators;
 using AllReady.Features.Event;
 using Microsoft.AspNetCore.Authorization;
-using AllReady.Areas.Admin.Features.Events;
 using Microsoft.AspNetCore.Http;
 using System.Reflection;
-using AllReady.Features.Event;
 using AllReady.ViewModels.Event;
+using Shouldly;
 
 namespace AllReady.UnitTest.Areas.Admin.Controllers
 {

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Models/EventDetailModelTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Models/EventDetailModelTests.cs
@@ -11,7 +11,7 @@ namespace AllReady.UnitTest.ModelTests
             var sut = new EventDetailModel();
             sut.EventType = AllReady.Models.EventType.Itinerary;
 
-            Assert.True(sut.DisplayItineraries);
+            Assert.True(sut.IsItineraryEvent);
         }
 
         [Fact]
@@ -20,7 +20,7 @@ namespace AllReady.UnitTest.ModelTests
             var sut = new EventDetailModel();
             sut.EventType = AllReady.Models.EventType.Rally;
 
-            Assert.False(sut.DisplayItineraries);
+            Assert.False(sut.IsItineraryEvent);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Requests/AddRequestCommandHandlerAsyncTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Requests/AddRequestCommandHandlerAsyncTests.cs
@@ -50,7 +50,7 @@ namespace AllReady.UnitTest.Features.Requests
             var result = await _sut.Handle(command);
 
             Assert.NotNull(request.RequestId);
-            Assert.Equal(RequestStatus.UnAssigned, request.Status);
+            Assert.Equal(RequestStatus.Unassigned, request.Status);
 
         }
 
@@ -73,7 +73,7 @@ namespace AllReady.UnitTest.Features.Requests
             {
                 ProviderId = pid,
                 RequestId = rid,
-                Status = RequestStatus.UnAssigned
+                Status = RequestStatus.Unassigned
             };
             _dataAccess.Setup(x => x.GetRequestByProviderIdAsync(pid)).ReturnsAsync(returnedRequest);
 
@@ -94,7 +94,7 @@ namespace AllReady.UnitTest.Features.Requests
                 City = "Happytown",
                 State = "HP",
                 Zip = "12345",
-                Status = RequestStatus.UnAssigned
+                Status = RequestStatus.Unassigned
             };
 
             var address = new Geocoding.Google.GoogleAddress(
@@ -130,7 +130,7 @@ namespace AllReady.UnitTest.Features.Requests
                 Zip = "12345",
                 Latitude = 13,
                 Longitude = 14,
-                Status = RequestStatus.UnAssigned
+                Status = RequestStatus.Unassigned
             };
 
             var address = new Geocoding.Google.GoogleAddress(
@@ -168,7 +168,6 @@ namespace AllReady.UnitTest.Features.Requests
 
             Assert.Equal(13, request.Latitude);
             Assert.Equal(0, request.Longitude);
-
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Events;
 using AllReady.Areas.Admin.Features.Campaigns;
+using AllReady.Areas.Admin.Features.Requests;
 using AllReady.Areas.Admin.Models;
 using AllReady.Extensions;
 using AllReady.Models;
@@ -15,343 +16,389 @@ using Microsoft.AspNetCore.Mvc;
 using AllReady.Areas.Admin.Models.Validators;
 using AllReady.Features.Event;
 using AllReady.ViewModels.Event;
+using AllReady.Areas.Admin.Models.EventViewModels;
+using AllReady.Areas.Admin.Models.ItineraryModels;
+using AllReady.Areas.Admin.Models.RequestModels;
+using Microsoft.CodeAnalysis.Differencing;
 
 namespace AllReady.Areas.Admin.Controllers
 {
-  [Area("Admin")]
-  [Authorize("OrgAdmin")]
-  public class EventController : Controller
-  {
-    private readonly IImageService _imageService;
-    private readonly IMediator _mediator;
-    private readonly IValidateEventDetailModels _eventDetailModelValidator;
-
-    public EventController(IImageService imageService, IMediator mediator, IValidateEventDetailModels eventDetailModelValidator)
+    [Area("Admin")]
+    [Authorize("OrgAdmin")]
+    public class EventController : Controller
     {
-      _imageService = imageService;
-      _mediator = mediator;
-      _eventDetailModelValidator = eventDetailModelValidator;
-    }
+        private readonly IImageService _imageService;
+        private readonly IMediator _mediator;
+        private readonly IValidateEventDetailModels _eventDetailModelValidator;
 
-    // GET: Event/Details/5
-    [HttpGet]
-    [Route("Admin/Event/Details/{id}")]
-    public async Task<IActionResult> Details(int id)
-    {
-      var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = id });
-      if (campaignEvent == null)
-      {
-        return NotFound();
-      }
-
-      if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      campaignEvent.ItinerariesDetailsUrl = GenerateItineraryDetailsTemplateUrl();
-
-      return View(campaignEvent);
-    }
-
-    private string GenerateItineraryDetailsTemplateUrl()
-    {
-      var url = Url.Action("Details", "Itinerary", new { Area = "Admin", id = 0 }).TrimEnd('0');
-
-      return string.Concat(url, "{id}");
-    }
-
-    // GET: Event/Create
-    [Route("Admin/Event/Create/{campaignId}")]
-    public async Task<IActionResult> Create(int campaignId)
-    {
-      var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
-      if (campaign == null || !User.IsOrganizationAdmin(campaign.OrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      var campaignEvent = new EventEditModel
-      {
-        CampaignId = campaign.Id,
-        CampaignName = campaign.Name,
-        TimeZoneId = campaign.TimeZoneId,
-        OrganizationId = campaign.OrganizationId,
-        OrganizationName = campaign.OrganizationName,
-        StartDateTime = DateTime.Today.Date,
-        EndDateTime = DateTime.Today.Date
-      };
-
-      return View("Edit", campaignEvent);
-    }
-
-    // POST: Event/Create
-    [HttpPost]
-    [ValidateAntiForgeryToken]
-    [Route("Admin/Event/Create/{campaignId}")]
-    public async Task<IActionResult> Create(int campaignId, EventEditModel campaignEvent, IFormFile fileUpload)
-    {
-      var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
-      if (campaign == null || !User.IsOrganizationAdmin(campaign.OrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      var errors = _eventDetailModelValidator.Validate(campaignEvent, campaign);
-      errors.ToList().ForEach(e => ModelState.AddModelError(e.Key, e.Value));
-
-      ModelState.Remove("NewItinerary");
-
-      //TryValidateModel is called explictly because of MVC 6 behavior that supresses model state validation during model binding when binding to an IFormFile.
-      //See #619.
-      if (ModelState.IsValid && TryValidateModel(campaignEvent))
-      {
-        if (fileUpload != null)
+        public EventController(IImageService imageService, IMediator mediator, IValidateEventDetailModels eventDetailModelValidator)
         {
-          if (!fileUpload.IsAcceptableImageContentType())
-          {
-            ModelState.AddModelError("ImageUrl", "You must upload a valid image file for the logo (.jpg, .png, .gif)");
-            return View("Edit", campaignEvent);
-          }
+            _imageService = imageService;
+            _mediator = mediator;
+            _eventDetailModelValidator = eventDetailModelValidator;
         }
 
-        campaignEvent.OrganizationId = campaign.OrganizationId;
-        var id = await _mediator.SendAsync(new EditEventCommand { Event = campaignEvent });
-
-        if (fileUpload != null)
+        // GET: Event/Details/5
+        [HttpGet]
+        [Route("Admin/Event/Details/{id}")]
+        public async Task<IActionResult> Details(int id)
         {
-          // resave now that event has the ImageUrl
-          campaignEvent.Id = id;
-          campaignEvent.ImageUrl = await _imageService.UploadEventImageAsync(campaign.OrganizationId, id, fileUpload);
-          await _mediator.SendAsync(new EditEventCommand { Event = campaignEvent });
-        }
+            var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = id });
+            if (campaignEvent == null)
+            {
+                return NotFound();
+            }
 
-        return RedirectToAction(nameof(Details), new { area = "Admin", id = id });
-      }
+            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            {
+                return Unauthorized();
+            }
 
-      return View("Edit", campaignEvent);
-    }
+            campaignEvent.ItinerariesDetailsUrl = GenerateItineraryDetailsTemplateUrl();
 
-    // GET: Event/Edit/5
-    public async Task<IActionResult> Edit(int id)
-    {
-      var campaignEvent = await _mediator.SendAsync(new EventEditQuery { EventId = id });
-      if (campaignEvent == null)
-      {
-        return NotFound();
-      }
-
-      if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      return View(campaignEvent);
-    }
-
-    // POST: Event/Edit/5
-    [HttpPost]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Edit(EventEditModel campaignEvent, IFormFile fileUpload)
-    {
-      if (campaignEvent == null)
-      {
-        return BadRequest();
-      }
-
-      var organizationId = _mediator.Send(new ManagingOrganizationIdByEventIdQuery { EventId = campaignEvent.Id });
-      if (!User.IsOrganizationAdmin(organizationId))
-      {
-        return Unauthorized();
-      }
-
-      var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignEvent.CampaignId });
-
-      var errors = _eventDetailModelValidator.Validate(campaignEvent, campaign);
-      errors.ForEach(e => ModelState.AddModelError(e.Key, e.Value));
-
-      if (ModelState.IsValid)
-      {
-        if (fileUpload != null)
-        {
-          if (fileUpload.IsAcceptableImageContentType())
-          {
-            campaignEvent.ImageUrl = await _imageService.UploadEventImageAsync(campaign.OrganizationId, campaignEvent.Id, fileUpload);
-          }
-          else
-          {
-            ModelState.AddModelError("ImageUrl", "You must upload a valid image file for the logo (.jpg, .png, .gif)");
             return View(campaignEvent);
-          }
         }
 
-        var id = await _mediator.SendAsync(new EditEventCommand { Event = campaignEvent });
+        private string GenerateItineraryDetailsTemplateUrl()
+        {
+            var url = Url.Action("Details", "Itinerary", new { Area = "Admin", id = 0 }).TrimEnd('0');
 
-        return RedirectToAction(nameof(Details), new { area = "Admin", id = id });
-      }
+            return string.Concat(url, "{id}");
+        }
 
-      return View(campaignEvent);
+        // GET: Event/Create
+        [Route("Admin/Event/Create/{campaignId}")]
+        public async Task<IActionResult> Create(int campaignId)
+        {
+            var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
+            if (campaign == null || !User.IsOrganizationAdmin(campaign.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            var campaignEvent = new EventEditModel
+            {
+                CampaignId = campaign.Id,
+                CampaignName = campaign.Name,
+                TimeZoneId = campaign.TimeZoneId,
+                OrganizationId = campaign.OrganizationId,
+                OrganizationName = campaign.OrganizationName,
+                StartDateTime = DateTime.Today.Date,
+                EndDateTime = DateTime.Today.Date
+            };
+
+            return View("Edit", campaignEvent);
+        }
+
+        // POST: Event/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        [Route("Admin/Event/Create/{campaignId}")]
+        public async Task<IActionResult> Create(int campaignId, EventEditModel campaignEvent, IFormFile fileUpload)
+        {
+            var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
+            if (campaign == null || !User.IsOrganizationAdmin(campaign.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            var errors = _eventDetailModelValidator.Validate(campaignEvent, campaign);
+            errors.ToList().ForEach(e => ModelState.AddModelError(e.Key, e.Value));
+
+            ModelState.Remove("NewItinerary");
+
+            //TryValidateModel is called explictly because of MVC 6 behavior that supresses model state validation during model binding when binding to an IFormFile.
+            //See #619.
+            if (ModelState.IsValid && TryValidateModel(campaignEvent))
+            {
+                if (fileUpload != null)
+                {
+                    if (!fileUpload.IsAcceptableImageContentType())
+                    {
+                        ModelState.AddModelError("ImageUrl", "You must upload a valid image file for the logo (.jpg, .png, .gif)");
+                        return View("Edit", campaignEvent);
+                    }
+                }
+
+                campaignEvent.OrganizationId = campaign.OrganizationId;
+                var id = await _mediator.SendAsync(new EditEventCommand { Event = campaignEvent });
+
+                if (fileUpload != null)
+                {
+                    // resave now that event has the ImageUrl
+                    campaignEvent.Id = id;
+                    campaignEvent.ImageUrl = await _imageService.UploadEventImageAsync(campaign.OrganizationId, id, fileUpload);
+                    await _mediator.SendAsync(new EditEventCommand { Event = campaignEvent });
+                }
+
+                return RedirectToAction(nameof(Details), new { area = "Admin", id = id });
+            }
+
+            return View("Edit", campaignEvent);
+        }
+
+        // GET: Event/Edit/5
+        public async Task<IActionResult> Edit(int id)
+        {
+            var campaignEvent = await _mediator.SendAsync(new EventEditQuery { EventId = id });
+            if (campaignEvent == null)
+            {
+                return NotFound();
+            }
+
+            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            return View(campaignEvent);
+        }
+
+        // POST: Event/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(EventEditModel campaignEvent, IFormFile fileUpload)
+        {
+            if (campaignEvent == null)
+            {
+                return BadRequest();
+            }
+
+            var organizationId = _mediator.Send(new ManagingOrganizationIdByEventIdQuery { EventId = campaignEvent.Id });
+            if (!User.IsOrganizationAdmin(organizationId))
+            {
+                return Unauthorized();
+            }
+
+            var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignEvent.CampaignId });
+
+            var errors = _eventDetailModelValidator.Validate(campaignEvent, campaign);
+            errors.ForEach(e => ModelState.AddModelError(e.Key, e.Value));
+
+            if (ModelState.IsValid)
+            {
+                if (fileUpload != null)
+                {
+                    if (fileUpload.IsAcceptableImageContentType())
+                    {
+                        campaignEvent.ImageUrl = await _imageService.UploadEventImageAsync(campaign.OrganizationId, campaignEvent.Id, fileUpload);
+                    }
+                    else
+                    {
+                        ModelState.AddModelError("ImageUrl", "You must upload a valid image file for the logo (.jpg, .png, .gif)");
+                        return View(campaignEvent);
+                    }
+                }
+
+                var id = await _mediator.SendAsync(new EditEventCommand { Event = campaignEvent });
+
+                return RedirectToAction(nameof(Details), new { area = "Admin", id = id });
+            }
+
+            return View(campaignEvent);
+        }
+
+        // GET: Event/Duplicate/5
+        [HttpGet]
+        public async Task<IActionResult> Duplicate(int id)
+        {
+            var campaignEvent = await _mediator.SendAsync(new DuplicateEventQuery { EventId = id });
+            if (campaignEvent == null)
+            {
+                return NotFound();
+            }
+            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            return View(campaignEvent);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Duplicate(DuplicateEventModel model)
+        {
+            if (model == null)
+                return BadRequest();
+
+            var organizationId = _mediator.Send(new ManagingOrganizationIdByEventIdQuery { EventId = model.Id });
+            if (!User.IsOrganizationAdmin(organizationId))
+                return Unauthorized();
+
+            var existingEvent = await _mediator.SendAsync(new EventEditQuery() { EventId = model.Id });
+            var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = existingEvent.CampaignId });
+            var newEvent = buildNewEventDetailsModel(existingEvent, model);
+
+            var errors = _eventDetailModelValidator.Validate(newEvent, campaign);
+            errors.ForEach(e => ModelState.AddModelError(e.Key, e.Value));
+
+            if (ModelState.IsValid)
+            {
+                var id = await _mediator.SendAsync(new DuplicateEventCommand { DuplicateEventModel = model });
+
+                return RedirectToAction(nameof(Details), new { area = "Admin", id = id });
+            }
+
+            return View(model);
+        }
+
+        private EventEditModel buildNewEventDetailsModel(EventEditModel existingEvent, DuplicateEventModel newEventDetails)
+        {
+            existingEvent.Id = 0;
+            existingEvent.Name = newEventDetails.Name;
+            existingEvent.Description = newEventDetails.Description;
+            existingEvent.StartDateTime = newEventDetails.StartDateTime;
+            existingEvent.EndDateTime = newEventDetails.EndDateTime;
+
+            return existingEvent;
+        }
+
+        // GET: Event/Delete/5
+        [ActionName("Delete")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = id });
+            if (campaignEvent == null)
+            {
+                return NotFound();
+            }
+
+            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            return View(campaignEvent);
+        }
+
+        // POST: Event/Delete/5
+        [HttpPost, ActionName("Delete")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteConfirmed(int id)
+        {
+            //TODO: Should be using an EventSummaryQuery here
+            var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = id });
+            if (campaignEvent == null)
+            {
+                return NotFound();
+            }
+
+            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            await _mediator.SendAsync(new DeleteEventCommand { EventId = id });
+
+            return RedirectToAction(nameof(CampaignController.Details), "Campaign", new { area = "Admin", id = campaignEvent.CampaignId });
+        }
+
+        [HttpGet]
+        public IActionResult Assign(int id)
+        {
+            var campaignEvent = GetEventBy(id);
+            if (campaignEvent == null)
+            {
+                return NotFound();
+            }
+
+            if (!User.IsOrganizationAdmin(campaignEvent.Campaign.ManagingOrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            var model = new EventViewModel(campaignEvent);
+            model.Tasks = model.Tasks.OrderBy(t => t.StartDateTime).ThenBy(t => t.Name).ToList();
+            model.Volunteers = campaignEvent.UsersSignedUp.Select(u => u.User).ToList();
+
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> MessageAllVolunteers(MessageEventVolunteersModel model)
+        {
+            if (!ModelState.IsValid)
+            {
+                return BadRequest(ModelState);
+            }
+
+            //TODO: Query only for the organization Id rather than the whole event detail
+            var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = model.EventId });
+            if (campaignEvent == null)
+            {
+                return NotFound();
+            }
+
+            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            await _mediator.SendAsync(new MessageEventVolunteersCommand { Model = model });
+
+            return Ok();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> PostEventFile(int id, IFormFile file)
+        {
+            var campaignEvent = GetEventBy(id);
+
+            campaignEvent.ImageUrl = await _imageService.UploadEventImageAsync(campaignEvent.Id, campaignEvent.Campaign.ManagingOrganizationId, file);
+            await _mediator.SendAsync(new UpdateEvent { Event = campaignEvent });
+
+            return RedirectToRoute(new { controller = "Event", Area = "Admin", action = nameof(Edit), id = id });
+        }
+
+        [HttpGet]
+        [Route("Admin/Event/[action]/{id}/{status?}")]
+        public async Task<IActionResult> Requests(int id, string status)
+        {
+            var campaignEvent = GetEventBy(id);
+            if (campaignEvent == null)
+            {
+                return NotFound();
+            }
+
+            if (!User.IsOrganizationAdmin(campaignEvent.Campaign.ManagingOrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            var criteria = new RequestSearchCriteria { EventId = id };
+
+            var pageTitle = "All Requests";
+
+            if (!string.IsNullOrEmpty(status))
+            { 
+                RequestStatus requestStatus;
+                if (Enum.TryParse(status, out requestStatus))
+                {
+                    criteria.Status = requestStatus;
+                    pageTitle = $"{status} Requests";
+                }
+                else
+                {
+                    return RedirectToAction(nameof(Requests), new {id});
+                }
+            }
+
+            var model = await _mediator.SendAsync(new EventRequestsQuery { EventId = id });
+
+            model.PageTitle = pageTitle;
+
+            model.Requests = await _mediator.SendAsync(new RequestListItemsQuery {Criteria = criteria});
+ 
+            return View(model);
+        }
+
+        private Event GetEventBy(int eventId)
+        {
+            //TODO: refactor message to async when IAllReadyDataAccess read ops are made async
+            return _mediator.Send(new EventByIdQuery { EventId = eventId });
+        }
     }
-
-    // GET: Event/Duplicate/5
-    [HttpGet]
-    public async Task<IActionResult> Duplicate(int id)
-    {
-      var campaignEvent = await _mediator.SendAsync(new DuplicateEventQuery { EventId = id });
-      if (campaignEvent == null)
-      {
-        return NotFound();
-      }
-      if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      return View(campaignEvent);
-    }
-
-    [HttpPost]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> Duplicate(DuplicateEventModel model)
-    {
-      if (model == null)
-        return BadRequest();
-
-      var organizationId = _mediator.Send(new ManagingOrganizationIdByEventIdQuery { EventId = model.Id });
-      if (!User.IsOrganizationAdmin(organizationId))
-        return Unauthorized();
-
-      var existingEvent = await _mediator.SendAsync(new EventEditQuery() { EventId = model.Id });
-      var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = existingEvent.CampaignId });
-      var newEvent = buildNewEventDetailsModel(existingEvent, model);
-
-      var errors = _eventDetailModelValidator.Validate(newEvent, campaign);
-      errors.ForEach(e => ModelState.AddModelError(e.Key, e.Value));
-
-      if (ModelState.IsValid)
-      {
-        var id = await _mediator.SendAsync(new DuplicateEventCommand { DuplicateEventModel = model });
-
-        return RedirectToAction(nameof(Details), new { area = "Admin", id = id });
-      }
-
-      return View(model);
-    }
-
-    private EventEditModel buildNewEventDetailsModel(EventEditModel existingEvent, DuplicateEventModel newEventDetails)
-    {
-      existingEvent.Id = 0;
-      existingEvent.Name = newEventDetails.Name;
-      existingEvent.Description = newEventDetails.Description;
-      existingEvent.StartDateTime = newEventDetails.StartDateTime;
-      existingEvent.EndDateTime = newEventDetails.EndDateTime;
-
-      return existingEvent;
-    }
-
-    // GET: Event/Delete/5
-    [ActionName("Delete")]
-    public async Task<IActionResult> Delete(int id)
-    {
-      var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = id });
-      if (campaignEvent == null)
-      {
-        return NotFound();
-      }
-
-      if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      return View(campaignEvent);
-    }
-
-    // POST: Event/Delete/5
-    [HttpPost, ActionName("Delete")]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> DeleteConfirmed(int id)
-    {
-      //TODO: Should be using an EventSummaryQuery here
-      var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = id });
-      if (campaignEvent == null)
-      {
-        return NotFound();
-      }
-
-      if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      await _mediator.SendAsync(new DeleteEventCommand { EventId = id });
-
-      return RedirectToAction(nameof(CampaignController.Details), "Campaign", new { area = "Admin", id = campaignEvent.CampaignId });
-    }
-
-    [HttpGet]
-    public IActionResult Assign(int id)
-    {
-      var campaignEvent = GetEventBy(id);
-      if (campaignEvent == null)
-      {
-        return NotFound();
-      }
-
-      if (!User.IsOrganizationAdmin(campaignEvent.Campaign.ManagingOrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      var model = new EventViewModel(campaignEvent);
-      model.Tasks = model.Tasks.OrderBy(t => t.StartDateTime).ThenBy(t => t.Name).ToList();
-      model.Volunteers = campaignEvent.UsersSignedUp.Select(u => u.User).ToList();
-
-      return View(model);
-    }
-
-    [HttpPost]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> MessageAllVolunteers(MessageEventVolunteersModel model)
-    {
-      if (!ModelState.IsValid)
-      {
-        return BadRequest(ModelState);
-      }
-
-      //TODO: Query only for the organization Id rather than the whole event detail
-      var campaignEvent = await _mediator.SendAsync(new EventDetailQuery { EventId = model.EventId });
-      if (campaignEvent == null)
-      {
-        return NotFound();
-      }
-
-      if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
-      {
-        return Unauthorized();
-      }
-
-      await _mediator.SendAsync(new MessageEventVolunteersCommand { Model = model });
-
-      return Ok();
-    }
-
-    [HttpPost]
-    [ValidateAntiForgeryToken]
-    public async Task<IActionResult> PostEventFile(int id, IFormFile file)
-    {
-      var campaignEvent = GetEventBy(id);
-
-      campaignEvent.ImageUrl = await _imageService.UploadEventImageAsync(campaignEvent.Id, campaignEvent.Campaign.ManagingOrganizationId, file);
-      await _mediator.SendAsync(new UpdateEvent { Event = campaignEvent });
-
-      return RedirectToRoute(new { controller = "Event", Area = "Admin", action = nameof(Edit), id = id });
-    }
-
-    private Event GetEventBy(int eventId)
-    {
-      //TODO: refactor message to async when IAllReadyDataAccess read ops are made async
-      return _mediator.Send(new EventByIdQuery { EventId = eventId });
-    }
-  }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -136,7 +136,7 @@ namespace AllReady.Areas.Admin.Controllers
                 return Unauthorized();
             }
 
-            var model = await BuildSelectItineraryRequestsModel(id, new RequestSearchCriteria());
+            var model = await BuildSelectItineraryRequestsModel(id, new RequestSearchCriteria { Status = RequestStatus.Unassigned });
 
             return View("SelectRequests", model);
         }
@@ -146,7 +146,7 @@ namespace AllReady.Areas.Admin.Controllers
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> SelectRequests(int id, SelectItineraryRequestsModel model)
         {
-            var newModel = await BuildSelectItineraryRequestsModel(id, new RequestSearchCriteria { Keywords = model.KeywordsFilter });
+            var newModel = await BuildSelectItineraryRequestsModel(id, new RequestSearchCriteria { Status = RequestStatus.Unassigned, Keywords = model.KeywordsFilter });
 
             return View("SelectRequests", newModel);
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventRequestsQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventRequestsQuery.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Areas.Admin.Models.EventViewModels;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Events
+{
+    public class EventRequestsQuery : IAsyncRequest<EventRequestsViewModel>
+    {
+        public int EventId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventRequestsQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventRequestsQueryHandler.cs
@@ -1,0 +1,36 @@
+﻿using AllReady.Areas.Admin.Models.EventViewModels;
+using AllReady.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Events
+{
+    public class EventRequestsQueryHandler : IAsyncRequestHandler<EventRequestsQuery, EventRequestsViewModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public EventRequestsQueryHandler(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<EventRequestsViewModel> Handle(EventRequestsQuery message)
+        {
+            return await _context.Events
+                .AsNoTracking()
+                .Include(rec => rec.Campaign)
+                .Select(rec => new EventRequestsViewModel
+                {
+                    EventId = rec.Id,
+                    EventName = rec.Name,
+                    CampaignId = rec.CampaignId,
+                    CampaignName = rec.Campaign.Name
+                })
+                .Where(rec => rec.EventId == message.EventId)
+                .SingleOrDefaultAsync();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddRequestsCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AddRequestsCommandHandlerAsync.cs
@@ -62,7 +62,7 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                 {
                     orderIndex++;
 
-                    if (request.Status == RequestStatus.UnAssigned)
+                    if (request.Status == RequestStatus.Unassigned)
                     {
                         request.Status = RequestStatus.Assigned;
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveRequestCommandHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveRequestCommandHandlerAsync.cs
@@ -31,7 +31,7 @@ namespace AllReady.Areas.Admin.Features.Itineraries
             }
 
             // Update the request status
-            requestToRemove.Request.Status = RequestStatus.UnAssigned;        
+            requestToRemove.Request.Status = RequestStatus.Unassigned;        
 
             // remove the request to itinerary assignment
             _context.ItineraryRequests.Remove(requestToRemove);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/RequestListItemsQueryHandlerAsync.cs
@@ -19,8 +19,7 @@ namespace AllReady.Areas.Admin.Features.Requests
 
         public async Task<List<RequestListModel>> Handle(RequestListItemsQuery message)
         {
-            var results = _context.Requests.AsNoTracking()
-                .Where(r => r.Status == RequestStatus.UnAssigned);
+            var results = _context.Requests.AsNoTracking();
 
             // Apply filtering based on criteria
             if (message.Criteria.RequestId.HasValue)
@@ -41,6 +40,11 @@ namespace AllReady.Areas.Admin.Features.Requests
             if (message.Criteria.EventId.HasValue)
             {
                 results = results.Where(r => r.EventId == message.Criteria.EventId.Value);
+            }
+
+            if (message.Criteria.Status.HasValue)
+            {
+                results = results.Where(r => r.Status == message.Criteria.Status); ;
             }
 
             if (!string.IsNullOrEmpty(message.Criteria.Keywords))

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventDetailModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventDetailModel.cs
@@ -1,24 +1,103 @@
-﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using AllReady.Areas.Admin.Models.ItineraryModels;
+﻿using AllReady.Areas.Admin.Models.ItineraryModels;
 using AllReady.Models;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace AllReady.Areas.Admin.Models
 {
+    /// <summary>
+    /// Defines data used by the admin event details page
+    /// </summary>
     public class EventDetailModel : EventSummaryModel
     {
+        /// <summary>
+        /// The location of the event being displayed
+        /// </summary>
         [UIHint("Location")]
         public LocationEditModel Location { get; set; }
+
+        /// <summary>
+        /// A list of the tasks currently associated with the event being displayed
+        /// </summary>
         public IList<TaskSummaryModel> Tasks { get; set; } = new List<TaskSummaryModel>();
+
+        /// <summary>
+        /// A list of the volunteers currently registered for the event being displayed
+        /// </summary>
         public IList<string> Volunteers { get; set; } = new List<string>();
 
+        /// <summary>
+        /// A list of the skills required from volunteers of the event being displayed
+        /// </summary>
         [Display(Name = "Required Skills")]
         public IEnumerable<EventSkill> RequiredSkills { get; set; } = new List<EventSkill>();
 
+        /// <summary>
+        /// An enumerable of itineraries associated with the event being displayed
+        /// </summary>
         public IEnumerable<ItineraryListModel> Itineraries { get; set; } = new List<ItineraryListModel>();
 
-        public bool DisplayItineraries => EventType == EventType.Itinerary;
+        /// <summary>
+        /// Indicates whether the event is an itinerary event
+        /// </summary>
+        public bool IsItineraryEvent => EventType == EventType.Itinerary;
 
+        /// <summary>
+        /// The total number of requests associated with the event being displayed
+        /// </summary>
+        public int TotalRequests { get; set; }
+
+        public int UnassignedRequests { get; set; }
+
+        public int AssignedRequests { get; set; }
+
+        public int CompletedRequests { get; set; }
+
+        public int CanceledRequests { get; set; }
+
+        public string UnassignedPercentage
+        {
+            get
+            {
+                var percentage = ((double)UnassignedRequests / (double)TotalRequests) * 100;
+
+                return percentage.ToString("0.0");
+            }
+        }
+
+        public string AssignedPercentage
+        {
+            get
+            {
+                var percentage = ((double)AssignedRequests / (double)TotalRequests) * 100;
+
+                return percentage.ToString("0.0");
+            }
+        }
+
+        public string CompletedPercentage
+        {
+            get
+            {
+                var percentage = ((double)CompletedRequests / (double)TotalRequests) * 100;
+
+                return percentage.ToString("0.0");
+            }
+        }
+
+        public string CanceledPercentage
+        {
+            get
+            {
+                var percentage = ((double)CanceledRequests / (double)TotalRequests) * 100;
+
+                return percentage.ToString("0.0");
+            }
+        }
+
+        /// <summary>
+        /// Model used to add a new itinerary
+        /// </summary>
         public ItineraryEditModel NewItinerary { get; set; } = new ItineraryEditModel();
 
         public string ItinerariesDetailsUrl { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventViewModels/EventRequestsViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventViewModels/EventRequestsViewModel.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using AllReady.Areas.Admin.Models.ItineraryModels;
+
+namespace AllReady.Areas.Admin.Models.EventViewModels
+{
+    /// <summary>
+    /// Defines data used by the admin event request lister page
+    /// </summary>
+    public class EventRequestsViewModel
+    {
+        public int EventId { get; set; }
+        public string EventName { get; set; }
+        public int CampaignId { get; set; }
+        public string CampaignName { get; set; }
+
+        public List<RequestListModel> Requests { get; set; } = new List<RequestListModel>();
+
+        public string PageTitle { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventViewModels/RequestListViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/EventViewModels/RequestListViewModel.cs
@@ -1,0 +1,19 @@
+﻿using AllReady.Models;
+using System;
+
+namespace AllReady.Areas.Admin.Models.EventViewModels
+{
+    public class RequestListViewModel
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+        public string Address { get; set; }
+        public string City { get; set; }
+        public string Postcode { get; set; }
+        public DateTime DateAdded { get; set; }
+        public RequestStatus Status { get; set; }
+
+        public int ItineraryId { get; set; }
+        public string ItineraryName { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/ItineraryDetailsModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/ItineraryModels/ItineraryDetailsModel.cs
@@ -4,9 +4,19 @@ using System.Collections.Generic;
 
 namespace AllReady.Areas.Admin.Models.ItineraryModels
 {
+    /// <summary>
+    /// Defines data used by the admin itinerary details page
+    /// </summary>
     public class ItineraryDetailsModel
     {
+        /// <summary>
+        /// The ID of the itinerary being displayed
+        /// </summary>
         public int Id { get; set; }
+
+        /// <summary>
+        /// The name of the itinerary being displayed
+        /// </summary>
         public string Name { get; set; }
         public DateTime Date { get; set; }
         public int OrganizationId { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/RequestModels/RedCrossRequestMap.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/RequestModels/RedCrossRequestMap.cs
@@ -16,7 +16,7 @@ namespace AllReady.Areas.Admin.Models.RequestModels
 
             // set defaults
             Map(r => r.RequestId).Default(Guid.NewGuid());
-            Map(r => r.Status).Default(RequestStatus.UnAssigned);
+            Map(r => r.Status).Default(RequestStatus.Unassigned);
 
             // map from Red Cross data
             Map(r => r.Name).Name("name");

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/RequestModels/RequestSearchCriteria.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Models/RequestModels/RequestSearchCriteria.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using AllReady.Models;
 
 namespace AllReady.Areas.Admin.Models.RequestModels
 {
@@ -10,5 +11,6 @@ namespace AllReady.Areas.Admin.Models.RequestModels
         public int? EventId { get; set; }
 
         public string Keywords { get; set; }
+        public RequestStatus? Status { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -1,4 +1,5 @@
 @using System.Threading.Tasks
+@using AllReady.Models
 @using AllReady.Security
 @model AllReady.Areas.Admin.Models.EventDetailModel
 @{
@@ -127,7 +128,7 @@
 
 @Html.Partial("~/Areas/Admin/Views/Task/_List.cshtml", Model.Tasks)
 
-@if (Model.DisplayItineraries)
+@if (Model.IsItineraryEvent)
 {
     <div class="row">
         <div class="col-md-12">
@@ -151,11 +152,11 @@
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                     <h4 class="modal-title" id="createItineraryLabel">Create Itinerary</h4>
                 </div>
-                <input type="hidden" id="itineraryDetailUrl" value="@Model.ItinerariesDetailsUrl"/>
+                <input type="hidden" id="itineraryDetailUrl" value="@Model.ItinerariesDetailsUrl" />
 
                 <form asp-area="Admin" asp-controller="Itinerary" asp-action="Create" method="post" >
                     <div class="modal-body">
-                        <input type="hidden" asp-for="NewItinerary.EventId" name="@nameof(Model.NewItinerary.EventId)" >
+                        <input type="hidden" asp-for="NewItinerary.EventId" name="@nameof(Model.NewItinerary.EventId)">
                         <div class="form-group">
                             <label for="@nameof(Model.NewItinerary.Name)" class="control-label">Name</label>
                             <input type="text" class="form-control wide" id="createItineraryModal-name" name="@nameof(Model.NewItinerary.Name)" asp-for="NewItinerary.Name">
@@ -172,6 +173,61 @@
                     </div>
                 </form>
             </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <h3>Requests</h3>
+            &nbsp;
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-5ths col-sm-4 col-xs-12">
+            <a asp-action="Requests" asp-route-id="@Model.Id" class="dashboard-block-link">
+                <div class="dashboard-block">
+                    <div class="overlay"></div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.TotalRequests</span></div>
+                    <div class="dashboard-block-subtext">Total Requests</div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-5ths col-sm-4 col-xs-12">
+            <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Unassigned" class="dashboard-block-link">
+                <div class="dashboard-block">
+                    <div class="overlay"></div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.UnassignedRequests</span> <span class="dashboard-block-main-suffix">(@Model.UnassignedPercentage%)</span></div>
+                    <div class="dashboard-block-subtext">Unassigned</div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-5ths col-sm-4 col-xs-12">
+            <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Assigned"  class="dashboard-block-link">
+                <div class="dashboard-block">
+                    <div class="overlay"></div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.AssignedRequests</span> <span class="dashboard-block-main-suffix">(@Model.AssignedPercentage%)</span></div>
+                    <div class="dashboard-block-subtext">Assigned</div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-5ths col-sm-4 col-xs-12">
+            <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Completed"  class="dashboard-block-link">
+                <div class="dashboard-block">
+                    <div class="overlay"></div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CompletedRequests</span> <span class="dashboard-block-main-suffix">(@Model.CompletedPercentage%)</span></div>
+                    <div class="dashboard-block-subtext">Completed</div>
+                </div>
+            </a>
+        </div>
+        <div class="col-md-5ths col-sm-4 col-xs-12">
+            <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Canceled"  class="dashboard-block-link">
+                <div class="dashboard-block">
+                    <div class="overlay"></div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CanceledRequests</span> <span class="dashboard-block-main-suffix">(@Model.CanceledPercentage%)</span></div>
+                    <div class="dashboard-block-subtext">Canceled</div>
+                </div>
+            </a>
         </div>
     </div>
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -197,8 +197,8 @@
             <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Unassigned" class="dashboard-block-link">
                 <div class="dashboard-block">
                     <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.UnassignedRequests</span> <span class="dashboard-block-main-suffix">(@Model.UnassignedPercentage%)</span></div>
-                    <div class="dashboard-block-subtext">Unassigned</div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.UnassignedRequests</span></div>
+                    <div class="dashboard-block-subtext">@Model.UnassignedPercentage% Unassigned</div>
                 </div>
             </a>
         </div>
@@ -206,8 +206,8 @@
             <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Assigned"  class="dashboard-block-link">
                 <div class="dashboard-block">
                     <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.AssignedRequests</span> <span class="dashboard-block-main-suffix">(@Model.AssignedPercentage%)</span></div>
-                    <div class="dashboard-block-subtext">Assigned</div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.AssignedRequests</span></div>
+                    <div class="dashboard-block-subtext">@Model.AssignedPercentage% Assigned</div>
                 </div>
             </a>
         </div>
@@ -215,8 +215,8 @@
             <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Completed"  class="dashboard-block-link">
                 <div class="dashboard-block">
                     <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CompletedRequests</span> <span class="dashboard-block-main-suffix">(@Model.CompletedPercentage%)</span></div>
-                    <div class="dashboard-block-subtext">Completed</div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CompletedRequests</span></div>
+                    <div class="dashboard-block-subtext">@Model.CompletedPercentage% Completed</div>
                 </div>
             </a>
         </div>
@@ -224,8 +224,8 @@
             <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Canceled"  class="dashboard-block-link">
                 <div class="dashboard-block">
                     <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CanceledRequests</span> <span class="dashboard-block-main-suffix">(@Model.CanceledPercentage%)</span></div>
-                    <div class="dashboard-block-subtext">Canceled</div>
+                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CanceledRequests</span></div>
+                    <div class="dashboard-block-subtext">@Model.CanceledPercentage% Canceled</div>
                 </div>
             </a>
         </div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Requests.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Requests.cshtml
@@ -1,0 +1,60 @@
+@using System.Threading.Tasks
+@using AllReady.Security
+
+@model AllReady.Areas.Admin.Models.EventViewModels.EventRequestsViewModel
+
+@{
+    ViewBag.Title = @Model.PageTitle;
+}
+
+<div class="row">
+    <div class="col-12">
+        <ol class="breadcrumb">
+            <li><a asp-controller="Campaign" asp-action="Index" asp-route-area="Admin">Campaigns</a></li>
+            <li><a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.CampaignId" asp-route-area="Admin">@Model.CampaignName</a></li>
+            <li><a asp-controller="Event" asp-action="Details" asp-route-area="Admin" asp-route-id="@Model.EventId">@Model.EventName</a></li>
+            <li>@Model.PageTitle</li>
+        </ol>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
+        <h2>
+            @Model.PageTitle
+        </h2>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
+        @if (Model.Requests.Count > 0)
+            {
+            <table class="table">
+                <tr>
+                    <th>Request Name</th>
+                    <th>Address</th>
+                    <th>City</th>
+                    <th>Postcode</th>
+                    <th>Date Added</th>
+                </tr>
+                @foreach (var req in Model.Requests)
+                {
+                    <tr>
+                        <td>@req.Name</td>
+                        <td>@req.Address</td>
+                        <td>@req.City</td>
+                        <td>@req.Postcode</td>
+                        <td>@req.DateAdded</td>
+                    </tr>
+                }
+            </table>
+        }
+        else
+        {
+            <br />
+                <p>There are no requests to display</p>
+        }
+
+    </div>
+</div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/SelectRequests.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/SelectRequests.cshtml
@@ -36,14 +36,14 @@
         <div>
             <form asp-area="Admin" asp-controller="Itinerary" asp-action="AddRequests">
                 <div class="row">
-                    <div class="col-12">
+                    <div class="col-md-12">
                         <button type="submit" class="btn btn-primary submit-form">Add Selected Requests</button>
                         <a asp-action="Details" asp-controller="Itinerary" asp-area="Admin" class="btn btn-default">Cancel</a>
                     </div>
                 </div>
 
                 <div class="row">
-                    <div class="col-12">
+                    <div class="col-md-12">
                         @if (Model.Requests.Count > 0)
                         {
                             <table class="table">

--- a/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
@@ -4,7 +4,6 @@ using AllReady.Attributes;
 using Microsoft.AspNetCore.Mvc;
 using AllReady.Models;
 using MediatR;
-using Microsoft.AspNetCore.Identity;
 using AllReady.Features.Requests;
 using AllReady.ViewModels.Requests;
 
@@ -62,13 +61,13 @@ namespace AllReady.Controllers
                 Phone = requestViewModel.Phone,
                 State = requestViewModel.State,
                 Zip = requestViewModel.Zip,
-                Status = RequestStatus.UnAssigned,
+                Status = RequestStatus.Unassigned,
                 Latitude = requestViewModel.Latitude,
                 Longitude = requestViewModel.Longitude
             };
 
             RequestStatus status;
-            if (RequestStatus.TryParse(requestViewModel.Status, out status))
+            if (Enum.TryParse(requestViewModel.Status, out status))
             {
                 request.Status = status;
             }

--- a/AllReadyApp/Web-App/AllReady/Models/RequestStatus.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/RequestStatus.cs
@@ -2,7 +2,7 @@
 {
     public enum RequestStatus
     {
-        UnAssigned = 0,
+        Unassigned = 0,
         Assigned = 1,
         Completed = 2,
         Canceled = 3

--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
@@ -33,6 +33,8 @@
         htbox.allReady.map = htbox.allReady.map || {};
         htbox.allReady.init = htbox.allReady.init || {};
     </script>
+
+    <link href='https://fonts.googleapis.com/css?family=Roboto:300,100' rel='stylesheet' type='text/css'>
 </head>
 <body>
     <header>

--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -548,10 +548,12 @@ a:hover .myevents-block {
 }
 
 .request-filter-section {
+    width: 100%;
     padding-left: 20px;
     padding-right: 20px;
     padding-bottom: 15px;
     border: 1px solid #ab6627;
+    background: rgba(171, 102, 39, 0.14);
     margin-top: 10px;
     margin-bottom: 25px;
 }
@@ -580,3 +582,114 @@ a:hover .myevents-block {
         margin-bottom: 25px;
         font-size: 20px;
     }
+
+.col-xs-5ths,
+.col-sm-5ths,
+.col-md-5ths,
+.col-lg-5ths {
+    position: relative;
+    min-height: 1px;
+    padding-right: 10px;
+    padding-left: 10px;
+}
+
+.col-xs-5ths {
+    width: 20%;
+    float: left;
+}
+
+@media (min-width: 768px) {
+    .col-sm-5ths {
+        width: 20%;
+        float: left;
+    }
+}
+
+@media (min-width: 992px) {
+    .col-md-5ths {
+        width: 20%;
+        float: left;
+    }
+}
+
+@media (min-width: 1200px) {
+    .col-lg-5ths {
+        width: 20%;
+        float: left;
+    }
+}
+
+.dashboard-block {
+    background: #d58033; /* Old browsers */
+    background-image: -moz-linear-gradient(-45deg, #d58033 0%, #d58033 20%, #e5bc55 100%);
+    background-image: -webkit-linear-gradient(-45deg, #d58033 0%,#d58033 20%,#e5bc55 100%);
+    background-image: linear-gradient(135deg, #d58033 0%,#d58033 20%,#e5bc55 100%);
+    filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#d58033', endColorstr='#e5bc55', GradientType=1);
+    background-size: cover;
+    background-position: center;
+    background-attachment: fixed; /* <- here it is */
+    width: 100%;
+    height: 170px;
+    text-align: center;
+    display: flex;
+    -webkit-box-orient: vertical;
+    -webkit-box-direction: normal;
+    flex-direction: column;
+    -webkit-box-pack: center;
+    justify-content: center;
+    -webkit-box-align: center;
+    align-items: center;
+    z-index: 1;
+    position: relative;
+    text-transform: uppercase;
+    color: #fff;
+    transition: 0.3s ease;
+    margin-bottom: 14px;
+}
+
+    .dashboard-block:before {
+        display: block;
+        content: " ";
+        position: absolute;
+        z-index: -1;
+        background: #000;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        opacity: 0;
+        transition: 0.3s ease;
+    }
+
+    .dashboard-block:hover:before {
+        opacity: 0.2;
+    }
+
+    .dashboard-block .dashboard-block-main {
+        font-family: Roboto, sans-serif;
+        margin-top: -10px;
+    }
+
+        .dashboard-block .dashboard-block-main .dashboard-block-main-text {
+            font-size: 5.6rem;
+            font-weight: 100;
+            text-align: left;
+        }
+
+        .dashboard-block .dashboard-block-main .dashboard-block-main-suffix {
+            font-size: 2.0rem;
+            font-weight: 100;
+            text-align: left;
+            text-transform: initial;
+        }
+
+    .dashboard-block .dashboard-block-subtext {
+        font-size: 1.3rem;
+        font-weight: 300;
+        text-align: left;
+        white-space: nowrap;
+    }
+
+.dashboard-block-link:hover {
+    text-decoration: none;
+}

--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -693,3 +693,4 @@ a:hover .myevents-block {
 .dashboard-block-link:hover {
     text-decoration: none;
 }
+


### PR DESCRIPTION
Closes #1045

Summary of changes:

Updated the event details admin page to include a dashboard style summary of the requests which are linked to the event - Includes counts and percentages

![image](https://cloud.githubusercontent.com/assets/3669103/17552373/8c1a94b8-5ef7-11e6-98e8-e449cdfda2a1.png)

Clicking on one of the dashboard tiles takes you to a new requests listing page for the events filtered based on the status that was clicked.

This is a fairly basic list at this stage. I have used the status string in the routing so that the page can be bookmarked.

![image](https://cloud.githubusercontent.com/assets/3669103/17552081/9cfccd8e-5ef5-11e6-9b2f-a34b0c501d86.png)

**Possible future ideas / enhancements:**

- Adding links to the other statuses directly from this page to make navigation quicker. Possibly could have a tabbed style layout.

- For "assigned" requests, include details of the Itinerary that the request is assigned to. (currently the domain model may need a little tweaking to make this simpler - I'll review).

- Include a link for each request to view/edit the request. Would it be preferred to link to a view page first and from that page have an edit button? Or have two buttons / links for each specifically to reduce clicks. I suspect editing a request will not be a common scenario. 

- Include ability to cancel requests from this list.

- Include ability to quick assign a request to an itinerary

@tonysurma - If you can advise on these thoughts I will establish some new issues to start the work on these as necessary.