### PR TITLE
Organization Admin: moved edit btn to left

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Organization/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Organization/Index.cshtml
@@ -13,19 +13,33 @@
     <div class="col-md-12">
         <table class="table table-responsive table-condensed">
             <tr>
-                <th class="col-md-3">
+                <th class="col-md-1">Action
                 </th>
                 <th class="col-md-3">
                     @Html.DisplayNameFor(model => model.Name)
                 </th>
-                <th class="col-md-4">
+                <th class="col-md-3">
                     @Html.DisplayNameFor(model => model.WebUrl)
                 </th>
-                <th class="col-md-2"></th>
+                <th class="col-md-4">
+                    Logo
+                </th>
+                <th class="col-md-1"></th>
             </tr>
             @foreach (var item in Model)
             {
                 <tr>
+                    <td>
+                        <div class="btn-group btn-group-sm row-btn-margin">
+                            <a data-toggle="tooltip" data-placement="top" title="Edit" href="@Url.Action("Edit", "Organization", new {id = item.Id})" class="btn btn-success"><span class="fa fa-edit"></span></a>
+                        </div>
+                    </td>
+                    <td>
+                        <a href="@Url.Action("Details", "Organization", new { id = item.Id })">@item.Name</a>
+                    </td>
+                    <td>
+                        <a href=@item.WebUrl target="_blank">@item.WebUrl</a>
+                    </td>
                     <td>
                         @if (!string.IsNullOrEmpty(item.LogoUrl))
                         {
@@ -35,17 +49,8 @@
                         }
                     </td>
                     <td>
-                        <a href="@Url.Action("Details", "Organization", new { id = item.Id })">@item.Name</a>
-                    </td>
-                    <td>
-                        <a href=@item.WebUrl target="_blank">@item.WebUrl</a>
-                    </td>
-                    <td>
                         <div class="btn-group btn-group-sm row-btn-margin pull-right">
                             <a data-toggle="tooltip" data-placement="top" title="Delete" href="@Url.Action("Delete", "Organization", new { id = item.Id })" class="btn btn-danger"><span class="fa fa-remove"></span></a>
-                        </div>
-                        <div class="btn-group btn-group-sm row-btn-margin pull-right">
-                            <a data-toggle="tooltip" data-placement="top" title="Edit" href="@Url.Action("Edit", "Organization", new {id = item.Id})" class="btn btn-success"><span class="fa fa-edit"></span></a>
                         </div>
                     </td>
                 </tr>


### PR DESCRIPTION
On the Organization admin page created an action column and moved the edit
button into it.  This made it match how the rest of the site worked.

To make the UI look right, I moved the logo to before the delete button.
Also, from a UX perspective it felt like the name was more important than
the logo was so the name should have been the 1st column instead of the
logo.

Closes #1248 