### PR TITLE
#1346 Fix copy contact info

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Organizations/OrganizationContactQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Organizations/OrganizationContactQueryHandler.cs
@@ -21,7 +21,7 @@ namespace AllReady.Areas.Admin.Features.Organizations
 
             var organization = await _context.Organizations
                 .AsNoTracking()
-                .Include(l => l.Location).ThenInclude(pc => pc.PostalCode)
+                .Include(l => l.Location)
                 .Include(oc => oc.OrganizationContacts).ThenInclude(c => c.Contact)
                 .SingleOrDefaultAsync(o => o.Id == message.OrganizationId);
 


### PR DESCRIPTION
The commit ad2bb418 changed the `PostalCode` from `PostalCodeGeo` to `string`.  As a part of this refactoring all the `.ThenInclude(pc => pc.PostalCode)` removed, but not in the `OrganizationContactQueryHandler`.

So `PostalCode`  is no longer a navigation property on the `Location` object
and currently calling `.ThenInclude(pc => pc.PostalCode)` results in an 

```
System.ArgumentNullException: Value cannot be null.
Parameter name: source
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor.BindPropertyExpressionCore[TResult](Expression propertyExpression, IQuerySource querySource, Func`3 propertyBinder)
   at Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor.BindNavigationPathPropertyExpression[TResult](Expression propertyExpression, Func`3 propertyBinder)
   at Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor.<IncludeNavigations>b__42_0(IncludeResultOperator includeResultOperator)
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.OrderedEnumerable`1.<GetEnumerator>d__1.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor.IncludeNavigations(QueryModel queryModel)
   at Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitor.CreateAsyncQueryExecutor[TResult](QueryModel queryModel)
   at Microsoft.EntityFrameworkCore.Query.Internal.CompiledQueryCache.GetOrAddAsyncQuery[TResult](Object cacheKey, Func`1 compiler)
   at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.ExecuteAsync[TResult](Expression query, CancellationToken cancellationToken)
```

Removing the unnecessary `ThenInclude` fixes this exception and the #1346 "Copy Contact" feature.
