### PR TITLE
Add filtering to organization list retreival during Campaign creation

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/SelectListServiceTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/SelectListServiceTests.cs
@@ -3,14 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using AllReady.Models;
 using AllReady.Services;
-using Microsoft.EntityFrameworkCore;
-using Moq;
 using Xunit;
 using System.Security.Claims;
 
 namespace AllReady.UnitTest.Services
 {
-    public class SelectListServiceTests
+    public class SelectListServiceTests : InMemoryContextTest
     {
         private static int _organizationId1 = 1;
         private static string _organizationName1 = "Organization Name 1";
@@ -18,14 +16,9 @@ namespace AllReady.UnitTest.Services
         [Fact]
         public void GetOrganizationsForAdminUserReturnsAllOrganizations()
         {
-            var mockSet = CreateOrganizationsInMockDataStore();
-
-            var mockContext = new Mock<AllReadyContext>();
-            mockContext.Setup(c => c.Organizations).Returns(mockSet.Object);
-
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(AllReady.Security.ClaimTypes.UserType, "SiteAdmin") }));
 
-            var service = new SelectListService(mockContext.Object);
+            var service = new SelectListService(Context);
             var organizations = service.GetOrganizations( principal ).ToList();
 
             Assert.Equal(2, organizations.Count);
@@ -36,17 +29,12 @@ namespace AllReady.UnitTest.Services
         [Fact]
         public void GetOrganizationsForOrgAdminUserReturnsOnlyAuthorizedOrganization()
         {
-            var mockSet = CreateOrganizationsInMockDataStore();
-
-            var mockContext = new Mock<AllReadyContext>();
-            mockContext.Setup(c => c.Organizations).Returns(mockSet.Object);
-
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] {
                 new Claim(AllReady.Security.ClaimTypes.UserType, "OrgAdmin"),
                 new Claim(AllReady.Security.ClaimTypes.Organization, _organizationId1.ToString())
             }));
 
-            var service = new SelectListService(mockContext.Object);
+            var service = new SelectListService(Context);
             var organizations = service.GetOrganizations(principal).ToList();
 
             Assert.Equal(1, organizations.Count);
@@ -57,16 +45,11 @@ namespace AllReady.UnitTest.Services
         [Fact]
         public void GetOrganizationsForOrgAdminUserWithNoAssociatedOrgReturnsNoOrganizations()
         {
-            var mockSet = CreateOrganizationsInMockDataStore();
-
-            var mockContext = new Mock<AllReadyContext>();
-            mockContext.Setup(c => c.Organizations).Returns(mockSet.Object);
-
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] {
                 new Claim(AllReady.Security.ClaimTypes.UserType, "OrgAdmin")
             }));
 
-            var service = new SelectListService(mockContext.Object);
+            var service = new SelectListService(Context);
             var organizations = service.GetOrganizations(principal).ToList();
 
             Assert.Equal(0, organizations.Count);
@@ -75,32 +58,22 @@ namespace AllReady.UnitTest.Services
         [Fact]
         public void GetOrganizationsForSimpleUserReturnsNoOrganizations()
         {
-            var mockSet = CreateOrganizationsInMockDataStore();
-
-            var mockContext = new Mock<AllReadyContext>();
-            mockContext.Setup(c => c.Organizations).Returns(mockSet.Object);
-
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new[] {
                 new Claim(AllReady.Security.ClaimTypes.UserType, "User")
             }));
 
-            var service = new SelectListService(mockContext.Object);
+            var service = new SelectListService(Context);
             var organizations = service.GetOrganizations(principal).ToList();
 
             Assert.Equal(0, organizations.Count);
-       }
+        }
 
         [Fact]
         public void GetOrganizationsForNoClaimsReturnsNoOrganizations()
         {
-            var mockSet = CreateOrganizationsInMockDataStore();
-
-            var mockContext = new Mock<AllReadyContext>();
-            mockContext.Setup(c => c.Organizations).Returns(mockSet.Object);
-
             var principal = new ClaimsPrincipal(new ClaimsIdentity(new Claim[0]));
 
-            var service = new SelectListService(mockContext.Object);
+            var service = new SelectListService(Context);
             var organizations = service.GetOrganizations(principal).ToList();
 
             Assert.Equal(0, organizations.Count);
@@ -113,19 +86,13 @@ namespace AllReady.UnitTest.Services
             {
                 new Skill { Id = 1, Description = "description1", Name = "c" },
                 new Skill { Id = 2, Description = "description2", Name = "b" },
-                new Skill { Id = 3, Description = "description3", Name = "a" },
-            }.AsQueryable();
+                new Skill { Id = 3, Description = "description3", Name = "a" }
+            };
 
-            var mockSet = new Mock<DbSet<Skill>>();
-            mockSet.As<IQueryable<Skill>>().Setup(m => m.Provider).Returns(data.Provider);
-            mockSet.As<IQueryable<Skill>>().Setup(m => m.Expression).Returns(data.Expression);
-            mockSet.As<IQueryable<Skill>>().Setup(m => m.ElementType).Returns(data.ElementType);
-            mockSet.As<IQueryable<Skill>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
+            data.ForEach(s => Context.Add(s));
+            Context.SaveChanges();
 
-            var mockContext = new Mock<AllReadyContext>();
-            mockContext.Setup(c => c.Skills).Returns(mockSet.Object);
-
-            var service = new SelectListService(mockContext.Object);
+            var service = new SelectListService(Context);
             var skills = service.GetSkills().ToList();
 
             var expected = data.OrderBy(x => x.Name).ToList();
@@ -135,33 +102,6 @@ namespace AllReady.UnitTest.Services
             Assert.Equal(expected, skills, new SkillComparer());
             // this check makes sure the equality comparer is functioning
             Assert.NotEqual(notExpected, skills, new SkillComparer());
-        }
-
-        private static Mock<DbSet<Organization>> CreateOrganizationsInMockDataStore()
-        {
-            Mock<DbSet<Organization>> mockSet;
-
-            var data = new List<Organization>
-            {
-                new Organization
-                {
-                    Id = _organizationId1,
-                    Name = _organizationName1,
-                },
-                 new Organization
-                {
-                    Id = 2,
-                    Name = "Organization Name 2",
-                }
-            }.AsQueryable();
-
-            mockSet = new Mock<DbSet<Organization>>();
-            mockSet.As<IQueryable<Organization>>().Setup(m => m.Provider).Returns(data.Provider);
-            mockSet.As<IQueryable<Organization>>().Setup(m => m.Expression).Returns(data.Expression);
-            mockSet.As<IQueryable<Organization>>().Setup(m => m.ElementType).Returns(data.ElementType);
-            mockSet.As<IQueryable<Organization>>().Setup(m => m.GetEnumerator()).Returns(data.GetEnumerator());
-
-            return mockSet;
         }
 
         private class SkillComparer : IEqualityComparer<Skill>
@@ -181,6 +121,13 @@ namespace AllReady.UnitTest.Services
             {
                 return obj.Id.GetHashCode();
             }
+        }
+
+        protected override void LoadTestData()
+        {
+            Context.Add(new Organization { Id = _organizationId1, Name = _organizationName1 });
+            Context.Add(new Organization { Id = 2, Name = "Organization Name 2" });
+            Context.SaveChanges();
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/SelectListServiceTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/SelectListServiceTests.cs
@@ -107,20 +107,6 @@ namespace AllReady.UnitTest.Services
         }
 
         [Fact]
-        public void GetOrganizationsForNullClaimsReturnsNoOrganizations()
-        {
-            var mockSet = CreateOrganizationsInMockDataStore();
-
-            var mockContext = new Mock<AllReadyContext>();
-            mockContext.Setup(c => c.Organizations).Returns(mockSet.Object);
-
-            var service = new SelectListService(mockContext.Object);
-            var organizations = service.GetOrganizations(null).ToList();
-
-            Assert.Equal(0, organizations.Count);
-        }
-
-        [Fact]
         public void GetSkills()
         {
             var data = new List<Skill>

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/SelectListServiceTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/SelectListServiceTests.cs
@@ -10,13 +10,13 @@ using System.Security.Claims;
 
 namespace AllReady.UnitTest.Services
 {
-    public class SelectListServiceShould
+    public class SelectListServiceTests
     {
         private static int _organizationId1 = 1;
         private static string _organizationName1 = "Organization Name 1";
 
         [Fact]
-        public void GetOrganizationsForAdminUserReturnsAllOrganizationsTest()
+        public void GetOrganizationsForAdminUserReturnsAllOrganizations()
         {
             var mockSet = CreateOrganizationsInMockDataStore();
 
@@ -34,7 +34,7 @@ namespace AllReady.UnitTest.Services
         }
 
         [Fact]
-        public void GetOrganizationsForOrgAdminUserReturnsOnlyAuthorizedOrganizationTest()
+        public void GetOrganizationsForOrgAdminUserReturnsOnlyAuthorizedOrganization()
         {
             var mockSet = CreateOrganizationsInMockDataStore();
 
@@ -55,7 +55,7 @@ namespace AllReady.UnitTest.Services
         }
 
         [Fact]
-        public void GetOrganizationsForOrgAdminUserWithNoAssociatedOrgReturnsNoOrganizationsTest()
+        public void GetOrganizationsForOrgAdminUserWithNoAssociatedOrgReturnsNoOrganizations()
         {
             var mockSet = CreateOrganizationsInMockDataStore();
 
@@ -73,7 +73,7 @@ namespace AllReady.UnitTest.Services
         }
 
         [Fact]
-        public void GetOrganizationsForSimpleUserReturnsNoOrganizationsTest()
+        public void GetOrganizationsForSimpleUserReturnsNoOrganizations()
         {
             var mockSet = CreateOrganizationsInMockDataStore();
 
@@ -91,7 +91,7 @@ namespace AllReady.UnitTest.Services
        }
 
         [Fact]
-        public void GetOrganizationsForNoClaimsReturnsNoOrganizationsTest()
+        public void GetOrganizationsForNoClaimsReturnsNoOrganizations()
         {
             var mockSet = CreateOrganizationsInMockDataStore();
 
@@ -107,7 +107,7 @@ namespace AllReady.UnitTest.Services
         }
 
         [Fact]
-        public void GetOrganizationsForNullClaimsReturnsNoOrganizationsTest()
+        public void GetOrganizationsForNullClaimsReturnsNoOrganizations()
         {
             var mockSet = CreateOrganizationsInMockDataStore();
 
@@ -121,7 +121,7 @@ namespace AllReady.UnitTest.Services
         }
 
         [Fact]
-        public void GetSkillsTest()
+        public void GetSkills()
         {
             var data = new List<Skill>
             {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
@@ -134,7 +134,7 @@
         <div class="form-group">
             <label asp-for="OrganizationId" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                @Html.DropDownListFor(model => model.OrganizationId, SelectListService.GetOrganizations(), htmlAttributes: new { @class = "form-control" })
+                @Html.DropDownListFor(model => model.OrganizationId, SelectListService.GetOrganizations(User), htmlAttributes: new { @class = "form-control" })
             </div>
         </div>
         <div class="form-group">

--- a/AllReadyApp/Web-App/AllReady/Services/ISelectListService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/ISelectListService.cs
@@ -1,12 +1,13 @@
 ﻿using System.Collections.Generic;
 using AllReady.Models;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Security.Claims;
 
 namespace AllReady.Services
 {
     public interface ISelectListService
     {
-        IEnumerable<SelectListItem> GetOrganizations();
+        IEnumerable<SelectListItem> GetOrganizations(ClaimsPrincipal user);
         IEnumerable<Skill> GetSkills();
         IEnumerable<SelectListItem> GetCampaignImpactTypes();
         IEnumerable<SelectListItem> GetTimeZones();

--- a/AllReadyApp/Web-App/AllReady/Services/SelectListService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/SelectListService.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using AllReady.Extensions;
 using AllReady.Models;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Security.Claims;
+using AllReady.Security;
 
 namespace AllReady.Services
 {
@@ -16,9 +18,46 @@ namespace AllReady.Services
             _context = context;
         }
 
-        public IEnumerable<SelectListItem> GetOrganizations()
+        public IEnumerable<SelectListItem> GetOrganizations(ClaimsPrincipal user)
         {
-            return _context.Organizations.Select(t => new SelectListItem { Value = t.Id.ToString(), Text = t.Name });
+            user = SanitizeUser(user);
+
+            // Default to authorizing the return of no organizations
+            var listOfOrganizations = new List<SelectListItem>();
+
+            if (user.IsUserType(UserType.SiteAdmin))
+            {
+                listOfOrganizations = GetOrganizationsForSiteAdmin();
+            }
+            else if (user.IsUserType(UserType.OrgAdmin))
+            {
+                listOfOrganizations = GetOrganizationForOrgAdmin(user);
+            }
+
+            return listOfOrganizations;
+        }
+
+        private List<SelectListItem> GetOrganizationsForSiteAdmin()
+        {
+            return _context.Organizations.Select(t => new SelectListItem { Value = t.Id.ToString(), Text = t.Name }).ToList();
+        }
+
+        private List<SelectListItem> GetOrganizationForOrgAdmin(ClaimsPrincipal user)
+        {
+            int? organizationId = user.GetOrganizationId();
+            if (organizationId.HasValue)
+            {
+                return _context.Organizations.Where(o => o.Id == organizationId)
+                    .Select(t => new SelectListItem { Value = t.Id.ToString(), Text = t.Name })
+                    .ToList();
+            }
+
+            return new List<SelectListItem>();
+        }
+
+        private ClaimsPrincipal SanitizeUser(ClaimsPrincipal user)
+        {
+            return (user == null) ? new ClaimsPrincipal() : user;
         }
 
         //TODO: this needs to be moved out of the SelecListService class b/c it does not return an IEnumerable<SelectListItem>

--- a/AllReadyApp/Web-App/AllReady/Services/SelectListService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/SelectListService.cs
@@ -20,8 +20,6 @@ namespace AllReady.Services
 
         public IEnumerable<SelectListItem> GetOrganizations(ClaimsPrincipal user)
         {
-            user = SanitizeUser(user);
-
             // Default to authorizing the return of no organizations
             var listOfOrganizations = new List<SelectListItem>();
 
@@ -53,11 +51,6 @@ namespace AllReady.Services
             }
 
             return new List<SelectListItem>();
-        }
-
-        private ClaimsPrincipal SanitizeUser(ClaimsPrincipal user)
-        {
-            return (user == null) ? new ClaimsPrincipal() : user;
         }
 
         //TODO: this needs to be moved out of the SelecListService class b/c it does not return an IEnumerable<SelectListItem>


### PR DESCRIPTION
Add filtering to the list of organizations that is returned to list box during the "Create Campaign" workflow thereby limiting which organizations are displayed.

Caveats:

- I cannot run the UI tests on my machine. They get four tests in and then the chromedriver.exe crashes on me. Therefore, I did not create a UI test to verify that this works. I did, however, test this manually.
- I am not very excited about this implementation, but I wanted to start somewhere and get some feedback from the team.
- It was not clear to me whether an OrgAdmin was only every an OrgAdmin for a *single* organization or potentially many. Based on the sample OrgAdmin's **Organization** claim, it appeared as if it is only one Organization, but I didn't want to make that assumption without asking.
- I can clean up the commits, but wanted to get some feedback on the overall approach first.

Closes #1347 