### PR TITLE
#1361 Fix the initialization of the "Message All Volunteers" modal

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
@@ -57,7 +57,7 @@
             <div class="col-md-12">
                 @if (Model.AssignedVolunteers.Any())
                 {
-                    <button type="button" id="openMessageToVolunteers" class="btn btn-primary" disabled="disabled" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button>
+                    <button type="button" id="openMessageToVolunteers" class="btn btn-primary" disabled="disabled" autocomplete="off" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button>
                     <table class="table">
                         <tr>
                             <th>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
@@ -57,7 +57,7 @@
             <div class="col-md-12">
                 @if (Model.AssignedVolunteers.Any())
                 {
-                    <button type="button" class="btn btn-primary" disabled="@(!Model.AssignedVolunteers.Any())" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button>
+                    <button type="button" id="openMessageToVolunteers" class="btn btn-primary" disabled="disabled" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button>
                     <table class="table">
                         <tr>
                             <th>
@@ -120,6 +120,7 @@
     <script type="text/javascript">
         $(function () {
             var taskDetailsAdmin = new HTBox.TaskDetailAdmin();
+            $("#openMessageToVolunteers").prop('disabled', false);
         });
     </script>
 }


### PR DESCRIPTION
Fixes #1361 with disabling the "Message All" button until the page is correctly loaded.

It was not trivial to reproduce the issue because it was related to the script execution order during the page load.

The notifications are only displayed wrongly when the user is clicked on the "Message all" button **before** the whole page was loaded.

The current (relevant) script execution order is the following:
 - bootstrap.js -> initialize the modals in the jquery page load
 - lots of other unrelated scripts 
 - script section -> hooks on the modal event handlers in the jquery page load in the taksDetails.js

So there is quite big window when the bootstrap modal is already working but our additional handler is not yet attached.