### PR TITLE
Fix Issue #1304 (bug)

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Providers/ExternalUserInformationProviders/Providers/TwitterRepository.cs
+++ b/AllReadyApp/Web-App/AllReady/Providers/ExternalUserInformationProviders/Providers/TwitterRepository.cs
@@ -16,6 +16,11 @@ namespace AllReady.Providers.ExternalUserInformationProviders.Providers
 
         public async Task<Account> GetTwitterAccount(string userId, string screenName)
         {
+            if (AnyTwitterAuthenticationSettingsAreNotSet())
+            {
+                return null;
+            }
+
             var authTwitter = new SingleUserAuthorizer
             {
                 CredentialStore = new SingleUserInMemoryCredentialStore
@@ -24,7 +29,6 @@ namespace AllReady.Providers.ExternalUserInformationProviders.Providers
                     ConsumerSecret = twitterAuthenticationSettings.Value.ConsumerSecret,
                     OAuthToken = twitterAuthenticationSettings.Value.OAuthToken,
                     OAuthTokenSecret = twitterAuthenticationSettings.Value.OAuthSecret,
-
                     UserID = ulong.Parse(userId),
                     ScreenName = screenName
                 }
@@ -36,10 +40,16 @@ namespace AllReady.Providers.ExternalUserInformationProviders.Providers
 
             //VERY important you explicitly keep the "== true" part of comparison. ReSharper will prompt you to remove this, and if it does, the query will not work
             var account = await (from acct in twitterCtx.Account
-                                 where (acct.Type == AccountType.VerifyCredentials) && (acct.IncludeEmail == true)
-                                 select acct).SingleOrDefaultAsync();
+                where (acct.Type == AccountType.VerifyCredentials) && (acct.IncludeEmail == true)
+                select acct).SingleOrDefaultAsync();
 
             return account;
+        }
+
+        private bool AnyTwitterAuthenticationSettingsAreNotSet()
+        {
+            return twitterAuthenticationSettings.Value.ConsumerKey == "[twitterconsumerkey]" || twitterAuthenticationSettings.Value.ConsumerSecret == "[twitterconsumersecret]" ||
+                   twitterAuthenticationSettings.Value.OAuthToken == "[twitteroauthtoken]" || twitterAuthenticationSettings.Value.OAuthSecret == "[twitteroauthsecret]";
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Providers/ExternalUserInformationProviders/Providers/TwitterRepository.cs
+++ b/AllReadyApp/Web-App/AllReady/Providers/ExternalUserInformationProviders/Providers/TwitterRepository.cs
@@ -36,10 +36,10 @@ namespace AllReady.Providers.ExternalUserInformationProviders.Providers
 
             await authTwitter.AuthorizeAsync();
 
-            var twitterCtx = new TwitterContext(authTwitter);
+            var twitterContext = new TwitterContext(authTwitter);
 
             //VERY important you explicitly keep the "== true" part of comparison. ReSharper will prompt you to remove this, and if it does, the query will not work
-            var account = await (from acct in twitterCtx.Account
+            var account = await (from acct in twitterContext.Account
                 where (acct.Type == AccountType.VerifyCredentials) && (acct.IncludeEmail == true)
                 select acct).SingleOrDefaultAsync();
 
@@ -48,8 +48,13 @@ namespace AllReady.Providers.ExternalUserInformationProviders.Providers
 
         private bool AnyTwitterAuthenticationSettingsAreNotSet()
         {
-            return twitterAuthenticationSettings.Value.ConsumerKey == "[twitterconsumerkey]" || twitterAuthenticationSettings.Value.ConsumerSecret == "[twitterconsumersecret]" ||
-                   twitterAuthenticationSettings.Value.OAuthToken == "[twitteroauthtoken]" || twitterAuthenticationSettings.Value.OAuthSecret == "[twitteroauthsecret]";
+            return
+                twitterAuthenticationSettings.Value.ConsumerKey == "[twitterconsumerkey]" ||
+                twitterAuthenticationSettings.Value.ConsumerSecret == "[twitterconsumersecret]" ||
+                twitterAuthenticationSettings.Value.OAuthToken == "[twitteroauthtoken]" ||
+                twitterAuthenticationSettings.Value.OAuthSecret == "[twitteroauthsecret]" ||
+                twitterAuthenticationSettings.Value.OAuthToken == string.Empty ||
+                twitterAuthenticationSettings.Value.OAuthSecret == string.Empty;
         }
     }
 }


### PR DESCRIPTION
Fixes #1304

A little background on the "fix":

This PR adds checks to TwitterRespository's AnyTwitterAuthenticationSettingsAreNotSet method which not only check against the default values provided for each authentication credential ("[twitterconsumerkey]", etc...), but also checks for string.Empty for OAuthToken and OAuthSecret

Interestingly enough, you cannot leave either ConsumerKey or ConsumerSecret an empty string ("ConsumerKey": "") in config.json, or you'll receive a runtime error when the site starts.

However, you CAN put an empty string as a value for OAuthToken and OAuthSecret and the site will start successfully.