### PR TITLE
WIP: Use specific input types on form elements

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
@@ -99,7 +99,7 @@
                 <p><cite>Optional link to an outside page</cite></p>
             </div>
             <div class="col-md-10">
-                <input asp-for="ExternalUrl" class="form-control" />
+                <input type="url" asp-for="ExternalUrl" class="form-control" />
                 <span asp-validation-for="ExternalUrl" class="text-danger"></span>
             </div>
         </div>
@@ -120,14 +120,14 @@
         <div class="form-group">
             <label asp-for="StartDate" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <input asp-for="StartDate" class="form-control datepicker" />
+                <input type="date" asp-for="StartDate" class="form-control datepicker" />
                 <span asp-validation-for="StartDate" class="text-danger"></span>
             </div>
         </div>
         <div class="form-group">
             <label asp-for="EndDate" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <input asp-for="EndDate" class="form-control datepicker" />
+                <input type="date" asp-for="EndDate" class="form-control datepicker" />
                 <span asp-validation-for="EndDate" class="text-danger"></span>
             </div>
         </div>
@@ -187,14 +187,14 @@
         <div class="form-group">
             <label asp-for="PrimaryContactPhoneNumber" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <input asp-for="PrimaryContactPhoneNumber" class="form-control" />
+                <input type="tel" asp-for="PrimaryContactPhoneNumber" class="form-control" />
                 <span asp-validation-for="PrimaryContactPhoneNumber" class="text-danger"></span>
             </div>
         </div>
         <div class="form-group">
             <label asp-for="PrimaryContactEmail" class="col-md-2 control-label"></label>
             <div class="col-md-10">
-                <input asp-for="PrimaryContactEmail" class="form-control" />
+                <input type="email" asp-for="PrimaryContactEmail" class="form-control" />
                 <span asp-validation-for="PrimaryContactEmail" class="text-danger"></span>
             </div>
         </div>


### PR DESCRIPTION
If we are looking for something more significant with polyfills, masking keys, etc then this might not be the best one for me to tackle. This is a minefield in terms of browser support. It may be safest and most future proof to just use the simple tweak of `<input type="tel|email|etc">` to start. My recommendation is to KISS for now and do something more _intense_ if we get additional feedback.

More detail can be found here: https://www.smashingmagazine.com/2015/05/form-inputs-browser-support-issue/

It seemed safest to not try to add specific patterns to the input, but if you guys have strong feelings (or have suggestions like leveraging polyfills like http://chemerisuk.github.io/better-dateinput-polyfill/ then let me know).