### PR TITLE
Fixing breadcrumb in create/edit task view

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Edit.cshtml
@@ -20,7 +20,6 @@
                 <li><a asp-controller="Task" asp-action="Details" asp-route-id="@Model.Id" asp-area="Admin">@Model.Name</a></li>
                 <li>Edit</li>
             }
-            <li>Edit</li>
         </ol>
     </div>
 </div>


### PR DESCRIPTION
Fixes #1219 

Taking out the trailing "/ Edit" part of the breadcrumb which is not needed.