### PR TITLE
Reverting changes to the Time tag helper

### DIFF
--- a/AllReadyApp/Web-App/AllReady/TagHelpers/TimeTagHelper.cs
+++ b/AllReadyApp/Web-App/AllReady/TagHelpers/TimeTagHelper.cs
@@ -49,8 +49,9 @@ namespace AllReady.TagHelpers
                 var dateTimeToDisplay = Value.Value;
                 if (!string.IsNullOrEmpty(TargetTimeZoneId))
                 {
-                    _dateTimeOffsetConverter.ConvertDateTimeOffsetTo(TargetTimeZoneId, dateTimeToDisplay);
-
+                    TimeZoneInfo targetTimeZone = TimeZoneInfo.FindSystemTimeZoneById(TargetTimeZoneId);
+                    var targetOffset = targetTimeZone.GetUtcOffset(dateTimeToDisplay);
+                    dateTimeToDisplay = dateTimeToDisplay.ToOffset(targetOffset);
                 }
                 var formattedTime = dateTimeToDisplay.ToString(Format);
                 output.Content.SetContent(formattedTime);


### PR DESCRIPTION
Fixes issue #1388 

The original intention here was to convert the time to the target timezone but at some point the logic was changed and the conversion was incorrect.