### PR TITLE
Updating project.json to ensure Areas are published

### DIFF
--- a/AllReadyApp/Web-App/AllReady/project.json
+++ b/AllReadyApp/Web-App/AllReady/project.json
@@ -92,7 +92,7 @@
   "publishOptions": {
     "include": [
       "wwwroot",
-      "Views",
+      "**/*.cshtml",
       "appsettings.json",
       "web.config"
     ]


### PR DESCRIPTION
Fixes #1294 

Adding in wildcard for cshtml files to ensure those in the Areas folder are included in build and publish.