### PR TITLE
Refactor to use the correct "nameof" in the ManageController

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -104,7 +104,7 @@ namespace AllReady.Controllers
 
             await UpdateUserProfileCompleteness(user);
 
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index));
+            return RedirectToAction(nameof(Index));
         }
 
         [HttpPost]
@@ -201,7 +201,7 @@ namespace AllReady.Controllers
                 await _signInManager.SignInAsync(user, isPersistent: false);
             }
 
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index));
+            return RedirectToAction(nameof(Index));
         }
 
         // POST: /Manage/DisableTwoFactorAuthentication
@@ -216,7 +216,7 @@ namespace AllReady.Controllers
                 await _signInManager.SignInAsync(user, isPersistent: false);
             }
 
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index));
+            return RedirectToAction(nameof(Index));
         }
 
         // GET: /Account/VerifyPhoneNumber
@@ -245,7 +245,7 @@ namespace AllReady.Controllers
                 {
                     await UpdateUserProfileCompleteness(user);
                     await _signInManager.SignInAsync(user, isPersistent: false);                    
-                    return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.AddPhoneSuccess });
+                    return RedirectToAction(nameof(Index), new { Message = ManageMessageId.AddPhoneSuccess });
                 }
             }
 
@@ -266,11 +266,11 @@ namespace AllReady.Controllers
                 {
                     await _signInManager.SignInAsync(user, isPersistent: false);
                     await UpdateUserProfileCompleteness(user);
-                    return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.RemovePhoneSuccess });
+                    return RedirectToAction(nameof(Index), new { Message = ManageMessageId.RemovePhoneSuccess });
                 }
             }
 
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.Error });
+            return RedirectToAction(nameof(Index), new { Message = ManageMessageId.Error });
         }
 
         // GET: /Manage/ChangePassword
@@ -297,7 +297,7 @@ namespace AllReady.Controllers
                 if (result.Succeeded)
                 {
                     await _signInManager.SignInAsync(user, isPersistent: false);
-                    return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.ChangePasswordSuccess });
+                    return RedirectToAction(nameof(Index), new { Message = ManageMessageId.ChangePasswordSuccess });
                 }
 
                 AddErrorsToModelState(result);
@@ -305,7 +305,7 @@ namespace AllReady.Controllers
                 return View(model);
             }
 
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.Error });
+            return RedirectToAction(nameof(Index), new { Message = ManageMessageId.Error });
         }
 
         // GET: /Manage/ChangeEmail
@@ -350,7 +350,7 @@ namespace AllReady.Controllers
                 return RedirectToAction(nameof(EmailConfirmationSent));                
             }
 
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.Error });
+            return RedirectToAction(nameof(Index), new { Message = ManageMessageId.Error });
         }
 
         // GET: /Manage/ConfirmNewEmail
@@ -378,7 +378,7 @@ namespace AllReady.Controllers
                 await _userManager.UpdateAsync(user);
             }
 
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.ChangeEmailSuccess });
+            return RedirectToAction(nameof(Index), new { Message = ManageMessageId.ChangeEmailSuccess });
         }
 
         [HttpPost]
@@ -406,7 +406,7 @@ namespace AllReady.Controllers
             user.PendingNewEmail = null;
             await _userManager.UpdateAsync(user);
 
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index));
+            return RedirectToAction(nameof(Index));
         }
 
         // GET: /Manage/SetPassword
@@ -433,12 +433,12 @@ namespace AllReady.Controllers
                 if (result.Succeeded)
                 {
                     await _signInManager.SignInAsync(user, isPersistent: false);
-                    return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.SetPasswordSuccess });
+                    return RedirectToAction(nameof(Index), new { Message = ManageMessageId.SetPasswordSuccess });
                 }
                 AddErrorsToModelState(result);
                 return View(model);
             }
-            return RedirectToAction(nameof(Microsoft.EntityFrameworkCore.Metadata.Internal.Index), new { Message = ManageMessageId.Error });
+            return RedirectToAction(nameof(Index), new { Message = ManageMessageId.Error });
         }
 
         //GET: /Account/Manage


### PR DESCRIPTION
Some actions in the `ManageController` are using  the very strange `Microsoft.EntityFrameworkCore.Metadata.Internal.Index` to set the `"Index"` string as the action name when returning with the `RedirectToAction`. 

It does not cause any problems because currently both methods are called `Index`, but all of these calls should reference the local `Index` function of the controller.

Fixing all the `nameof` usages to use the correct `nameof(Index)` in the `RedirectToAction`s.