### PR TITLE
Adding Volunteer Summary for Event Details Page

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/ViewModels/EventDetailViewModelTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/ViewModels/EventDetailViewModelTests.cs
@@ -133,5 +133,33 @@ namespace AllReady.UnitTest.Areas.Admin.ViewModels
 
             result.ShouldBe("20.0");
         }
+
+        [Fact]
+        public void VolunteerFulfilmentPercentage_ReturnsZero_WhenVoluneersRequiredIsZero()
+        {
+            var sut = new EventDetailViewModel
+            {
+                VolunteersRequired = 0,
+                AcceptedVolunteers = 0
+            };
+
+            var result = sut.VolunteerFulfilmentPercentage;
+
+            result.ShouldBe("0.0");
+        }
+
+        [Fact]
+        public void VolunteerFulfilmentPercentage_ReturnsCorrectPercentage()
+        {
+            var sut = new EventDetailViewModel
+            {
+                VolunteersRequired = 10,
+                AcceptedVolunteers = 2
+            };
+
+            var result = sut.VolunteerFulfilmentPercentage;
+
+            result.ShouldBe("20.0");
+        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/EventDetailQueryHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/EventDetailQueryHandlerTests.cs
@@ -1,0 +1,105 @@
+﻿using AllReady.Areas.Admin.Features.Events;
+using AllReady.Models;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+using TaskStatus = AllReady.Areas.Admin.Features.Tasks.TaskStatus;
+
+namespace AllReady.UnitTest.Features.Notifications
+{
+    public class EventDetailQueryHandlerTests : InMemoryContextTest
+    {
+        public EventDetailQueryHandlerTests()
+        {
+            var org = new Organization
+            {
+                Id = 1,
+                Name = "Organization"
+            };
+
+            var campaign = new Campaign
+            {
+                Id = 1,
+                Name = "Campaign",
+                ManagingOrganization = org
+            };
+
+            var campaignEvent = new Models.Event
+            {
+                Id = 1,
+                Name = "Event",
+                Campaign = campaign
+            };
+
+            var task1 = new AllReadyTask
+            {
+                Id = 1,
+                Name = "Task 1",
+                Event = campaignEvent,
+                NumberOfVolunteersRequired = 22
+            };
+
+            var task2 = new AllReadyTask
+            {
+                Id = 2,
+                Name = "Task 2",
+                Event = campaignEvent,
+                NumberOfVolunteersRequired = 8
+            };
+
+            var user = new ApplicationUser { Id = Guid.NewGuid().ToString(), Email = "user@example.com " };
+            var user2 = new ApplicationUser { Id = Guid.NewGuid().ToString(), Email = "user2@example.com " };
+
+            var taskSignup1 = new TaskSignup
+            {
+                User = user,
+                Task = task1,
+                Status = TaskStatus.Accepted.ToString()
+            };
+
+            var taskSignup2 = new TaskSignup
+            {
+                User = user2,
+                Task = task1,
+                Status = TaskStatus.Accepted.ToString()
+            };
+
+            var taskSignup3 = new TaskSignup
+            {
+                User = user,
+                Task = task2,
+                Status = TaskStatus.Accepted.ToString()
+            };
+
+            Context.Add(campaign);
+            Context.Add(campaignEvent);
+            Context.Add(task1);
+            Context.Add(task2);
+            Context.Add(user);
+            Context.Add(user2);
+            Context.Add(taskSignup1);
+            Context.Add(taskSignup2);
+            Context.Add(taskSignup3);
+            Context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task EventDetailQueryHandler_ReturnsCorrectVolunteersRequiredValue()
+        {
+            var handler = new EventDetailQueryHandler(Context);
+            var result = await handler.Handle(new EventDetailQuery { EventId = 1 });
+
+            result.VolunteersRequired.ShouldBe(30);
+        }
+
+        [Fact]
+        public async Task EventDetailQueryHandler_ReturnsCorrectAcceptedVolunteerValue()
+        {
+            var handler = new EventDetailQueryHandler(Context);
+            var result = await handler.Handle(new EventDetailQuery { EventId = 1 });
+
+            result.AcceptedVolunteers.ShouldBe(3);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventDetailQueryHandler.cs
@@ -7,6 +7,7 @@ using AllReady.Areas.Admin.ViewModels.Event;
 using AllReady.Areas.Admin.ViewModels.Itinerary;
 using AllReady.Areas.Admin.ViewModels.Shared;
 using AllReady.Areas.Admin.ViewModels.Task;
+using TaskStatus = AllReady.Areas.Admin.Features.Tasks.TaskStatus;
 
 namespace AllReady.Areas.Admin.Features.Events
 {
@@ -105,6 +106,16 @@ namespace AllReady.Areas.Admin.Features.Events
 
                 result.TotalRequests = result.CompletedRequests + result.CanceledRequests + result.AssignedRequests +
                                        result.UnassignedRequests;
+
+                result.VolunteersRequired = await _context.Tasks.Where(rec => rec.EventId == result.Id).SumAsync(rec => rec.NumberOfVolunteersRequired);
+
+                var acceptedVolunteers = await _context.Tasks
+                    .AsNoTracking()
+                    .Include(rec => rec.AssignedVolunteers)
+                    .Where(rec => rec.EventId == result.Id)
+                    .ToListAsync();
+
+                result.AcceptedVolunteers = acceptedVolunteers.Sum(x => x.AssignedVolunteers.Where(v => v.Status == TaskStatus.Accepted.ToString()).Count());
             }
 
             return result;

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Event/EventDetailViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Event/EventDetailViewModel.cs
@@ -141,6 +141,39 @@ namespace AllReady.Areas.Admin.ViewModels.Event
         /// </summary>
         public ItineraryEditViewModel NewItinerary { get; set; } = new ItineraryEditViewModel();
 
+        /// <summary>
+        /// The number of volunteers required across all tasks for the event
+        /// </summary>
+        public int VolunteersRequired { get; set; }
+
+        /// <summary>
+        /// The number of volunteers assigned to any of the event's tasks (in accepted status)
+        /// </summary>
+        public int AcceptedVolunteers { get; set; }
+
+        /// <summary>
+        /// The calculated percentage of volunteer fulfilment
+        /// </summary>
+        public string VolunteerFulfilmentPercentage
+        {
+            get
+            {
+                var percentage = 0.0;
+
+                if (VolunteersRequired > 0)
+                {
+                    percentage = ((double)AcceptedVolunteers / (double)VolunteersRequired) * 100;
+                }
+
+                return percentage.ToString("0.0");
+            }
+        }
+
+        /// <summary>
+        /// The number of tasks assigned to the event
+        /// </summary>
+        public int TaskCount => Tasks.Count;
+
         public string ItinerariesDetailsUrl { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -62,6 +62,15 @@
 
 <div class="row">
     <div class="col-md-12">
+        <h3>Volunteer Summary</h3>
+        <p>@Model.VolunteersRequired @(Model.VolunteersRequired == 1 ? "volunteer" : "volunteers") are required across @Model.TaskCount @(Model.TaskCount == 1 ? "task" : "tasks").</p>
+        <p>@Model.AcceptedVolunteers @(Model.AcceptedVolunteers == 1 ? "volunteer" : "volunteers") are currently assigned and accepted. This event's volunteer requirement is @Model.VolunteerFulfilmentPercentage% fulfiled.</p>
+    </div>
+</div>
+
+
+<div class="row">
+    <div class="col-md-12">
         <h3>Tasks</h3>
     </div>
 </div>
@@ -116,100 +125,100 @@
         </div>
     </div>
 
-    <div class="row">
-        <div class="col-md-12">
-            <button type="button" class="btn btn-default" data-toggle="modal" data-target="#createItineraryModal">Create Itinerary</button>
-        </div>
-    </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <button type="button" class="btn btn-default" data-toggle="modal" data-target="#createItineraryModal">Create Itinerary</button>
+                </div>
+            </div>
 
-    @Html.Partial("~/Areas/Admin/Views/Itinerary/_List.cshtml", Model.Itineraries)
+            @Html.Partial("~/Areas/Admin/Views/Itinerary/_List.cshtml", Model.Itineraries)
 
     <!-- Create Itinerary Modal -->
-    <div class="modal fade" id="createItineraryModal" tabindex="-1" role="dialog" aria-labelledby="createItineraryLabel">
-        <div class="modal-dialog" role="document">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title" id="createItineraryLabel">Create Itinerary</h4>
-                </div>
-                <input type="hidden" id="itineraryDetailUrl" value="@Model.ItinerariesDetailsUrl" />
+            <div class="modal fade" id="createItineraryModal" tabindex="-1" role="dialog" aria-labelledby="createItineraryLabel">
+                <div class="modal-dialog" role="document">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                            <h4 class="modal-title" id="createItineraryLabel">Create Itinerary</h4>
+                        </div>
+                        <input type="hidden" id="itineraryDetailUrl" value="@Model.ItinerariesDetailsUrl" />
 
-                <form asp-area="Admin" asp-controller="Itinerary" asp-action="Create" method="post" >
-                    <div class="modal-body">
-                        <input type="hidden" asp-for="NewItinerary.EventId" name="@nameof(Model.NewItinerary.EventId)">
-                        <div class="form-group">
-                            <label for="@nameof(Model.NewItinerary.Name)" class="control-label">Name</label>
-                            <input type="text" class="form-control wide" id="createItineraryModal-name" name="@nameof(Model.NewItinerary.Name)" asp-for="NewItinerary.Name">
-                        </div>
-                        <div class="form-group">
-                            <label for="@nameof(Model.NewItinerary.Date)" class="control-label">Scheduled Date</label>
-                            <input class="form-control" id="createItineraryModal-date" asp-for="NewItinerary.Date" name="@nameof(Model.NewItinerary.Date)" value="@Model.NewItinerary.Date.ToString("yyyy-MM-dd")">
-                        </div>
-                        <div class="alert alert-danger" role="alert"></div>
+                        <form asp-area="Admin" asp-controller="Itinerary" asp-action="Create" method="post">
+                            <div class="modal-body">
+                                <input type="hidden" asp-for="NewItinerary.EventId" name="@nameof(Model.NewItinerary.EventId)">
+                                <div class="form-group">
+                                    <label for="@nameof(Model.NewItinerary.Name)" class="control-label">Name</label>
+                                    <input type="text" class="form-control wide" id="createItineraryModal-name" name="@nameof(Model.NewItinerary.Name)" asp-for="NewItinerary.Name">
+                                </div>
+                                <div class="form-group">
+                                    <label for="@nameof(Model.NewItinerary.Date)" class="control-label">Scheduled Date</label>
+                                    <input class="form-control" id="createItineraryModal-date" asp-for="NewItinerary.Date" name="@nameof(Model.NewItinerary.Date)" value="@Model.NewItinerary.Date.ToString("yyyy-MM-dd")">
+                                </div>
+                                <div class="alert alert-danger" role="alert"></div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                <button type="submit" id="createItinerary" class="btn btn-primary">Save</button>
+                            </div>
+                        </form>
                     </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-                        <button type="submit" id="createItinerary" class="btn btn-primary">Save</button>
-                    </div>
-                </form>
+                </div>
             </div>
-        </div>
-    </div>
 
-    <div class="row">
-        <div class="col-md-12">
-            <h3>Requests</h3>
-            &nbsp;
-        </div>
-    </div>
+            <div class="row">
+                <div class="col-md-12">
+                    <h3>Requests</h3>
+                    &nbsp;
+                </div>
+            </div>
 
-    <div class="row">
-        <div class="col-md-5ths col-sm-4 col-xs-12">
-            <a asp-action="Requests" asp-route-id="@Model.Id" class="dashboard-block-link">
-                <div class="dashboard-block">
-                    <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.TotalRequests</span></div>
-                    <div class="dashboard-block-subtext">Total Requests</div>
+            <div class="row">
+                <div class="col-md-5ths col-sm-4 col-xs-12">
+                    <a asp-action="Requests" asp-route-id="@Model.Id" class="dashboard-block-link">
+                        <div class="dashboard-block">
+                            <div class="overlay"></div>
+                            <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.TotalRequests</span></div>
+                            <div class="dashboard-block-subtext">Total Requests</div>
+                        </div>
+                    </a>
                 </div>
-            </a>
-        </div>
-        <div class="col-md-5ths col-sm-4 col-xs-12">
-            <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Unassigned" class="dashboard-block-link">
-                <div class="dashboard-block">
-                    <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.UnassignedRequests</span></div>
-                    <div class="dashboard-block-subtext">@Model.UnassignedPercentage% Unassigned</div>
+                <div class="col-md-5ths col-sm-4 col-xs-12">
+                    <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Unassigned" class="dashboard-block-link">
+                        <div class="dashboard-block">
+                            <div class="overlay"></div>
+                            <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.UnassignedRequests</span></div>
+                            <div class="dashboard-block-subtext">@Model.UnassignedPercentage% Unassigned</div>
+                        </div>
+                    </a>
                 </div>
-            </a>
-        </div>
-        <div class="col-md-5ths col-sm-4 col-xs-12">
-            <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Assigned"  class="dashboard-block-link">
-                <div class="dashboard-block">
-                    <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.AssignedRequests</span></div>
-                    <div class="dashboard-block-subtext">@Model.AssignedPercentage% Assigned</div>
+                <div class="col-md-5ths col-sm-4 col-xs-12">
+                    <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Assigned" class="dashboard-block-link">
+                        <div class="dashboard-block">
+                            <div class="overlay"></div>
+                            <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.AssignedRequests</span></div>
+                            <div class="dashboard-block-subtext">@Model.AssignedPercentage% Assigned</div>
+                        </div>
+                    </a>
                 </div>
-            </a>
-        </div>
-        <div class="col-md-5ths col-sm-4 col-xs-12">
-            <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Completed"  class="dashboard-block-link">
-                <div class="dashboard-block">
-                    <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CompletedRequests</span></div>
-                    <div class="dashboard-block-subtext">@Model.CompletedPercentage% Completed</div>
+                <div class="col-md-5ths col-sm-4 col-xs-12">
+                    <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Completed" class="dashboard-block-link">
+                        <div class="dashboard-block">
+                            <div class="overlay"></div>
+                            <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CompletedRequests</span></div>
+                            <div class="dashboard-block-subtext">@Model.CompletedPercentage% Completed</div>
+                        </div>
+                    </a>
                 </div>
-            </a>
-        </div>
-        <div class="col-md-5ths col-sm-4 col-xs-12">
-            <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Canceled"  class="dashboard-block-link">
-                <div class="dashboard-block">
-                    <div class="overlay"></div>
-                    <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CanceledRequests</span></div>
-                    <div class="dashboard-block-subtext">@Model.CanceledPercentage% Canceled</div>
+                <div class="col-md-5ths col-sm-4 col-xs-12">
+                    <a asp-action="Requests" asp-route-id="@Model.Id" asp-route-status="@RequestStatus.Canceled" class="dashboard-block-link">
+                        <div class="dashboard-block">
+                            <div class="overlay"></div>
+                            <div class="dashboard-block-main"><span class="dashboard-block-main-text">@Model.CanceledRequests</span></div>
+                            <div class="dashboard-block-subtext">@Model.CanceledPercentage% Canceled</div>
+                        </div>
+                    </a>
                 </div>
-            </a>
-        </div>
-    </div>
+            </div>
 }
 
 @section scripts {


### PR DESCRIPTION
Fixes #1225 

Adds a basic volunteer summary to the event details page.

![image](https://cloud.githubusercontent.com/assets/3669103/18232951/9979c018-72d2-11e6-83f1-e30fe45e5b18.png)