### PR TITLE
Partially closed EventAdminController: finish unit tests

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/EventAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/EventAdminControllerTests.cs
@@ -8,6 +8,7 @@ using AllReady.Services;
 using AllReady.UnitTest.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
 using Moq;
 using Xunit;
 using System.Linq;
@@ -28,20 +29,9 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         //delete this line when all unit tests using it have been completed
         private static readonly Task<int> TaskFromResultZero = Task.FromResult(0);
 
-        [Fact(Skip = "NotImplemented")]
-        public async Task DetailsSendsEventDetailQueryWithCorrectEventId()
-        {
-            // delete this line when starting work on this unit test
-            await TaskFromResultZero;
-        }
-
         [Fact]
         public async Task DetailsReturnsHttpNotFoundResult_WhenEventIsNull()
         {
-            //var mediator = new Mock<IMediator>();
-            //mediator.Setup(x => x.SendAsync(It.IsAny<CampaignSummaryQueryAsync>())).ReturnsAsync(new CampaignSummaryViewModel());
-
-            //var sut = new EventController(null, mediator.Object, null);
             var sut = new EventController(null, Mock.Of<IMediator>(), null);
             var result = await sut.Details(It.IsAny<int>());
 
@@ -71,13 +61,13 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact(Skip = "NotImplemented")]
-        public async Task DetailsReturnsCorrectViewModel_WhenEventIsNotNull_AndUserIsOrgAdmin()
+		public async Task DetailsReturnsCorrectViewModel_WhenEventIsNotNull_AndUserIsOrgAdmin()
         {
-            // delete this line when starting work on this unit test
-            await TaskFromResultZero;
-        }
+			// delete this line when starting work on this unit test
+			await TaskFromResultZero;
+		}
 
-        [Fact]
+		[Fact]
         public void DetailsHasHttpGetAttribute()
         {
             var sut = EventControllerWithNoInjectedDependencies();
@@ -114,7 +104,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         public async Task CreateGetReturnsHttpUnauthorizedResult_WhenUserIsNotOrgAdmin()
         {
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<EventDetailQuery>())).ReturnsAsync(new EventDetailViewModel { Id = 1, Name = "Itinerary", OrganizationId = 1 });
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventDetailQuery>()))
+				.ReturnsAsync(new EventDetailViewModel { Id = 1, Name = "Itinerary", OrganizationId = 1 });
 
             var sut = new EventController(null, mediator.Object, null);
             sut.MakeUserNotAnOrgAdmin();
@@ -123,11 +114,11 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact(Skip = "NotImplemented")]
-        public async Task CreateGetReturnsCorrectView_AndViewModel()
+		public async Task CreateGetReturnsCorrectView_AndViewModel()
         {
-            // delete this line when starting work on this unit test
-            await TaskFromResultZero;
-        }
+			// delete this line when starting work on this unit test
+			await TaskFromResultZero;
+		}
 
         [Fact]
         public void CreateGetHasRouteAttributeWithCorrectRoute()
@@ -164,7 +155,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task CreatePostReturnsEditView_When_EventDetailsModelValidatorHasErrors()
+		public async Task CreatePostReturnsEditView_When_EventDetailsModelValidatorHasErrors()
         {
             var imageService = new Mock<IImageService>();
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
@@ -12,6 +12,7 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
 using AllReady.Areas.Admin.ViewModels.Event;
 using AllReady.Areas.Admin.ViewModels.Validators;
 using AllReady.Areas.Admin.ViewModels.Request;
@@ -49,8 +50,9 @@ namespace AllReady.Areas.Admin.Controllers
                 return Unauthorized();
             }
 
-            var url = Url.Action("Details", "Itinerary", new { Area = "Admin", id = 0 }).TrimEnd('0');
-            viewModel.ItinerariesDetailsUrl = string.Concat(url, "{id}");
+			var url = Url.Action(new UrlActionContext { Action = nameof(Details), Controller = "Itinerary", Values = new { id = id, Area = "Admin" } });//.TrimEnd('0');
+
+			viewModel.ItinerariesDetailsUrl = url;
 
             return View(viewModel);
         }


### PR DESCRIPTION
 https://github.com/HTBox/allReady/issues/617

Refactored Admin/Event/Details

Deleted Test DetailsSendsEventDetailQueryWithCorrectEventId as 
DetailsReturnsCorrectViewModel_WhenEventIsNotNull_AndUserIsOrgAdmin covers this case

Completed DetailsReturnsCorrectViewModel_WhenEventIsNotNull_AndUserIsOrgAdmin 