### PR TITLE
Adding manual creation/edit of requests

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/RequestControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/RequestControllerTests.cs
@@ -1,0 +1,139 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using AllReady.Areas.Admin.Controllers;
+using AllReady.Areas.Admin.Features.Events;
+using AllReady.Areas.Admin.Features.Itineraries;
+using AllReady.Areas.Admin.ViewModels.Itinerary;
+using AllReady.Areas.Admin.ViewModels.Request;
+using AllReady.Areas.Admin.ViewModels.Shared;
+using AllReady.UnitTest.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Controllers
+{
+    public class RequestControllerTests
+    {
+        [Fact]
+        public void ControllerHasAreaAtttribute_WithTheCorrectAreaName()
+        {
+            var sut = new RequestController(null);
+            var attribute = sut.GetAttributes().OfType<AreaAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.RouteValue, "Admin");
+        }
+
+        [Fact]
+        public void ControllerHasAreaAuthorizeAttribute_WithCorrectPolicy()
+        {
+            var sut = new RequestController(null);
+            var attribute = sut.GetAttributes().OfType<AuthorizeAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Policy, "OrgAdmin");
+        }
+
+        [Fact]
+        public void ControllerHasRouteAttribute_WithCorrectTemplate()
+        {
+            var sut = new RequestController(null);
+            var attribute = sut.GetAttributes().OfType<RouteAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+            Assert.Equal(attribute.Template, "Admin/Requests");
+        }
+
+        [Fact]
+        public void Create_HasHttpGetAttribute()
+        {
+            var sut = new RequestController(null);
+            var attribute = sut.GetAttributesOn(x => x.Create(It.IsAny<int>())).OfType<HttpGetAttribute>().SingleOrDefault();
+            Assert.NotNull(attribute);
+        }
+
+        [Fact]
+        public void Create_HasRouteAttribute_WithCorrectTemplate()
+        {
+            var sut = new RequestController(null);
+            var routeAttribute = sut.GetAttributesOn(x => x.Create(It.IsAny<int>())).OfType<RouteAttribute>().SingleOrDefault();
+            Assert.NotNull(routeAttribute);
+            Assert.Equal(routeAttribute.Template, "Create");
+        }
+
+        [Fact]
+        public async Task Create_SendsEventSummaryQuery_WithCorrectEventId()
+        {
+            const int id = 1;
+
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(null).Verifiable();
+
+            var sut = new RequestController(mockMediator.Object);
+            await sut.Create(id);
+
+            mockMediator.Verify(x => x.SendAsync(It.Is<EventSummaryQuery>(a => a.EventId == id)), Times.Once);
+        }
+
+        [Fact]
+        public async Task Create_ReturnsBadRequest_WhenEventSummaryQueryReturnsNull()
+        {
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(null).Verifiable();
+
+            var sut = new RequestController(mockMediator.Object);
+            var result = await sut.Create(1);
+
+            var objResult = Assert.IsType<BadRequestObjectResult>(result);
+            objResult.StatusCode.ShouldNotBeNull();
+            objResult.StatusCode.Value.ShouldBe(StatusCodes.Status400BadRequest);
+        }
+
+        [Fact]
+        public async Task DetailsReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        {
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel());
+
+            var sut = new RequestController(mockMediator.Object);
+            sut.MakeUserNotAnOrgAdmin();
+
+            var result = await sut.Create(1);
+
+            var objResult = Assert.IsType<UnauthorizedResult>(result);
+            objResult.StatusCode.ShouldBe(StatusCodes.Status401Unauthorized);
+        }
+
+        [Fact]
+        public async Task DetailsReturnsCorrectViewAndViewModelWhenEventIsNotNullAndUserIsOrgAdmin()
+        {
+            const int eventId = 1;
+            const int orgId = 1;
+            var viewModel = new EventSummaryViewModel { Id = eventId, OrganizationId = orgId };
+
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(viewModel);
+
+            var sut = new RequestController(mockMediator.Object);
+            sut.MakeUserAnOrgAdmin(orgId.ToString());
+
+            var result = await sut.Create(It.IsAny<int>());
+
+            var objResult = Assert.IsType<ViewResult>(result);
+
+            objResult.ViewName.ShouldBe("Edit");
+
+            var resultViewModel = Assert.IsType<EditRequestViewModel>(objResult.ViewData.Model);
+            resultViewModel.EventId.ShouldBe(viewModel.Id);
+            resultViewModel.OrganizationId.ShouldBe(viewModel.OrganizationId);
+
+            var viewBagTitle = objResult.ViewData["Title"];
+            viewBagTitle.ShouldNotBeNull();
+            viewBagTitle.ShouldBe(RequestController.CreateRequestTitle);
+        }
+    }
+}
+

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
@@ -16,6 +16,7 @@ namespace AllReady.Areas.Admin.Controllers
     public class RequestController : Controller
     {
         public static string CreateRequestTitle = "Create New Request";
+        public const string EditRequestPostRouteName = "EditRequestPost";
 
         private readonly IMediator _mediator;
 
@@ -82,7 +83,7 @@ namespace AllReady.Areas.Admin.Controllers
                 return Unauthorized();
             }
 
-            ViewData["Title"] = "Edit" + model.Name;
+            ViewData["Title"] = "Edit " + model.Name;
 
             return View("Edit", model);
         }
@@ -93,7 +94,7 @@ namespace AllReady.Areas.Admin.Controllers
         /// <param name="model">The request edit model</param>
         /// <returns></returns>
         [HttpPost]
-        [Route("Edit", Name = "EditRequestPost")]
+        [Route("Edit", Name = EditRequestPostRouteName)]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(EditRequestViewModel model)
         {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.Events;
+using AllReady.Security;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using AllReady.Areas.Admin.ViewModels.Request;
+
+namespace AllReady.Areas.Admin.Controllers
+{
+    [Area("Admin")]
+    [Authorize("OrgAdmin")]
+    [Route("Admin/Requests")]
+    public class RequestController : Controller
+    {
+        private readonly IMediator _mediator;
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="RequestController"/>.
+        /// </summary>
+        /// <param name="mediator"></param>
+        public RequestController(IMediator mediator)
+        {
+            _mediator = mediator;
+        }
+
+        /// <summary>
+        /// Returns the view to allow a new request to be added.
+        /// </summary>
+        /// <param name="eventId">The id of the event which the request will be linked to.</param>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("Create")]
+        public async Task<IActionResult> Create(int eventId)
+        {
+            var campaignEvent = await _mediator.SendAsync(new EventSummaryQuery { EventId = eventId });
+
+            if (campaignEvent == null)
+            {
+                return BadRequest("Invalid event id");
+            }
+
+            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            var model = new EditRequestViewModel
+            {
+                OrganizationId = campaignEvent.OrganizationId,
+                OrganizationName = campaignEvent.OrganizationName,
+                CampaignId = campaignEvent.CampaignId,
+                CampaignName = campaignEvent.CampaignName,
+                EventId = campaignEvent.Id,
+                EventName = campaignEvent.Name,
+            };
+
+            ViewBag.Title = "Create New Request";
+
+            return View("Edit", model);
+        }
+
+        [HttpPost]
+        [Route("Admin/Request/Create")]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> Edit(EditRequestViewModel model)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
@@ -14,6 +14,8 @@ namespace AllReady.Areas.Admin.Controllers
     [Route("Admin/Requests")]
     public class RequestController : Controller
     {
+        public static string CreateRequestTitle = "Create New Request";
+
         private readonly IMediator _mediator;
 
         /// <summary>
@@ -56,7 +58,7 @@ namespace AllReady.Areas.Admin.Controllers
                 EventName = campaignEvent.Name,
             };
 
-            ViewBag.Title = "Create New Request";
+            ViewBag.Title = CreateRequestTitle;
 
             return View("Edit", model);
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Events;
 using AllReady.Areas.Admin.Features.Requests;
 using AllReady.Security;
@@ -64,12 +65,35 @@ namespace AllReady.Areas.Admin.Controllers
         }
 
         /// <summary>
-        /// Handles edit request POST requests
+        ///  Returns the view to allow a request to be modified.
+        /// </summary>
+        /// <returns></returns>
+        [HttpGet]
+        [Route("Edit/{id}")]
+        public async Task<IActionResult> Edit(Guid id)
+        {
+            var model = await _mediator.SendAsync(new EditRequestQuery() { Id = id });
+
+            if (model == null)
+                return NotFound();
+
+            if (!User.IsOrganizationAdmin(model.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            ViewData["Title"] = "Edit" + model.Name;
+
+            return View("Edit", model);
+        }
+
+        /// <summary>
+        /// Handles edit request POST
         /// </summary>
         /// <param name="model">The request edit model</param>
         /// <returns></returns>
         [HttpPost]
-        [Route("Edit")]
+        [Route("Edit", Name = "EditRequestPost")]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Edit(EditRequestViewModel model)
         {
@@ -92,7 +116,7 @@ namespace AllReady.Areas.Admin.Controllers
 
             await _mediator.SendAsync(new EditRequestCommand { RequestModel = model });
 
-            return RedirectToAction("Details", "Event", new { id = model.EventId });
+            return RedirectToAction("Requests", "Event", new { id = model.EventId });
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommand.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using AllReady.Areas.Admin.ViewModels.Request;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Requests
+{
+    public class EditRequestCommand : IAsyncRequest<Guid>
+    {
+        public EditRequestViewModel RequestModel { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
@@ -21,8 +21,6 @@ namespace AllReady.Areas.Admin.Features.Requests
                 .Include(l => l.Event)
                 .SingleOrDefaultAsync(t => t.RequestId == message.RequestModel.Id).ConfigureAwait(false) ?? _context.Add(new Request()).Entity;
 
-            if (request.RequestId == Guid.Empty) request.RequestId = Guid.NewGuid();
-
             request.EventId = message.RequestModel.EventId;
             request.Address = message.RequestModel.Address;
             request.City = message.RequestModel.City;
@@ -31,8 +29,6 @@ namespace AllReady.Areas.Admin.Features.Requests
             request.Zip = message.RequestModel.Zip;
             request.Email = message.RequestModel.Email;
             request.Phone = message.RequestModel.Phone;
-            request.Status = RequestStatus.Unassigned;
-            request.DateAdded = DateTime.UtcNow;
 
             // todo - longitude and latitude lookup
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AllReady.Areas.Admin.Features.Requests
+{
+    public class EditRequestCommandHandler : IAsyncRequestHandler<EditRequestCommand, Guid>
+    {
+        private readonly AllReadyContext _context;
+
+        public EditRequestCommandHandler(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<Guid> Handle(EditRequestCommand message)
+        {
+            var request = await _context.Requests
+                .Include(l => l.Event)
+                .SingleOrDefaultAsync(t => t.RequestId == message.RequestModel.Id).ConfigureAwait(false) ?? _context.Add(new Request()).Entity;
+
+            if (request.RequestId == Guid.Empty) request.RequestId = Guid.NewGuid();
+
+            request.EventId = message.RequestModel.EventId;
+            request.Address = message.RequestModel.Address;
+            request.City = message.RequestModel.City;
+            request.Name = message.RequestModel.Name;
+            request.State = message.RequestModel.State;
+            request.Zip = message.RequestModel.Zip;
+            request.Email = message.RequestModel.Email;
+            request.Phone = message.RequestModel.Phone;
+            request.Status = RequestStatus.Unassigned;
+            request.DateAdded = DateTime.UtcNow;
+
+            // todo - longitude and latitude lookup
+
+            await _context.SaveChangesAsync();
+
+            return request.RequestId;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestQuery.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using AllReady.Areas.Admin.ViewModels.Request;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Requests
+{
+    public class EditRequestQuery : IAsyncRequest<EditRequestViewModel>
+    {
+        public Guid Id { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestQueryHandler.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading.Tasks;
+using AllReady.Areas.Admin.ViewModels.Request;
+using AllReady.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AllReady.Areas.Admin.Features.Requests
+{
+    public class EditRequestQueryHandler : IAsyncRequestHandler<EditRequestQuery, EditRequestViewModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public EditRequestQueryHandler(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<EditRequestViewModel> Handle(EditRequestQuery message)
+        {
+            var request = await _context.Requests
+                .Include(l => l.Event).ThenInclude(rec => rec.Campaign).ThenInclude(rec => rec.ManagingOrganization)
+                .SingleOrDefaultAsync(t => t.RequestId == message.Id).ConfigureAwait(false);
+
+            if (request == null)
+                return null;
+
+            return new EditRequestViewModel
+            {
+                Address = request.Address,
+                CampaignId = request.Event.CampaignId,
+                CampaignName = request.Event.Campaign.Name,
+                City = request.City,
+                DateAdded = request.DateAdded,
+                Email = request.Email,
+                EventId = request.Event.Id,
+                EventName = request.Event.Name,
+                Id = request.RequestId,
+                Latitude = request.Latitude,
+                Longitude = request.Longitude,
+                OrganizationId = request.Event.Campaign.ManagingOrganizationId,
+                Name = request.Name,
+                OrganizationName = request.Event.Campaign.ManagingOrganization.Name,
+                Phone = request.Phone,
+                Status = request.Status,
+                State = request.State,
+                Zip = request.Zip
+            };
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Request/EditRequestViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Request/EditRequestViewModel.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using AllReady.Models;
+
+namespace AllReady.Areas.Admin.ViewModels.Request
+{
+    public class EditRequestViewModel
+    {
+        public int OrganizationId { get; set; }
+        public string OrganizationName { get; set; }
+        public int CampaignId { get; set; }
+
+        [Display(Name = "Campaign")]
+        public string CampaignName { get; set; }
+        public int EventId { get; set; }
+
+        [Display(Name = "Event")]
+        public string EventName { get; set; }
+
+        public Guid Id { get; set; }
+
+        [Required]
+        public string Name { get; set; }
+
+        [Required]
+        public string Address { get; set; }
+
+        [Required]
+        public string City { get; set; }
+
+        [Required]
+        public string State { get; set; }
+
+        [Required]
+        public string Zip { get; set; }
+
+        [Required]
+        [Phone(ErrorMessage = "Invalid Phone Number")]
+        public string Phone { get; set; }
+
+        [EmailAddress(ErrorMessage = "Invalid Email Address")]
+        public string Email { get; set; }
+
+        [Required]
+        public RequestStatus Status { get; set; } = RequestStatus.Unassigned;
+
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+
+        public DateTime DateAdded { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Requests.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Requests.cshtml
@@ -28,6 +28,12 @@
 
 <div class="row">
     <div class="col-md-12">
+        <a asp-action="Create" asp-controller="Request" asp-area="Admin" asp-route-eventId="@Model.EventId" class="btn btn-default">Create Request</a>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
         <div class="tabbed-nav">
             <nav>
                 <a asp-action="Requests" asp-route-status="" class="@(@Model.CurrentPage == "All" ? "current" : "")">All Requests</a>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Requests.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Requests.cshtml
@@ -61,7 +61,7 @@
                 @foreach (var req in Model.Requests)
                 {
                     <tr>
-                        <td>@req.Name</td>
+                        <td><a asp-action="Edit" asp-controller="Request" asp-route-id="@req.Id">@req.Name</a></td>
                         <td>@req.Address</td>
                         <td>@req.City</td>
                         <td>@req.Postcode</td>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Request/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Request/Edit.cshtml
@@ -1,0 +1,124 @@
+﻿@model AllReady.Areas.Admin.ViewModels.Request.EditRequestViewModel
+
+<div class="row">
+    <div class="col-12">
+        <ol class="breadcrumb">
+            <li><a asp-controller="Campaign" asp-action="Index" asp-route-area="Admin">Campaigns</a></li>
+            <li><a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.CampaignId" asp-route-area="Admin">@Model.CampaignName</a></li>
+            <li><a asp-controller="Event" asp-action="Details" asp-route-id="@Model.EventId" asp-route-area="Admin">@Model.EventName</a></li>
+            @if (Model.Id == Guid.Empty)
+            {
+                <li>Create New Request</li>
+            }
+            else
+            {
+                <li><a asp-controller="Task" asp-action="Details" asp-route-id="@Model.Id" asp-area="Admin">@Model.Name</a></li>
+                <li>Edit</li>
+            }
+        </ol>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-12">
+        <h2>@ViewBag.Title</h2>
+        <br/>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-12">
+        <form asp-controller="Request" asp-action="Edit" asp-area="Admin">
+            <div class="form-horizontal">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+
+                <input type="hidden" asp-for="OrganizationId" />
+                <input type="hidden" asp-for="OrganizationName" />
+                <input type="hidden" asp-for="EventId" />
+                <input type="hidden" asp-for="EventName" />
+                <input type="hidden" asp-for="CampaignId" />
+                <input type="hidden" asp-for="CampaignName" />
+
+                <div class="form-group">
+                    <label asp-for="CampaignName" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <p class="form-control-static">@Model.CampaignName</p>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label asp-for="EventName" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <p class="form-control-static">@Model.EventName</p>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label asp-for="Name" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <input asp-for="Name" class="form-control" />
+                        <span asp-validation-for="Name" class="text-danger"></span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label asp-for="Address" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <input asp-for="Address" class="form-control" />
+                        <span asp-validation-for="Address" class="text-danger"></span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label asp-for="City" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <input asp-for="City" class="form-control" />
+                        <span asp-validation-for="City" class="text-danger"></span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label asp-for="State" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <input asp-for="State" class="form-control" />
+                        <span asp-validation-for="State" class="text-danger"></span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label asp-for="Zip" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <input asp-for="Zip" class="form-control" />
+                        <span asp-validation-for="Zip" class="text-danger"></span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label asp-for="Phone" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <input asp-for="Phone" class="form-control" />
+                        <span asp-validation-for="Phone" class="text-danger"></span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label asp-for="Email" class="control-label col-md-2"></label>
+                    <div class="col-md-10">
+                        <input asp-for="Email" class="form-control" />
+                        <span asp-validation-for="Email" class="text-danger"></span>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="col-md-offset-2 col-md-10">
+                        <button type="submit" class="btn btn-default">Save</button>
+                    </div>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Request/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Request/Edit.cshtml
@@ -1,4 +1,6 @@
-﻿@model AllReady.Areas.Admin.ViewModels.Request.EditRequestViewModel
+﻿@using System.Threading.Tasks
+@using AllReady.Areas.Admin.Controllers
+@model AllReady.Areas.Admin.ViewModels.Request.EditRequestViewModel
 
 <div class="row">
     <div class="col-12">
@@ -28,7 +30,7 @@
 
 <div class="row">
     <div class="col-12">
-        <form asp-route="EditRequestPost" asp-area="Admin">
+        <form asp-route="@RequestController.EditRequestPostRouteName" asp-area="Admin">
             <div class="form-horizontal">
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
                 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Request/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Request/Edit.cshtml
@@ -28,10 +28,11 @@
 
 <div class="row">
     <div class="col-12">
-        <form asp-controller="Request" asp-action="Edit" asp-area="Admin">
+        <form asp-route="EditRequestPost" asp-area="Admin">
             <div class="form-horizontal">
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-
+                
+                <input type="hidden" asp-for="Id" />
                 <input type="hidden" asp-for="OrganizationId" />
                 <input type="hidden" asp-for="OrganizationName" />
                 <input type="hidden" asp-for="EventId" />

--- a/AllReadyApp/Web-App/AllReady/Models/Request.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Request.cs
@@ -19,7 +19,7 @@ namespace AllReady.Models
         public string Zip { get; set; }
         public string Phone { get; set; }
         public string Email { get; set; }
-        public RequestStatus Status { get; set; }
+        public RequestStatus Status { get; set; } = RequestStatus.Unassigned;
 
         // no support yet for spatial types
         public double Latitude { get; set; }
@@ -34,6 +34,6 @@ namespace AllReady.Models
 
         public ICollection<ItineraryRequest> Itineraries { get; set; }
 
-        public DateTime DateAdded { get; set; }
+        public DateTime DateAdded { get; set; } = DateTime.UtcNow;
     }
 }


### PR DESCRIPTION
Fixes #1227 and fixes #1251 

Added initial code to allow the manual creation of a request in the allReady application.

This is accessed from the requests list page for an event by clicking the create request button.

PR updated to include the ability to edit requests.