### PR TITLE
Removing Event Volunteer Limit

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CampaignDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CampaignDetailQueryHandler.cs
@@ -11,7 +11,7 @@ namespace AllReady.Areas.Admin.Features.Campaigns
 {
     public class CampaignDetailQueryHandler : IAsyncRequestHandler<CampaignDetailQuery, CampaignDetailViewModel>
     {
-        private AllReadyContext _context;
+        private readonly AllReadyContext _context;
 
         public CampaignDetailQueryHandler(AllReadyContext context)
         {
@@ -65,7 +65,6 @@ namespace AllReady.Areas.Admin.Features.Campaigns
                         OrganizationId = campaign.ManagingOrganizationId,
                         OrganizationName = campaign.ManagingOrganization.Name,
                         ImageUrl = a.ImageUrl,
-                        UsersSignedUp = a.UsersSignedUp,
                         IsLimitVolunteers = a.IsLimitVolunteers,
                         IsAllowWaitList = a.IsAllowWaitList
                     })

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EditEventCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EditEventCommandHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
-using AllReady.Areas.Admin.Models;
 using AllReady.Extensions;
 using AllReady.Models;
 using MediatR;
@@ -11,7 +10,7 @@ namespace AllReady.Areas.Admin.Features.Events
 {
     public class EditEventCommandHandler : IAsyncRequestHandler<EditEventCommand, int>
     {
-        private AllReadyContext _context;
+        private readonly AllReadyContext _context;
 
         public EditEventCommandHandler(AllReadyContext context)
         {
@@ -35,7 +34,6 @@ namespace AllReady.Areas.Admin.Features.Events
             campaignEvent.CampaignId = message.Event.CampaignId;
             
             campaignEvent.ImageUrl = message.Event.ImageUrl;
-            campaignEvent.NumberOfVolunteersRequired = message.Event.NumberOfVolunteersRequired;
 
             if (campaignEvent.IsLimitVolunteers != message.Event.IsLimitVolunteers || campaignEvent.IsAllowWaitList != message.Event.IsAllowWaitList)
             {
@@ -43,7 +41,7 @@ namespace AllReady.Areas.Admin.Features.Events
                 campaignEvent.IsLimitVolunteers = message.Event.IsLimitVolunteers;
                 
                 // cascade values to all tasks associated with this event
-                foreach (var task in _context.Tasks.Where(task => task.Event.Id == campaignEvent.Id))
+                foreach (var task in campaignEvent.Tasks)
                 {
                     task.IsLimitVolunteers = campaignEvent.IsLimitVolunteers;
                     task.IsAllowWaitList = campaignEvent.IsAllowWaitList;
@@ -81,6 +79,7 @@ namespace AllReady.Areas.Admin.Features.Events
         {
             return await _context.Events
                 .Include(a => a.RequiredSkills)
+                .Include(a => a.Tasks)
                 .SingleOrDefaultAsync(c => c.Id == message.Event.Id)
                 .ConfigureAwait(false);
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventDetailQueryHandler.cs
@@ -40,8 +40,6 @@ namespace AllReady.Areas.Admin.Features.Events
                     TimeZoneId = campaignEvent.Campaign.TimeZoneId,
                     StartDateTime = campaignEvent.StartDateTime,
                     EndDateTime = campaignEvent.EndDateTime,
-                    Volunteers = campaignEvent.UsersSignedUp.Select(u => u.User.UserName).ToList(),
-                    NumberOfVolunteersRequired = campaignEvent.NumberOfVolunteersRequired,
                     IsLimitVolunteers = campaignEvent.IsLimitVolunteers,
                     IsAllowWaitList = campaignEvent.IsAllowWaitList,
                     Location = campaignEvent.Location.ToEditModel(),
@@ -120,7 +118,6 @@ namespace AllReady.Areas.Admin.Features.Events
                 .Include(a => a.Tasks).ThenInclude(t => t.AssignedVolunteers).ThenInclude(av => av.User)
                 .Include(a => a.RequiredSkills).ThenInclude(s => s.Skill).ThenInclude(s => s.ParentSkill)
                 .Include(a => a.Location)
-                .Include(a => a.UsersSignedUp).ThenInclude(a => a.User)
                 .Include(a => a.Itineraries).ThenInclude(a => a.TeamMembers)
                 .Include(a => a.Itineraries).ThenInclude(a => a.Requests)
                 .SingleOrDefaultAsync(a => a.Id == message.EventId)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventEditQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventEditQueryHandlerAsync.cs
@@ -36,7 +36,6 @@ namespace AllReady.Areas.Admin.Features.Events
                     TimeZoneId = campaignEvent.Campaign.TimeZoneId,
                     StartDateTime = campaignEvent.StartDateTime,
                     EndDateTime = campaignEvent.EndDateTime,
-                    NumberOfVolunteersRequired = campaignEvent.NumberOfVolunteersRequired,
                     IsLimitVolunteers = campaignEvent.IsLimitVolunteers,
                     IsAllowWaitList = campaignEvent.IsAllowWaitList,
                     Location = campaignEvent.Location.ToEditModel(),

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventSummaryQueryHandlerAsync.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventSummaryQueryHandlerAsync.cs
@@ -36,7 +36,6 @@ namespace AllReady.Areas.Admin.Features.Events
                     TimeZoneId = campaignEvent.Campaign.TimeZoneId,
                     StartDateTime = campaignEvent.StartDateTime,
                     EndDateTime = campaignEvent.EndDateTime,
-                    NumberOfVolunteersRequired = campaignEvent.NumberOfVolunteersRequired,
                     IsLimitVolunteers = campaignEvent.IsLimitVolunteers,
                     IsAllowWaitList = campaignEvent.IsAllowWaitList,
                     ImageUrl = campaignEvent.ImageUrl,

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Event/EventDetailViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Event/EventDetailViewModel.cs
@@ -24,11 +24,6 @@ namespace AllReady.Areas.Admin.ViewModels.Event
         public IList<TaskSummaryViewModel> Tasks { get; set; } = new List<TaskSummaryViewModel>();
 
         /// <summary>
-        /// A list of the volunteers currently registered for the event being displayed
-        /// </summary>
-        public IList<string> Volunteers { get; set; } = new List<string>();
-
-        /// <summary>
         /// A list of the skills required from volunteers of the event being displayed
         /// </summary>
         [Display(Name = "Required Skills")]

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Shared/EventSummaryViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Shared/EventSummaryViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using AllReady.Models;
 
@@ -21,6 +20,7 @@ namespace AllReady.Areas.Admin.ViewModels.Shared
 
         [Display(Name = "Campaign")]
         public int CampaignId { get; set; }
+
         [Display(Name = "Campaign")]
         public string CampaignName { get; set; }
 
@@ -35,10 +35,6 @@ namespace AllReady.Areas.Admin.ViewModels.Shared
         [Display(Name = "Browse for image")]
         public string FileUpload { get; set; }
 
-        [Range(1, int.MaxValue, ErrorMessage = "'Volunteers Required' must be greater than 0")]
-        [Display(Name = "Volunteers Required")]
-        public int NumberOfVolunteersRequired { get; set; }
-        
         public string TimeZoneId { get; set; }
 
         [MaxLength(150)]
@@ -46,17 +42,15 @@ namespace AllReady.Areas.Admin.ViewModels.Shared
 
         [Display(Name = "Start Date")]
         public DateTimeOffset StartDateTime { get; set; }
+
         [Display(Name = "End Date")]
         public DateTimeOffset EndDateTime { get; set; }
-        [Display(Name = "Enforce Volunteer Limit")]
+
+        [Display(Name = "Enforce volunteer limit on tasks")]
         public bool IsLimitVolunteers { get; set; } = true;
 
-        [Display(Name = "Allow Wait List")]
-        public List<EventSignup> UsersSignedUp { get; set; } = new List<EventSignup>();
-        public bool IsAllowWaitList { get; set; } = true;
-        public int NumberOfUsersSignedUp => UsersSignedUp.Count;
-        public bool IsFull => NumberOfUsersSignedUp >= NumberOfVolunteersRequired;
-        public bool IsAllowSignups => !IsLimitVolunteers || !IsFull || IsAllowWaitList;
-
+        // NOTE: stevejgordon - 31-08-16 - Defaulting to false at part of work on #919 since the code to ensure this is working doesn't seem to be fully in place.
+        [Display(Name = "Allow waiting list for tasks")]
+        public bool IsAllowWaitList { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -1,11 +1,12 @@
 @using System.Threading.Tasks
-@using AllReady.Models
 @using AllReady.Security
 @model AllReady.Areas.Admin.ViewModels.Event.EventDetailViewModel
+
 @{
     ViewBag.Title = Model.Name;
     var userTimeZoneId = User.GetTimeZoneId();
 }
+
 <div class="row">
     <div class="col-12">
         <ol class="breadcrumb">
@@ -58,34 +59,13 @@
         </div>
     </div>
 }
-<div class="row">
-    <div class="col-md-12">
-        <h3>
-            Volunteers @if (Model.NumberOfVolunteersRequired > 0)
-            {
-                <span class="text-muted">(@Model.NumberOfVolunteersRequired Required)</span>
-            } <button type="button" class="btn btn-primary" disabled="@(!Model.Volunteers.Any())" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button>
-        </h3>
-        @if (Model.Volunteers == null || Model.Volunteers.Count == 0)
-        {
-            <text>No volunteers yet. </text>
-        }
-        else
-        {
-            <ul>
-                @foreach (var volunteer in Model.Volunteers)
-                {
-                    <li><strong>@volunteer</strong></li>
-                }
-            </ul>
-        }
-    </div>
-</div>
+
 <div class="row">
     <div class="col-md-12">
         <h3>Tasks</h3>
     </div>
 </div>
+
 <div class="row">
     <div class="col-md-12">
         <a asp-area="Admin" asp-controller="Task" asp-action="Create" asp-route-eventId="@Model.Id" class="btn btn-default">Create Task</a>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Edit.cshtml
@@ -36,7 +36,7 @@
             {
                 <li>Create New Event</li>
             }
-            
+
         </ol>
     </div>
 </div>
@@ -86,14 +86,6 @@
                 </div>
             </div>
             <div class="form-group">
-                <label asp-for="NumberOfVolunteersRequired" class="control-label col-md-2"></label>
-                <div class="col-md-10">
-                    <input asp-for="NumberOfVolunteersRequired" class="form-control"  min="1" />
-                    <span asp-validation-for="NumberOfVolunteersRequired" class="text-danger"></span>
-                </div>
-            </div>
-
-            <div class="form-group">
                 <label asp-for="IsLimitVolunteers" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="IsLimitVolunteers" type="checkbox" class="form-control" />
@@ -103,15 +95,15 @@
 
             <!-- Uncomment this code when wait list functionality is completed -->
             @*@{
-                    var displaySetting = Model.IsLimitVolunteers ? "" : "style=display:none";
-                }
-                <div id="IsAllowWaitListControl" class="form-group" @displaySetting>
-                    <label asp-for="IsAllowWaitList" class="control-label col-md-2"></label>
-                    <div class="col-md-10">
-                        <input asp-for="IsAllowWaitList" type="checkbox" class="form-control" />
-                        <span asp-validation-for="IsAllowWaitList" class="text-danger"></span>
-                    </div>
-                </div>*@
+                var displaySetting = Model.IsLimitVolunteers ? "" : "style=display:none";
+            }
+            <div id="IsAllowWaitListControl" class="form-group" @displaySetting>
+                <label asp-for="IsAllowWaitList" class="control-label col-md-2"></label>
+                <div class="col-md-10">
+                    <input asp-for="IsAllowWaitList" type="checkbox" class="form-control" />
+                    <span asp-validation-for="IsAllowWaitList" class="text-danger"></span>
+                </div>
+            </div>*@
 
             <div class="form-group">
                 <label asp-for="StartDateTime" class="control-label col-md-2"></label>
@@ -152,52 +144,52 @@
             <div class="form-group">
                 <label asp-for="Location.Address1" class="control-label col-md-2"></label>
                 <div class="col-md-10">
-                @if (Model.EventType == EventType.Rally)
-                {
-                    <input asp-for="Location.Address1" class="form-control  location-address1"  data-val="true" data-val-required="The Address1 field is required." type="text" />
-                    <span asp-validation-for="Location.Address1" class="text-danger col-md-10"/>
+                    @if (Model.EventType == EventType.Rally)
+                    {
+                        <input asp-for="Location.Address1" class="form-control  location-address1" data-val="true" data-val-required="The Address1 field is required." type="text" />
+                        <span asp-validation-for="Location.Address1" class="text-danger col-md-10" />
 
-                }
-                else
-                {
-                    <input asp-for="Location.Address1" class="form-control" />
-                    <span asp-validation-for="Location.Address1" class="text-danger col-md-10"/>
-                }
+                    }
+                    else
+                    {
+                        <input asp-for="Location.Address1" class="form-control" />
+                        <span asp-validation-for="Location.Address1" class="text-danger col-md-10" />
+                    }
                 </div>
             </div>
             <div class="form-group">
                 <label asp-for="Location.Address2" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="Location.Address2" class="form-control" />
-                    <span asp-validation-for="Location.Address2"  class="text-danger col-md-10"/>
+                    <span asp-validation-for="Location.Address2" class="text-danger col-md-10" />
                 </div>
             </div>
             <div class="form-group">
                 <label asp-for="Location.City" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="Location.City" class="form-control" />
-                    <span asp-validation-for="Location.City" class="text-danger col-md-10"/>
+                    <span asp-validation-for="Location.City" class="text-danger col-md-10" />
                 </div>
             </div>
             <div class="form-group">
                 <label asp-for="Location.State" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="Location.State" class="form-control" />
-                    <span asp-validation-for="Location.State" class="text-danger col-md-10"/>
+                    <span asp-validation-for="Location.State" class="text-danger col-md-10" />
                 </div>
             </div>
             <div class="form-group">
                 <label asp-for="Location.PostalCode" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="Location.PostalCode" class="form-control" />
-                    <span asp-validation-for="Location.PostalCode" class="text-danger col-md-10"/>
+                    <span asp-validation-for="Location.PostalCode" class="text-danger col-md-10" />
                 </div>
             </div>
             <div class="form-group">
                 <label asp-for="Location.Country" class="control-label col-md-2"></label>
                 <div class="col-md-10">
                     <input asp-for="Location.Country" class="form-control" />
-                    <span asp-validation-for="Location.Country" class="text-danger col-md-10"/>
+                    <span asp-validation-for="Location.Country" class="text-danger col-md-10" />
                 </div>
             </div>
         </div>
@@ -248,7 +240,7 @@
             });
 
         (function (ko, $, requiredSkills, availableSkills) {
-            
+
             function AdminEventViewModel(requiredSkills, availableSkills) {
 
                 function RequiredSkillObservable(skillModel) {

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyTask.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyTask.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
-using System.Linq;
 using AllReady.ViewModels.Task;
 
 namespace AllReady.Models
@@ -22,7 +21,7 @@ namespace AllReady.Models
         public List<TaskSignup> AssignedVolunteers { get; set; } = new List<TaskSignup>();
         public List<TaskSkill> RequiredSkills { get; set; } = new List<TaskSkill>();
         public bool IsLimitVolunteers { get; set; } = true;
-        public bool IsAllowWaitList { get; set; } = true;
+        public bool IsAllowWaitList { get; set; }
 
         [NotMapped]
         public int NumberOfUsersSignedUp => AssignedVolunteers.Count;

--- a/AllReadyApp/Web-App/AllReady/ViewModels/Task/TaskViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Task/TaskViewModel.cs
@@ -114,7 +114,7 @@ namespace AllReady.ViewModels.Task
      
         public int AcceptedVolunteerCount => AssignedVolunteers?.Where(v => v.Status == "Accepted").Count() ?? 0;
         public bool IsLimitVolunteers { get; set; } = true;
-        public bool IsAllowWaitList { get; set; } = true;
+        public bool IsAllowWaitList { get; set; }
         public int NumberOfUsersSignedUp { get; set; }
         public bool IsFull => NumberOfUsersSignedUp >= NumberOfVolunteersRequired;
         public int AmountOfVolunteersNeeded => NumberOfVolunteersRequired - NumberOfUsersSignedUp;

--- a/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
@@ -288,7 +288,6 @@
 {
     @Html.Partial("_VolunteerModal", Model)
 
-
     <!-- CannotComplete Modal -->
     <div class="modal fade" id="CannotCompleteModal" tabindex="-1" role="dialog">
         <div class="modal-dialog" role="document">


### PR DESCRIPTION
Fixes #919 

After discussion with @tonysurma this PR is limited to removing the UI and model properties for the concept of a volunteer limit on events. Events don't allow direct signup and all signups are at the task level. Each task will maintain it's own limit.

The event UI for enforcing volunteer limits remains and applies to all tasks belonging to that event. Therefore if this is enabled for the event, all tasks will enforce a signup limit as per their own volunteer limit property.

There is also the concept on the model for allowing a waiting list. However this appears incomplete and the UI is not implemented. I have left the property on the model which defaults to false until this is completed.

The event details view model and view no longer expose a list of volunteers for an event. We can later review adding this back by building the volunteer list from all of the task signups.

Most importantly we still have code left in place which updates an EventSignups table. I started work on removing this table but it started to touch a lot of areas in the code, including notifications. On reflection it requires some thought around how to best update the notifications to work based purely on the task signups and to ensure we don't loose functionality which currently is underpinned by this table.

I do feel that eventual removal of the EventSignups table is the right move since we should be able to work out event level aggregated list of volunteers from the associated tasks. It feels redundant to maintain this longer term.

I suggest this is merged and once we have #1182 also merged we can begin work on steps to remove the EventSignup table.

NOTE: @VishalMadhvani had completed a WIP #980 around this issue.