### PR TITLE
Adding breadcrumbs to campaign and event details

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Campaign/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Campaign/Details.cshtml
@@ -3,6 +3,14 @@
 @{
     ViewData["Title"] = Model.Name;
 }
+<div class="row">
+    <div class="col-12">
+        <ol class="breadcrumb">
+            <li><a asp-controller="Campaign" asp-action="Index">Campaigns</a></li>
+            <li>@Model.Name</li>
+        </ol>
+    </div>
+</div>
 
 <div class="row">
     <div id="col-main">

--- a/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
@@ -6,6 +6,16 @@
     var userTimeZoneId = User.GetTimeZoneId();
 }
 
+<div class="row">
+    <div class="col-12">
+        <ol class="breadcrumb">
+            <li><a asp-controller="Campaign" asp-action="Index">Campaigns</a></li>
+            <li><a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.CampaignId">@Model.CampaignName</a></li>
+            <li>@Model.Title</li>
+        </ol>
+    </div>
+</div>
+
 <div id="MainView">
 
     @Html.Partial("_Alert")


### PR DESCRIPTION
Fixes #1244

Added breadcrumbs on the public pages to aid navigation.

![image](https://cloud.githubusercontent.com/assets/3669103/19410942/da0efc64-92ef-11e6-93af-ea1c7e2982bc.png)
