### PR TITLE
Issue 519 Fixed 

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Campaign/CampaignSummaryViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Campaign/CampaignSummaryViewModel.cs
@@ -8,6 +8,8 @@ namespace AllReady.Areas.Admin.ViewModels.Campaign
 {
     public class CampaignSummaryViewModel: IPrimaryContactViewModel
     {
+        private const int EVENT_DAYS_STD = 30;
+
         public CampaignSummaryViewModel()
         {
             this.CampaignImpact = new CampaignImpact();
@@ -78,5 +80,16 @@ namespace AllReady.Areas.Admin.ViewModels.Campaign
         public bool Locked { get; set; }
 
         public bool Featured { get; set; }
+
+        public int DefaultEventDays
+        {
+            get
+            {
+                // At some point an enumeration could be added to allow an admin to determine the priority
+                // of the campaign which could affect this value that would translate to the initial value for
+                // an event's End Date
+                return EVENT_DAYS_STD;
+            }
+        }
     }
 }


### PR DESCRIPTION
Added check to Campaign Event to make sure that the Start Date is not… set prior to the Campaign's Start Date.  Also added a default End Date of 30 days from the Start Date.

A couple of questions/concerns that I had on the matter:

1. Should an error occur if the admin selects an Activity Start Date that exceeds the Campaign End Date?  Similarly, should an error occur if the admin selects an Activity End Date that exceeds the Campaign End Date?

2. If the defaulted Activity End Date exceeds the Campaign End Date, should the Campaign End Date be used instead?