### PR TITLE
Added check to Campaign Event to make sure that the Start Date is not…

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Campaign/CampaignSummaryViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Campaign/CampaignSummaryViewModel.cs
@@ -79,5 +79,13 @@ namespace AllReady.Areas.Admin.ViewModels.Campaign
         public bool Locked { get; set; }
 
         public bool Featured { get; set; }
+
+        private const int EVENT_DAYS_STD = 30;
+
+        // At some point an enumeration could be added to allow an admin to determine the priority
+        // of the campaign which could affect this value that would translate to the initial value for
+        // an event's End Date
+        public int DefaultEventDays => EVENT_DAYS_STD;
+
     }
 }


### PR DESCRIPTION
… set prior to the Campaign's Start Date. Also added a default End Date of 30 days from the Start Date, thanks @NotTheNull

Fixes #1186 via rebase, Fixes #519