### PR TITLE
Moved text on 404 screen above image.

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Error/404.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Error/404.cshtml
@@ -1,45 +1,15 @@
-﻿@section styles 
-{    <style>
-        .errbackimage         
-        { 
-            background:  url("/images/404.jpg");
-            background-repeat:no-repeat;
-            background-size:contain;
-            margin-left:-40px;
-            margin-top:-40px;
-            width:99%;
-            height:800px;
-            padding:0;
-        }
-        .errtxt
-        {
-            font-size:xx-large;
-            font-weight: 600;
-            text-align:left;
-            margin-left: 2%;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
-        }
-         .errtxtbg
-        {
-            font-size: 48pt;
-            text-align:left;
-            padding-top: 2%;
-            margin-left: 2%;
-            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif        
-        }
-    </style>
-    }
-    @{
+﻿@{
     ViewBag.Title = "404! We went off the rails...";
-    }
-
-    <div class="errbackimage">
-        <p class="errtxtbig">
-            404 :(
-           </p> 
-    <p class="errtxt">
-         We went off the rails and couldn’t find your page! <br /> Don’t worry. We’ll get back on track.
-        </p>
-        <br />
+}
+<p class="lead">
+    404 :(
+</p>
+<p class="lead">
+    We went off the rails and couldn’t find your page! <br />
+    Don’t worry. We’ll get back on track.
+</p>
+<div class="row">
+    <div class="col-lg-6 col-md-8 col-sm-10">
+        <img src="~/images/404.jpg" class="img-responsive center-block" alt="404" />
     </div>
-
+</div>


### PR DESCRIPTION
Moved the text on the 404 screen above the image.
To address display issues caused by the text interacting with the existing CSS I placed the image in its own img tag which is sized using the bootstrap responsive image and cleaned up the unused CSS.

Closes #1484 