### PR TITLE
Adding map to Itinerary Details page

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItineraryDetailQueryHandler.cs
@@ -51,7 +51,9 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                         Name = r.Request.Name,
                         Address = r.Request.Address,
                         City = r.Request.City,
-                        Status = r.Request.Status
+                        Status = r.Request.Status,
+                        Longitude = r.Request.Longitude,
+                        Latitude = r.Request.Latitude
                     }).ToList()
                 })
                 .SingleOrDefaultAsync().ConfigureAwait(false);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -20,7 +20,7 @@
         <h2>
             @Model.Name
             @*<a asp-area="Admin" asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
-            <a asp-area="Admin" asp-controller="Itinerary" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>*@
+                <a asp-area="Admin" asp-controller="Itinerary" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>*@
         </h2>
         <p>Scheduled for @Model.DisplayDate</p>
     </div>
@@ -137,18 +137,18 @@ else
                         </td>
                         <td>
                             <form asp-action="MoveRequestUp" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
-                                <button type="submit" class="btn btn-default submit-form" @if (@request.IsFirst) { <text>disabled</text> }><span class="fa fa-arrow-up"></span></button>
+                                <button type="submit" class="btn btn-default submit-form" @if (@request.IsFirst) { <text> disabled</text> }><span class="fa fa-arrow-up"></span></button>
                             </form>
                             <form asp-action="MoveRequestDown" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
-                                <button type="submit" class="btn btn-default submit-form" @if (@request.IsLast) { <text>disabled</text> }><span class="fa fa-arrow-down"></span></button>
+                                <button type="submit" class="btn btn-default submit-form" @if (@request.IsLast) { <text> disabled</text> }><span class="fa fa-arrow-down"></span></button>
                             </form>
 
                             <a data-toggle="tooltip" data-placement="top" title="Remove from itinerary" asp-action="ConfirmRemoveRequest" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="btn btn-danger right-action-btn"><span class="fa fa-trash"></span></a>
                         </td>
                         <td>
-                         @request.Status
-                            @if(request.Status == RequestStatus.Assigned)
-                            { 
+                            @request.Status
+                            @if (request.Status == RequestStatus.Assigned)
+                            {
                                 <form asp-action="MarkComplete" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
                                     <button type="submit" class="btn btn-success submit-form" title="Mark this request as complete"><span class="fa fa-check"></span></button>
                                 </form>
@@ -160,7 +160,7 @@ else
                                 </form>
                             }
                         </td>
-                    </tr> 
+                    </tr>
                 }
             </table>
         }
@@ -171,4 +171,37 @@ else
         }
     </div>
 </div>
+
+<div id="myMap" style="position:relative;width:100%;height:500px;"></div>
+
+@section scripts {
+    <script type='text/javascript'
+            src='http://www.bing.com/api/maps/mapcontrol?callback=GetMap'
+            async defer></script>
+    <script type='text/javascript'>
+        function GetMap() {
+            renderRequestsMap("myMap", getLocationsFromModelRequests());
+        };
+
+        function getLocationsFromModelRequests() {
+            var requestData = [];
+            @foreach (var request in Model.Requests){
+                @:var reqData = {lat:@request.Latitude, long:@request.Longitude, name:'@request.Name', color:'blue'};
+
+                if (request.Status == RequestStatus.Completed)
+                {
+                    @:reqData.color = 'green';
+                            }
+
+                if (request.Status == RequestStatus.Canceled)
+                {
+                    @:reqData.color = 'red';
+                }
+
+                @:requestData.push(reqData)
+                        }
+            return requestData;
+        }
+    </script>
+}
 

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/site.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/site.js
@@ -16,6 +16,13 @@ var renderBingMap = function (divIdForMap, positionCoordsList) {
     }
 }
 
+var renderRequestsMap = function(divIdForMap, requestData) {
+    if (requestData) {
+        var bingMap = createBingMap(divIdForMap);
+        addRequestPins(bingMap, requestData);
+    }
+}
+
 var getGeoCoordinates = function (address1, address2, city, state, postalCode, country, callbackFunction) {
     var lookupAddress = "";
     lookupAddress = lookupAddress + (address1 != undefined || address1 != null ? " " + address1 : null);
@@ -65,6 +72,19 @@ function createMapLocationsAndAddPushPinsToMap(bingMap, positionCoordsList) {
         bingMap.entities.push(pushpin);
     });
     return microsoftMapsLocations;
+}
+
+function addRequestPins(bingMap, requestData) {
+    var locations = [];
+    $.each(requestData, function (index, data) {
+        var location = new Microsoft.Maps.Location(data.lat, data.long);
+        locations.push(location);
+        var order = index + 1;
+        var pin = new Microsoft.Maps.Pushpin(location, { title: data.name, color: data.color, text: order.toString() });
+        bingMap.entities.push(pin);        
+    });
+    var rect = Microsoft.Maps.LocationRect.fromLocations(locations);
+    bingMap.setView({ bounds: rect, padding: 80 });
 }
 
 function setMapCenterAndZoom(bingMap, microsoftMapsLocations) {


### PR DESCRIPTION
Added a map to the Itinerary Details page which displays all requests for that itinerary.

Requests are colour coded:

Blue = Assigned
Green = Complete
Red = Cancelled

Requests include a number which shows their order.
Pins include the name of the request.
It currently assumes all requests are geocoded with a Lat/Long.

![image](https://cloud.githubusercontent.com/assets/3669103/19280195/a2da4926-8fdc-11e6-9584-438f75a0f801.png)

Fixes #1375
Fixes #1099