### PR TITLE
Fixing infinite loops in skills hierarchy

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SkillControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SkillControllerTests.cs
@@ -749,8 +749,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         {
             return new List<SkillSummaryViewModel>
             {
-                new SkillSummaryViewModel { Id = 1, HierarchicalName = "Name", OwningOrganizationName = "Org" },
-                new SkillSummaryViewModel { Id = 2, HierarchicalName = "Name 2", OwningOrganizationName = "Org" }
+                new SkillSummaryViewModel { Id = 1, HierarchicalName = "Name", OwningOrganizationName = "Org", DescendantIds=new List<int> () },
+                new SkillSummaryViewModel { Id = 2, HierarchicalName = "Name 2", OwningOrganizationName = "Org", DescendantIds=new List<int> () }
             };
         }
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SkillControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SkillControllerTests.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Mvc.Rendering;
 using System.Linq;
 using AllReady.Areas.Admin.ViewModels.Skill;
 using Microsoft.AspNetCore.Routing;
+using Shouldly;
 
 namespace AllReady.UnitTest.Areas.Admin.Controllers
 {
@@ -428,6 +429,28 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
+        public async Task SkillEditGet_ReturnsEmptyParentSelection_WhenNoValidSkillsReturnedByListQuery()
+        {
+            // Arrange
+            var mockMediator = new Mock<IMediator>();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillEditQuery>())).ReturnsAsync(EditSkillModel());
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillListQuery>())).ReturnsAsync(new List<SkillSummaryViewModel>());
+
+            var sut = new SkillController(mockMediator.Object);
+            var mockContext = MockControllerContextWithUser(SiteAdmin());
+            sut.ControllerContext = mockContext.Object;
+
+            // Act
+            var result = await sut.Edit(1);
+
+            // Assert
+            var viewResult = Assert.IsType<ViewResult>(result);
+            var model = viewResult.Model as SkillEditViewModel;
+
+            model.ParentSelection.ShouldBeEmpty();
+        }
+
+        [Fact]
         public async Task SkillEditPostForOrgAdminWithValidModelStateReturnsRedirectToAction()
         {
             // Arrange
@@ -749,8 +772,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         {
             return new List<SkillSummaryViewModel>
             {
-                new SkillSummaryViewModel { Id = 1, HierarchicalName = "Name", OwningOrganizationName = "Org", DescendantIds=new List<int> () },
-                new SkillSummaryViewModel { Id = 2, HierarchicalName = "Name 2", OwningOrganizationName = "Org", DescendantIds=new List<int> () }
+                new SkillSummaryViewModel { Id = 1, HierarchicalName = "Name", OwningOrganizationName = "Org", DescendantIds = new List<int>() },
+                new SkillSummaryViewModel { Id = 2, HierarchicalName = "Name 2", OwningOrganizationName = "Org", DescendantIds = new List<int>() }
             };
         }
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Skills/SkillListQueryHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Skills/SkillListQueryHandlerTests.cs
@@ -1,8 +1,6 @@
 ﻿using AllReady.Areas.Admin.Features.Skills;
-using AllReady.Models;
 using System.Linq;
 using System.Threading.Tasks;
-using AllReady.UnitTest.Features.Campaigns;
 using Xunit;
 
 namespace AllReady.UnitTest.Areas.Admin.Features.Skills

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Models/SkillTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Models/SkillTests.cs
@@ -1,0 +1,30 @@
+﻿using AllReady.Models;
+using Shouldly;
+using Xunit;
+
+namespace AllReady.UnitTest.ModelTests
+{
+    public class SkillTests
+    {
+        [Fact]
+        public void HierarchicalName_ShouldNever_IterateMoreThan10_LayersOfHierarchy()
+        {
+            // DESCRIPTION: It's possible to get an infinite loop with the data so we need to ensure we short circuit that when evaluating the hierarchical name
+            // NOTE: sgordon - If the code we're testing still creates a loop this will cause this test to also run infinitely
+
+            // Arrange
+            var parentSkill = new Skill {Name = "Parent", Id = 1 };
+            var childSkill = new Skill {Name = "Child Skill", ParentSkill = parentSkill, Id = 2, ParentSkillId = 1 };
+            parentSkill.ParentSkill = childSkill;
+
+            // Act
+
+            var parentResult = parentSkill.HierarchicalName;
+            var childResult = childSkill.HierarchicalName;
+
+            // Assert
+            parentResult.ShouldBe(Skill.InvalidHierarchy);
+            childResult.ShouldBe(Skill.InvalidHierarchy);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Models/SkillTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Models/SkillTests.cs
@@ -1,4 +1,5 @@
-﻿using AllReady.Models;
+﻿using System.Collections.Generic;
+using AllReady.Models;
 using Shouldly;
 using Xunit;
 
@@ -7,10 +8,10 @@ namespace AllReady.UnitTest.ModelTests
     public class SkillTests
     {
         [Fact]
-        public void HierarchicalName_ShouldNever_IterateMoreThan10_LayersOfHierarchy()
+        public void HierarchicalName_ShouldReturnInvalidHierarchy_WhenAChildParentLoopIsDetected()
         {
             // DESCRIPTION: It's possible to get an infinite loop with the data so we need to ensure we short circuit that when evaluating the hierarchical name
-            // NOTE: sgordon - If the code we're testing still creates a loop this will cause this test to also run infinitely
+            // NOTE: by sgordon - If the code we're testing still creates a loop this will cause this test to also run infinitely - not ideal!
 
             // Arrange
             var parentSkill = new Skill {Name = "Parent", Id = 1 };
@@ -25,6 +26,165 @@ namespace AllReady.UnitTest.ModelTests
             // Assert
             parentResult.ShouldBe(Skill.InvalidHierarchy);
             childResult.ShouldBe(Skill.InvalidHierarchy);
+        }
+
+        [Fact]
+        public void HierarchicalName_ReturnsCorrectName_WhenSkillHasNoChildren()
+        {
+            // Arrange
+            var parentSkill = new Skill { Name = "Parent", Id = 1 };
+
+            // Act
+
+            var result = parentSkill.HierarchicalName;
+
+            // Assert
+            result.ShouldBe("Parent");
+        }
+
+        [Fact]
+        public void HierarchicalName_ReturnsCorrectNameForParent_WhenSkillHasChildren()
+        {
+            // Arrange
+            var parentSkill = new Skill { Name = "Parent", Id = 1 };
+            var childSkill = new Skill { Name = "Child Skill", ParentSkill = parentSkill, Id = 2, ParentSkillId = 1 };
+
+            // Act
+
+            var result = parentSkill.HierarchicalName;
+
+            // Assert
+            result.ShouldBe("Parent");
+        }
+
+        [Fact]
+        public void HierarchicalName_ReturnsCorrectNameForAChildSkill()
+        {
+            // Arrange
+            var parentSkill = new Skill { Name = "Parent", Id = 1 };
+            var childSkill = new Skill { Name = "Child Skill", ParentSkill = parentSkill, Id = 2, ParentSkillId = 1 };
+
+            // Act
+
+            var result = childSkill.HierarchicalName;
+
+            // Assert
+            result.ShouldBe("Parent > Child Skill");
+        }
+
+        [Fact]
+        public void HierarchicalName_ReturnsCorrectNameForAThirdLevelAncestor()
+        {
+            // Arrange
+            var parentSkill = new Skill { Name = "Parent", Id = 1 };
+            var childSkill = new Skill { Name = "Child Skill", ParentSkill = parentSkill, Id = 2, ParentSkillId = 1 };
+            var thridAncestorSkills = new Skill { Name = "Final Skill", ParentSkill = childSkill, Id = 3, ParentSkillId = 2 };
+
+            // Act
+
+            var result = thridAncestorSkills.HierarchicalName;
+
+            // Assert
+            result.ShouldBe("Parent > Child Skill > Final Skill");
+        }
+
+        [Fact]
+        public void DescendantIds_ReturnsNull_WhenChildSkillsIsNull()
+        {
+            // Arrange
+            var sut = new Skill { Id = 1, Name = "Skill" };
+
+            // Act
+            var result = sut.DescendantIds;
+
+            result.ShouldBeNull();
+        }
+
+        [Fact]
+        public void DescendantIds_ReturnsEmptyList_WhenChildSkillsIsEmpty()
+        {
+            // Arrange
+            var sut = new Skill { Id = 1, Name = "Skill", ChildSkills = new List<Skill>()};
+
+            // Act
+            var result = sut.DescendantIds;
+
+            result.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public void DescendantIds_ReturnsCorrectId_WhenSingleChild()
+        {
+            // Arrange
+            var sut = new Skill { Id = 1, Name = "Skill", ChildSkills = new List<Skill> { new Skill() { Id = 2, Name = "Child" } } };
+
+            // Act
+            var result = sut.DescendantIds;
+
+            result.ShouldNotBeEmpty();
+            result.Count.ShouldBe(1);
+            result.Contains(2).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DescendantIds_ReturnsCorrectIds_WhenTwoChild_AtSameLevel()
+        {
+            // Arrange
+            var sut = new Skill { Id = 1, Name = "Skill", ChildSkills = new List<Skill> { new Skill { Id = 2, Name = "Child" }, new Skill { Id = 3, Name= "Child 2"} } };
+
+            // Act
+            var result = sut.DescendantIds;
+
+            result.ShouldNotBeEmpty();
+            result.Count.ShouldBe(2);
+            result.Contains(2).ShouldBeTrue();
+            result.Contains(3).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DescendantIds_ReturnsCorrectIds_WhenChildrenATMultipleLevels()
+        {
+            // Arrange
+            var sut = new Skill {
+                Id = 1,
+                Name = "Skill",
+                ChildSkills = new List<Skill> { new Skill {
+                    Id = 2,
+                    Name = "Child",
+                    ChildSkills = new List<Skill> { new Skill {
+                        Id = 3,
+                        Name = "Child 2",
+                        ChildSkills = new List<Skill> { new Skill
+                            {
+                                Id = 4,
+                                Name = "Child 3"
+                            }
+                        }
+                    }
+                }}}};
+
+            // Act
+            var result = sut.DescendantIds;
+
+            result.ShouldNotBeEmpty();
+            result.Count.ShouldBe(3);
+            result.Contains(2).ShouldBeTrue();
+            result.Contains(3).ShouldBeTrue();
+            result.Contains(4).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DescendantIds_ReturnsNull_WhenThereIsALoopInTheHierarchy()
+        {
+            // Arrange
+            var parentSkill = new Skill { Name = "Parent", Id = 1 };
+            var childSkill = new Skill { Name = "Child Skill", ParentSkill = parentSkill, Id = 2, ParentSkillId = 1 };
+            parentSkill.ParentSkill = childSkill;
+
+            // Act
+            var result = parentSkill.DescendantIds;
+
+            result.ShouldBeNull();
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SkillController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SkillController.cs
@@ -141,7 +141,10 @@ namespace AllReady.Areas.Admin.Controllers
                 model.ParentSelection = await _mediator.SendAsync(new SkillListQuery { OrganizationId = organizationId.Value });
             }
 
+            var descendants = model.ParentSelection.Single(x => x.Id == id).DescendantIds;
+
             model.ParentSelection = model.ParentSelection.Where(p => p.Id != model.Id); // remove self from the parent select list
+            model.ParentSelection = model.ParentSelection.Where(p => !descendants.Contains(p.Id)); // remove any descendants from the parent selection list to avoid hierarchical loops
 
             return View("Edit", model);
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SkillController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/SkillController.cs
@@ -8,6 +8,7 @@ using AllReady.Security;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 
 namespace AllReady.Areas.Admin.Controllers
 {
@@ -141,7 +142,7 @@ namespace AllReady.Areas.Admin.Controllers
                 model.ParentSelection = await _mediator.SendAsync(new SkillListQuery { OrganizationId = organizationId.Value });
             }
 
-            var descendants = model.ParentSelection.Single(x => x.Id == id).DescendantIds;
+            var descendants = model.ParentSelection.SingleOrDefault(x => x.Id == id)?.DescendantIds ?? new List<int>();
 
             model.ParentSelection = model.ParentSelection.Where(p => p.Id != model.Id); // remove self from the parent select list
             model.ParentSelection = model.ParentSelection.Where(p => !descendants.Contains(p.Id)); // remove any descendants from the parent selection list to avoid hierarchical loops

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventDetailQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Events/EventDetailQueryHandler.cs
@@ -43,8 +43,7 @@ namespace AllReady.Areas.Admin.Features.Events
                     EndDateTime = campaignEvent.EndDateTime,
                     IsLimitVolunteers = campaignEvent.IsLimitVolunteers,
                     IsAllowWaitList = campaignEvent.IsAllowWaitList,
-                    Location = campaignEvent.Location.ToEditModel(),
-                    RequiredSkills = campaignEvent.RequiredSkills,
+                    Location = campaignEvent.Location.ToEditModel(),                    
                     ImageUrl = campaignEvent.ImageUrl,
                     Tasks = campaignEvent.Tasks.Select(t => new TaskSummaryViewModel
                     {
@@ -71,6 +70,22 @@ namespace AllReady.Areas.Admin.Features.Events
                         RequestCount = i.Requests.Count
                     }).OrderBy(i => i.Date).ToList()
                 };
+
+
+                // required skills
+
+                var skillIds = campaignEvent.RequiredSkills.Select(s => s.SkillId);
+
+                var skillNames = await _context.Skills.AsNoTracking()
+                    .Include(s => s.ParentSkill)
+                    .Include(s => s.ChildSkills)
+                    .Where(s => skillIds.Contains(s.Id))
+                    .Where(s => s.HierarchicalName != Skill.InvalidHierarchy)
+                    .ToListAsync();
+
+                result.RequiredSkillNames = skillNames.Select(s => s.HierarchicalName).ToList();
+
+                // end required skills
 
                 result.NewItinerary.EventId = result.Id;
                 result.NewItinerary.Date = result.StartDateTime.DateTime;

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Skills/SkillEditQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Skills/SkillEditQuery.cs
@@ -3,8 +3,14 @@ using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Skills
 {
+    /// <summary>
+    /// A query which returns a <see cref="SkillEditViewModel"/> for a specified skill id
+    /// </summary>
     public class SkillEditQuery : IAsyncRequest<SkillEditViewModel>
     {
+        /// <summary>
+        /// The Id of the skill to be edited
+        /// </summary>
         public int Id { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Skills/SkillEditQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Skills/SkillEditQueryHandler.cs
@@ -21,7 +21,7 @@ namespace AllReady.Areas.Admin.Features.Skills
         {
             var skill = await _context.Skills.AsNoTracking()
                 .Include(s => s.ParentSkill)
-                .Include(s => s.ChildSkills).ThenInclude(cs => cs.ChildSkills)
+                .Include(s => s.ChildSkills)
                 .Include(s => s.OwningOrganization)
                 .SingleOrDefaultAsync(s => s.Id == message.Id);
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Skills/SkillEditQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Skills/SkillEditQueryHandler.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Areas.Admin.ViewModels.Skill;
 using AllReady.Models;
 using MediatR;
@@ -8,15 +10,18 @@ namespace AllReady.Areas.Admin.Features.Skills
 {
     public class SkillEditQueryHandler : IAsyncRequestHandler<SkillEditQuery, SkillEditViewModel>
     {
-        private AllReadyContext _context;
+        private readonly AllReadyContext _context;
+
         public SkillEditQueryHandler(AllReadyContext context)
         {
             _context = context;
         }
+
         public async Task<SkillEditViewModel> Handle(SkillEditQuery message)
         {
             var skill = await _context.Skills.AsNoTracking()
                 .Include(s => s.ParentSkill)
+                .Include(s => s.ChildSkills).ThenInclude(cs => cs.ChildSkills)
                 .Include(s => s.OwningOrganization)
                 .SingleOrDefaultAsync(s => s.Id == message.Id);
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Skills/SkillListQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Skills/SkillListQuery.cs
@@ -4,6 +4,9 @@ using MediatR;
 
 namespace AllReady.Areas.Admin.Features.Skills
 {
+    /// <summary>
+    /// A query which returns all skills in the form of a <see cref="SkillSummaryViewModel"/>, including their descendant info. This excludes returning any skills with an invalid hierarchy
+    /// </summary>
     public class SkillListQuery : IAsyncRequest<IEnumerable<SkillSummaryViewModel>>
     {
         /// <summary>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Event/EventDetailViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Event/EventDetailViewModel.cs
@@ -23,11 +23,8 @@ namespace AllReady.Areas.Admin.ViewModels.Event
         /// </summary>
         public IList<TaskSummaryViewModel> Tasks { get; set; } = new List<TaskSummaryViewModel>();
 
-        /// <summary>
-        /// A list of the skills required from volunteers of the event being displayed
-        /// </summary>
         [Display(Name = "Required Skills")]
-        public IEnumerable<EventSkill> RequiredSkills { get; set; } = new List<EventSkill>();
+        public List<string> RequiredSkillNames { get; set; } = new List<string>();
 
         /// <summary>
         /// An enumerable of itineraries associated with the event being displayed

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Event/EventDetailViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Event/EventDetailViewModel.cs
@@ -23,6 +23,9 @@ namespace AllReady.Areas.Admin.ViewModels.Event
         /// </summary>
         public IList<TaskSummaryViewModel> Tasks { get; set; } = new List<TaskSummaryViewModel>();
 
+        /// <summary>		
+        /// A list of the skills required from volunteers of the event being displayed		
+        /// </summary>
         [Display(Name = "Required Skills")]
         public List<string> RequiredSkillNames { get; set; } = new List<string>();
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Skill/SkillSummaryViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Skill/SkillSummaryViewModel.cs
@@ -3,15 +3,30 @@ using System.ComponentModel.DataAnnotations;
 
 namespace AllReady.Areas.Admin.ViewModels.Skill
 {
+    /// <summary>
+    /// A view model for display the summary details for a skill
+    /// </summary>
     public class SkillSummaryViewModel
     {
+        /// <summary>
+        ///  The id of the skill
+        /// </summary>
         public int Id { get; set; }
 
+        /// <summary>
+        /// The hierarchical name of the skill including all direct ancestors
+        /// </summary>
         [Display(Name = "Name")]
         public string HierarchicalName { get; set; }
 
+        /// <summary>
+        /// The description of the skill
+        /// </summary>
         public string Description { get; set; }
 
+        /// <summary>
+        /// The name of the organization to which the skill belongs.
+        /// </summary>
         [Display(Name = "Owning organization")]
         public string OwningOrganizationName { get; set; }
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Skill/SkillSummaryViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Skill/SkillSummaryViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 
 namespace AllReady.Areas.Admin.ViewModels.Skill
 {
@@ -13,5 +14,10 @@ namespace AllReady.Areas.Admin.ViewModels.Skill
 
         [Display(Name = "Owning organization")]
         public string OwningOrganizationName { get; set; }
+
+        /// <summary>
+        /// A list ids for all descendants of the skill
+        /// </summary>
+        public List<int> DescendantIds { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -45,15 +45,15 @@
         }
     </div>
 </div>
-@if (Model.RequiredSkills.Any())
+@if (Model.RequiredSkillNames.Any())
 {
     <div class="row">
         <div class="col-md-12">
             <h3>Required Skills</h3>
             <ul>
-                @foreach (var requiredSkill in Model.RequiredSkills)
+                @foreach (var requiredSkill in Model.RequiredSkillNames)
                 {
-                    <li><strong>@requiredSkill.Skill.HierarchicalName</strong></li>
+                    <li><strong>@requiredSkill</strong></li>
                 }
             </ul>
         </div>

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
@@ -151,7 +151,7 @@ namespace AllReady.Models
 
     private void Map(EntityTypeBuilder<Skill> builder)
     {
-      builder.HasOne(s => s.ParentSkill);
+      builder.HasOne(s => s.ParentSkill).WithMany(s => s.ChildSkills).HasForeignKey(s => s.ParentSkillId);
       builder.Ignore(s => s.HierarchicalName);
     }
 

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
@@ -6,203 +6,204 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
 namespace AllReady.Models
 {
-  public class AllReadyContext : IdentityDbContext<ApplicationUser>
-  {
-    public AllReadyContext() { }
-
-    public AllReadyContext(DbContextOptions options) : base(options) { }
-
-    public virtual DbSet<Organization> Organizations { get; set; }
-    public DbSet<Campaign> Campaigns { get; set; }
-    public DbSet<CampaignImpact> CampaignImpacts { get; set; }
-    public DbSet<Event> Events { get; set; }
-    public DbSet<EventSkill> EventSkills { get; set; }
-    public DbSet<Location> Locations { get; set; }
-    public DbSet<PostalCodeGeo> PostalCodes { get; set; }
-    public DbSet<AllReadyTask> Tasks { get; set; }
-    public DbSet<TaskSkill> TaskSkills { get; set; }
-    public DbSet<TaskSignup> TaskSignups { get; set; }
-    public DbSet<Resource> Resources { get; set; }
-    public virtual DbSet<Skill> Skills { get; set; }
-    public DbSet<UserSkill> UserSkills { get; set; }
-    public DbSet<Contact> Contacts { get; set; }
-    public DbSet<OrganizationContact> OrganizationContacts { get; set; }
-    public DbSet<CampaignContact> CampaignContacts { get; set; }
-    public DbSet<ClosestLocation> ClosestLocations { get; set; }
-    public DbSet<PostalCodeGeoCoordinate> PostalCodeGeoCoordinates { get; set; }
-    public DbSet<Request> Requests { get; set; }
-    public DbSet<Itinerary> Itineraries { get; set; }
-    public DbSet<ItineraryRequest> ItineraryRequests { get; set; }
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    public class AllReadyContext : IdentityDbContext<ApplicationUser>
     {
-      base.OnModelCreating(modelBuilder);
+        public AllReadyContext() { }
 
-      // Keep old database table naming convention
-      foreach (var entity in modelBuilder.Model.GetEntityTypes())
-      {
-        entity.Relational().TableName = entity.DisplayName();
-      }
+        public AllReadyContext(DbContextOptions options) : base(options) { }
 
-      Map(modelBuilder.Entity<Campaign>());
-      Map(modelBuilder.Entity<CampaignSponsors>());
-      Map(modelBuilder.Entity<Event>());
-      Map(modelBuilder.Entity<EventSkill>());
-      Map(modelBuilder.Entity<AllReadyTask>());
-      Map(modelBuilder.Entity<TaskSkill>());
-      Map(modelBuilder.Entity<TaskSignup>());
-      Map(modelBuilder.Entity<PostalCodeGeo>());
-      Map(modelBuilder.Entity<Skill>());
-      Map(modelBuilder.Entity<UserSkill>());
-      Map(modelBuilder.Entity<ApplicationUser>());
-      Map(modelBuilder.Entity<Organization>());
-      Map(modelBuilder.Entity<OrganizationContact>());
-      Map(modelBuilder.Entity<CampaignContact>());
-      Map(modelBuilder.Entity<Contact>());
-      Map(modelBuilder.Entity<CampaignImpact>());
-      Map(modelBuilder.Entity<ClosestLocation>());
-      Map(modelBuilder.Entity<PostalCodeGeoCoordinate>());
-      Map(modelBuilder.Entity<Request>());
-      Map(modelBuilder.Entity<Itinerary>());
-      Map(modelBuilder.Entity<ItineraryRequest>());
+        public virtual DbSet<Organization> Organizations { get; set; }
+        public DbSet<Campaign> Campaigns { get; set; }
+        public DbSet<CampaignImpact> CampaignImpacts { get; set; }
+        public DbSet<Event> Events { get; set; }
+        public DbSet<EventSkill> EventSkills { get; set; }
+        public DbSet<Location> Locations { get; set; }
+        public DbSet<PostalCodeGeo> PostalCodes { get; set; }
+        public DbSet<AllReadyTask> Tasks { get; set; }
+        public DbSet<TaskSkill> TaskSkills { get; set; }
+        public DbSet<TaskSignup> TaskSignups { get; set; }
+        public DbSet<Resource> Resources { get; set; }
+        public virtual DbSet<Skill> Skills { get; set; }
+        public DbSet<UserSkill> UserSkills { get; set; }
+        public DbSet<Contact> Contacts { get; set; }
+        public DbSet<OrganizationContact> OrganizationContacts { get; set; }
+        public DbSet<CampaignContact> CampaignContacts { get; set; }
+        public DbSet<ClosestLocation> ClosestLocations { get; set; }
+        public DbSet<PostalCodeGeoCoordinate> PostalCodeGeoCoordinates { get; set; }
+        public DbSet<Request> Requests { get; set; }
+        public DbSet<Itinerary> Itineraries { get; set; }
+        public DbSet<ItineraryRequest> ItineraryRequests { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            // Keep old database table naming convention
+            foreach (var entity in modelBuilder.Model.GetEntityTypes())
+            {
+                entity.Relational().TableName = entity.DisplayName();
+            }
+
+            Map(modelBuilder.Entity<Campaign>());
+            Map(modelBuilder.Entity<CampaignSponsors>());
+            Map(modelBuilder.Entity<Event>());
+            Map(modelBuilder.Entity<EventSkill>());
+            Map(modelBuilder.Entity<AllReadyTask>());
+            Map(modelBuilder.Entity<TaskSkill>());
+            Map(modelBuilder.Entity<TaskSignup>());
+            Map(modelBuilder.Entity<PostalCodeGeo>());
+            Map(modelBuilder.Entity<Skill>());
+            Map(modelBuilder.Entity<UserSkill>());
+            Map(modelBuilder.Entity<ApplicationUser>());
+            Map(modelBuilder.Entity<Organization>());
+            Map(modelBuilder.Entity<OrganizationContact>());
+            Map(modelBuilder.Entity<CampaignContact>());
+            Map(modelBuilder.Entity<Contact>());
+            Map(modelBuilder.Entity<CampaignImpact>());
+            Map(modelBuilder.Entity<ClosestLocation>());
+            Map(modelBuilder.Entity<PostalCodeGeoCoordinate>());
+            Map(modelBuilder.Entity<Request>());
+            Map(modelBuilder.Entity<Itinerary>());
+            Map(modelBuilder.Entity<ItineraryRequest>());
+        }
+
+        private void Map(EntityTypeBuilder<Request> builder)
+        {
+            builder.HasKey(x => x.RequestId);
+            builder.HasMany(x => x.Itineraries).WithOne(x => x.Request).HasForeignKey(x => x.RequestId);
+        }
+
+        private void Map(EntityTypeBuilder<CampaignImpact> builder)
+        {
+            builder.Ignore(c => c.PercentComplete);
+        }
+
+        private void Map(EntityTypeBuilder<CampaignContact> builder)
+        {
+            builder.HasKey(tc => new { tc.CampaignId, tc.ContactId, tc.ContactType });
+            builder.HasOne(tc => tc.Contact);
+            builder.HasOne(tc => tc.Campaign);
+        }
+
+        private void Map(EntityTypeBuilder<Contact> builder)
+        {
+            builder.HasMany(c => c.OrganizationContacts);
+            builder.HasMany(c => c.CampaignContacts);
+        }
+
+        private void Map(EntityTypeBuilder<OrganizationContact> builder)
+        {
+            builder.HasKey(tc => new { tc.OrganizationId, tc.ContactId, tc.ContactType });
+            builder.HasOne(tc => tc.Contact);
+            builder.HasOne(tc => tc.Organization);
+        }
+
+        private void Map(EntityTypeBuilder<Organization> builder)
+        {
+            builder.HasOne(t => t.Location);
+            builder.HasMany(t => t.OrganizationContacts);
+            builder.Property(t => t.Name).IsRequired();
+        }
+
+        private void Map(EntityTypeBuilder<PostalCodeGeo> builder)
+        {
+            builder.HasKey(k => k.PostalCode);
+        }
+
+        private void Map(EntityTypeBuilder<TaskSignup> builder)
+        {
+            builder.HasOne(u => u.Task).WithMany(x => x.AssignedVolunteers).HasForeignKey(x => x.TaskId);
+        }
+
+        private void Map(EntityTypeBuilder<AllReadyTask> builder)
+        {
+            builder.HasOne(t => t.Event).WithMany(e => e.Tasks).HasForeignKey(t => t.EventId);
+            builder.HasOne(t => t.Organization);
+            builder.HasMany(t => t.AssignedVolunteers)
+                .WithOne(ts => ts.Task)
+                .OnDelete(DeleteBehavior.Cascade);
+            builder.HasMany(t => t.RequiredSkills).WithOne(ts => ts.Task);
+            builder.Property(p => p.Name).IsRequired();
+        }
+
+        private void Map(EntityTypeBuilder<TaskSkill> builder)
+        {
+            builder.HasKey(acsk => new { acsk.TaskId, acsk.SkillId });
+        }
+
+        private void Map(EntityTypeBuilder<Event> builder)
+        {
+            builder.HasOne(a => a.Campaign);
+            builder.HasOne(a => a.Location);
+            builder.HasMany(a => a.Tasks)
+                .WithOne(t => t.Event)
+                .OnDelete(DeleteBehavior.Cascade);
+            builder.HasMany(a => a.RequiredSkills).WithOne(acsk => acsk.Event);
+            builder.Property(p => p.Name).IsRequired();
+            builder.HasMany(x => x.Itineraries).WithOne(x => x.Event).HasForeignKey(x => x.EventId).IsRequired();
+            builder.HasMany(x => x.Requests).WithOne(x => x.Event).HasForeignKey(x => x.EventId).IsRequired(false).OnDelete(DeleteBehavior.SetNull);
+        }
+
+        private void Map(EntityTypeBuilder<EventSkill> builder)
+        {
+            builder.HasKey(acsk => new { acsk.EventId, acsk.SkillId });
+        }
+
+        private void Map(EntityTypeBuilder<Skill> builder)
+        {
+            builder.HasOne(s => s.ParentSkill).WithMany(s => s.ChildSkills).HasForeignKey(s => s.ParentSkillId);
+            builder.Ignore(s => s.HierarchicalName);
+            builder.Ignore(s => s.DescendantIds);
+        }
+
+        private void Map(EntityTypeBuilder<CampaignSponsors> builder)
+        {
+            builder.HasOne(s => s.Campaign)
+                   .WithMany(c => c.ParticipatingOrganizations);
+            builder.HasOne(s => s.Organization);
+        }
+
+        private void Map(EntityTypeBuilder<Campaign> builder)
+        {
+            builder.HasOne(c => c.ManagingOrganization);
+            builder.HasOne(c => c.CampaignImpact);
+            builder.HasMany(c => c.Events);
+            builder.HasOne(t => t.Location);
+            builder.HasMany(t => t.CampaignContacts);
+            builder.Property(a => a.Name).IsRequired();
+        }
+
+        private void Map(EntityTypeBuilder<ApplicationUser> builder)
+        {
+            builder.HasMany(u => u.AssociatedSkills).WithOne(us => us.User);
+        }
+
+        private void Map(EntityTypeBuilder<UserSkill> builder)
+        {
+            builder.HasKey(us => new { us.UserId, us.SkillId });
+        }
+
+        private void Map(EntityTypeBuilder<ClosestLocation> builder)
+        {
+            builder.HasKey(us => new { us.PostalCode });
+        }
+
+        private void Map(EntityTypeBuilder<PostalCodeGeoCoordinate> builder)
+        {
+            builder.HasKey(us => new { us.Latitude, us.Longitude });
+        }
+
+        public void Map(EntityTypeBuilder<Itinerary> builder)
+        {
+            builder.HasKey(x => x.Id);
+            builder.HasMany(x => x.Requests).WithOne(x => x.Itinerary).HasForeignKey((x => x.ItineraryId));
+            builder.HasMany(x => x.TeamMembers).WithOne(x => x.Itinerary).HasForeignKey(x => x.ItineraryId).IsRequired(false);
+        }
+
+        public void Map(EntityTypeBuilder<ItineraryRequest> builder)
+        {
+            builder.HasKey(x => new { x.ItineraryId, x.RequestId });
+        }
+
     }
-
-    private void Map(EntityTypeBuilder<Request> builder)
-    {
-      builder.HasKey(x => x.RequestId);
-      builder.HasMany(x => x.Itineraries).WithOne(x => x.Request).HasForeignKey(x => x.RequestId);
-    }
-
-    private void Map(EntityTypeBuilder<CampaignImpact> builder)
-    {
-      builder.Ignore(c => c.PercentComplete);
-    }
-
-    private void Map(EntityTypeBuilder<CampaignContact> builder)
-    {
-      builder.HasKey(tc => new { tc.CampaignId, tc.ContactId, tc.ContactType });
-      builder.HasOne(tc => tc.Contact);
-      builder.HasOne(tc => tc.Campaign);
-    }
-
-    private void Map(EntityTypeBuilder<Contact> builder)
-    {
-      builder.HasMany(c => c.OrganizationContacts);
-      builder.HasMany(c => c.CampaignContacts);
-    }
-
-    private void Map(EntityTypeBuilder<OrganizationContact> builder)
-    {
-      builder.HasKey(tc => new { tc.OrganizationId, tc.ContactId, tc.ContactType });
-      builder.HasOne(tc => tc.Contact);
-      builder.HasOne(tc => tc.Organization);
-    }
-
-    private void Map(EntityTypeBuilder<Organization> builder)
-    {
-      builder.HasOne(t => t.Location);
-      builder.HasMany(t => t.OrganizationContacts);
-      builder.Property(t => t.Name).IsRequired();
-    }
-
-    private void Map(EntityTypeBuilder<PostalCodeGeo> builder)
-    {
-      builder.HasKey(k => k.PostalCode);
-    }
-
-    private void Map(EntityTypeBuilder<TaskSignup> builder)
-    {
-      builder.HasOne(u => u.Task).WithMany(x => x.AssignedVolunteers).HasForeignKey(x => x.TaskId);
-    }
-
-    private void Map(EntityTypeBuilder<AllReadyTask> builder)
-    {
-      builder.HasOne(t => t.Event).WithMany(e => e.Tasks).HasForeignKey(t => t.EventId);
-      builder.HasOne(t => t.Organization);
-      builder.HasMany(t => t.AssignedVolunteers)
-          .WithOne(ts => ts.Task)
-          .OnDelete(DeleteBehavior.Cascade);
-      builder.HasMany(t => t.RequiredSkills).WithOne(ts => ts.Task);
-      builder.Property(p => p.Name).IsRequired();
-    }
-
-    private void Map(EntityTypeBuilder<TaskSkill> builder)
-    {
-      builder.HasKey(acsk => new { acsk.TaskId, acsk.SkillId });
-    }
-
-    private void Map(EntityTypeBuilder<Event> builder)
-    {
-      builder.HasOne(a => a.Campaign);
-      builder.HasOne(a => a.Location);
-      builder.HasMany(a => a.Tasks)
-          .WithOne(t => t.Event)
-          .OnDelete(DeleteBehavior.Cascade);
-      builder.HasMany(a => a.RequiredSkills).WithOne(acsk => acsk.Event);
-      builder.Property(p => p.Name).IsRequired();
-      builder.HasMany(x => x.Itineraries).WithOne(x => x.Event).HasForeignKey(x => x.EventId).IsRequired();
-      builder.HasMany(x => x.Requests).WithOne(x => x.Event).HasForeignKey(x => x.EventId).IsRequired(false).OnDelete(DeleteBehavior.SetNull);
-    }
-
-    private void Map(EntityTypeBuilder<EventSkill> builder)
-    {
-      builder.HasKey(acsk => new { acsk.EventId, acsk.SkillId });
-    }
-
-    private void Map(EntityTypeBuilder<Skill> builder)
-    {
-      builder.HasOne(s => s.ParentSkill).WithMany(s => s.ChildSkills).HasForeignKey(s => s.ParentSkillId);
-      builder.Ignore(s => s.HierarchicalName);
-    }
-
-    private void Map(EntityTypeBuilder<CampaignSponsors> builder)
-    {
-      builder.HasOne(s => s.Campaign)
-             .WithMany(c => c.ParticipatingOrganizations);
-      builder.HasOne(s => s.Organization);
-    }
-
-    private void Map(EntityTypeBuilder<Campaign> builder)
-    {
-      builder.HasOne(c => c.ManagingOrganization);
-      builder.HasOne(c => c.CampaignImpact);
-      builder.HasMany(c => c.Events);
-      builder.HasOne(t => t.Location);
-      builder.HasMany(t => t.CampaignContacts);
-      builder.Property(a => a.Name).IsRequired();
-    }
-
-    private void Map(EntityTypeBuilder<ApplicationUser> builder)
-    {
-      builder.HasMany(u => u.AssociatedSkills).WithOne(us => us.User);
-    }
-
-    private void Map(EntityTypeBuilder<UserSkill> builder)
-    {
-      builder.HasKey(us => new { us.UserId, us.SkillId });
-    }
-
-    private void Map(EntityTypeBuilder<ClosestLocation> builder)
-    {
-      builder.HasKey(us => new { us.PostalCode });
-    }
-
-    private void Map(EntityTypeBuilder<PostalCodeGeoCoordinate> builder)
-    {
-      builder.HasKey(us => new { us.Latitude, us.Longitude });
-    }
-
-    public void Map(EntityTypeBuilder<Itinerary> builder)
-    {
-      builder.HasKey(x => x.Id);
-      builder.HasMany(x => x.Requests).WithOne(x => x.Itinerary).HasForeignKey((x => x.ItineraryId));
-      builder.HasMany(x => x.TeamMembers).WithOne(x => x.Itinerary).HasForeignKey(x => x.ItineraryId).IsRequired(false);
-    }
-
-    public void Map(EntityTypeBuilder<ItineraryRequest> builder)
-    {
-      builder.HasKey(x => new { x.ItineraryId, x.RequestId });
-    }
-
-  }
 }

--- a/AllReadyApp/Web-App/AllReady/Models/Skill.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Skill.cs
@@ -1,34 +1,84 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace AllReady.Models
 {
+    /// <summary>
+    /// Defines a skill in the allReady application. This is used for EF mapping
+    /// </summary>
     public class Skill
     {
+        [NotMapped]
+        public const string InvalidHierarchy = "Invalid hierarchy";
+
+        /// <summary>
+        /// The unique ID of the skill - set by SQL
+        /// </summary>
         public int Id { get; set; }
+
+        /// <summary>
+        /// The name of skill
+        /// </summary>
         [Required]
         public string Name { get; set; }
+
+        /// <summary>
+        /// A description of the skill
+        /// </summary>
         public string Description { get; set; }
+
+        /// <summary>
+        /// The owning organization if the skill is not a general skill
+        /// </summary>
         public int? OwningOrganizationId { get; set; }
+
+        /// <summary>
+        /// The navigation property for the owning organization if this skill has one
+        /// </summary>
         [Display(Name = "Owning organization")]
         public Organization OwningOrganization { get; set; }
 
+        /// <summary>
+        /// The id of the parent skill. This will be null if the skill is the top level parent
+        /// </summary>
         public int? ParentSkillId { get; set; }
 
+        /// <summary>
+        /// A navigational property to the parent skill if set
+        /// </summary>
         [Display(Name = "Parent skill")]
         public virtual Skill ParentSkill { get; set; }
 
+        public List<Skill> ChildSkills { get; set; }
+
+        /// <summary>
+        /// Returns a calculated full hierarchical name for the skill showing it's parent/children. This is not mapped to EF
+        /// </summary>
         public string HierarchicalName
         {
             get
             {
-                var retStr = Name;
+                var usedSkills = new List<int> { Id };
+                var hierarchicalName = Name;
                 var parent = ParentSkill;
+
                 while (parent != null)
                 {
-                    retStr = $"{parent.Name} > {retStr}";
+                    if (usedSkills.Contains(parent.Id))
+                    {
+                        // Prevents an infinite hierarchical loop
+                        // We shouldn't have a parent being added which has already been included in our hierarchy
+                        return InvalidHierarchy;
+                    }
+
+                    usedSkills.Add(parent.Id);
+
+                    hierarchicalName = $"{parent.Name} > {hierarchicalName}";
                     parent = parent.ParentSkill;
                 }
-                return retStr;
+
+                return hierarchicalName;
             }
         }
     }


### PR DESCRIPTION
Fixes #1318

Work includes:
- preventing an infinite loop for any skills which are added with a reciprocal hierarchy
- preventing new reciprocal hierarchies by ensuring we hide all descendants from the parent selection list when editing skills
- fix to event details to ensure the full hierarchy of the skill name is included
- unit tests