### PR TITLE
Fixing Create Request button

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -173,7 +173,7 @@
 
             <div class="row">
                 <div class="col-md-12">
-                    <button type="button" asp-action="Create" asp-controller="Request" asp-area="Admin" asp-route-eventId="@Model.Id" class="btn btn-default">Create Request</button>
+                    <a asp-action="Create" asp-controller="Request" asp-area="Admin" asp-route-eventId="@Model.Id" class="btn btn-default">Create Request</a>
                 </div>
                 &nbsp;
             </div>


### PR DESCRIPTION
Link tag heleper does not target the button tag. It only targets the `<a>`
tag
Fixes bug introduced in PR #1390 