### PR TITLE
Making the test asserts locale independent

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/ViewModels/EventDetailViewModelTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/ViewModels/EventDetailViewModelTests.cs
@@ -146,7 +146,7 @@ namespace AllReady.UnitTest.Areas.Admin.ViewModels
 
             var result = sut.VolunteerFulfilmentPercentage;
 
-            result.ShouldBe("0.0");
+            result.ShouldBe(0D.ToString("0.0"));
         }
 
         [Fact]
@@ -160,7 +160,7 @@ namespace AllReady.UnitTest.Areas.Admin.ViewModels
 
             var result = sut.VolunteerFulfilmentPercentage;
 
-            result.ShouldBe("20.0");
+            result.ShouldBe(20D.ToString("0.0"));
         }
     }
 }


### PR DESCRIPTION
When the tests are run with the current culture set to hu-HU then the following two tests fail:
- VolunteerFulfilmentPercentage_ReturnsZero_WhenVoluneersRequiredIsZero
- VolunteerFulfilmentPercentage_ReturnsCorrectPercentage

They are failing because of the asserts are hard coded the decimal point.

Fixing the asserts to use the same pattern as the other tests in the  `EventDetailViewModelTests`.