### PR TITLE
Request creation/edit looks up lat/long for address

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
@@ -1,18 +1,36 @@
 ﻿using AllReady.Areas.Admin.Features.Requests;
 using AllReady.Areas.Admin.ViewModels.Request;
+using AllReady.Models;
 using AllReady.Providers;
 using MediatR;
 using Moq;
 using System;
 using System.Threading.Tasks;
 using Xunit;
+using System.Linq;
 
 namespace AllReady.UnitTest.Areas.Admin.Features.Requests
 {
     public class EditRequestCommandHandlerShould : InMemoryContextTest
     {
+        private Request _existingRequest;
         protected override void LoadTestData()
         {
+            _existingRequest = new Request
+            {
+                Address = "1234 Nowhereville",
+                City = "",
+                Name = "",
+                DateAdded = DateTime.MinValue,
+                EventId = 1,
+                Phone = "555-555-5555",
+                Email = "something@example.com",
+                State = "WA",
+                Zip = "55555"
+            };
+
+            Context.Requests.Add(_existingRequest);
+            Context.SaveChanges();
         }
 
         [Fact]
@@ -24,6 +42,22 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
             var requestId = await handler.Handle(new EditRequestCommand { RequestModel = new EditRequestViewModel {  } });
 
             Assert.NotEqual(Guid.Empty, requestId);
+        }
+
+        [Fact]
+        public async Task UpdateRequestsThatAlreadyExisted()
+        {
+            var mockMediator = new Mock<IMediator>();
+            string expectedName = "replaced name";
+
+            var handler = new EditRequestCommandHandler(Context, new NullObjectGeocoder());
+            var requestId = await handler.Handle(new EditRequestCommand
+            {
+                RequestModel = new EditRequestViewModel { Id = _existingRequest.RequestId, Name = expectedName }
+            });
+
+            var request = Context.Requests.First(r => r.RequestId == _existingRequest.RequestId);
+            Assert.Equal(expectedName, request.Name );
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
@@ -40,8 +40,6 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
         [Fact]
         public async Task ReturnNewRequestIdOnSuccessfulCreation()
         {
-            var mockMediator = new Mock<IMediator>();
-
             var handler = new EditRequestCommandHandler(Context, new NullObjectGeocoder());
             var requestId = await handler.Handle(new EditRequestCommand { RequestModel = new EditRequestViewModel {  } });
 
@@ -51,11 +49,10 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
         [Fact]
         public async Task UpdateRequestsThatAlreadyExisted()
         {
-            var mockMediator = new Mock<IMediator>();
             string expectedName = "replaced name";
 
             var handler = new EditRequestCommandHandler(Context, new NullObjectGeocoder());
-            var requestId = await handler.Handle(new EditRequestCommand
+            await handler.Handle(new EditRequestCommand
             {
                 RequestModel = new EditRequestViewModel { Id = _existingRequest.RequestId, Name = expectedName }
             });
@@ -67,14 +64,13 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
         [Fact]
         public async Task AlwaysGeocodeAddressWhenUpdatingExistingRequest()
         {
-            var mockMediator = new Mock<IMediator>();
             var mockGeocoder = new Mock<IGeocoder>();
 
             // Because the Geocode method takes a set of strings as arguments, verify the arguments are passed in to the mock the correct order.
             mockGeocoder.Setup(g => g.Geocode(_existingRequest.Address, _existingRequest.City, _existingRequest.State, _existingRequest.Zip, It.IsAny<string>())).Returns(new List<Address>());
 
             var handler = new EditRequestCommandHandler(Context, mockGeocoder.Object);
-            var requestId = await handler.Handle(new EditRequestCommand
+            await handler.Handle(new EditRequestCommand
             {
                 RequestModel = new EditRequestViewModel { Id = _existingRequest.RequestId, Address = _existingRequest.Address, City = _existingRequest.City, State = _existingRequest.State, Zip = _existingRequest.Zip }
             });

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
@@ -28,7 +28,9 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
                 Phone = "555-555-5555",
                 Email = "something@example.com",
                 State = "WA",
-                Zip = "55555"
+                Zip = "55555",
+                Latitude = 10,
+                Longitude = 10
             };
 
             Context.Requests.Add(_existingRequest);
@@ -63,7 +65,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
         }
 
         [Fact]
-        public async Task AttemptToGeocodeAddressToGetLatitudeAndLongitude()
+        public async Task AlwaysGeocodeAddressWhenUpdatingExistingRequest()
         {
             var mockMediator = new Mock<IMediator>();
             var mockGeocoder = new Mock<IGeocoder>();
@@ -74,7 +76,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
             var handler = new EditRequestCommandHandler(Context, mockGeocoder.Object);
             var requestId = await handler.Handle(new EditRequestCommand
             {
-                RequestModel = new EditRequestViewModel { Address = _existingRequest.Address, City = _existingRequest.City, State = _existingRequest.State, Zip = _existingRequest.Zip }
+                RequestModel = new EditRequestViewModel { Id = _existingRequest.RequestId, Address = _existingRequest.Address, City = _existingRequest.City, State = _existingRequest.State, Zip = _existingRequest.Zip }
             });
 
             mockGeocoder.Verify(x => x.Geocode(_existingRequest.Address, _existingRequest.City, _existingRequest.State, _existingRequest.Zip, It.IsAny<string>()), Times.Once);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
@@ -2,7 +2,6 @@
 using AllReady.Areas.Admin.ViewModels.Request;
 using AllReady.Models;
 using AllReady.Providers;
-using MediatR;
 using Moq;
 using System;
 using System.Threading.Tasks;

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
@@ -1,0 +1,29 @@
+﻿using AllReady.Areas.Admin.Features.Requests;
+using AllReady.Areas.Admin.ViewModels.Request;
+using AllReady.Providers;
+using MediatR;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.Requests
+{
+    public class EditRequestCommandHandlerShould : InMemoryContextTest
+    {
+        protected override void LoadTestData()
+        {
+        }
+
+        [Fact]
+        public async Task ReturnNewRequestIdOnSuccessfulCreation()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            var handler = new EditRequestCommandHandler(Context, new NullObjectGeocoder());
+            var requestId = await handler.Handle(new EditRequestCommand { RequestModel = new EditRequestViewModel {  } });
+
+            Assert.NotEqual(Guid.Empty, requestId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Requests/EditRequestCommandHandlerShould.cs
@@ -8,6 +8,8 @@ using System;
 using System.Threading.Tasks;
 using Xunit;
 using System.Linq;
+using Geocoding;
+using System.Collections.Generic;
 
 namespace AllReady.UnitTest.Areas.Admin.Features.Requests
 {
@@ -19,8 +21,8 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
             _existingRequest = new Request
             {
                 Address = "1234 Nowhereville",
-                City = "",
-                Name = "",
+                City = "Seattle",
+                Name = "Request unit test",
                 DateAdded = DateTime.MinValue,
                 EventId = 1,
                 Phone = "555-555-5555",
@@ -58,6 +60,24 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Requests
 
             var request = Context.Requests.First(r => r.RequestId == _existingRequest.RequestId);
             Assert.Equal(expectedName, request.Name );
+        }
+
+        [Fact]
+        public async Task AttemptToGeocodeAddressToGetLatitudeAndLongitude()
+        {
+            var mockMediator = new Mock<IMediator>();
+            var mockGeocoder = new Mock<IGeocoder>();
+
+            // Because the Geocode method takes a set of strings as arguments, verify the arguments are passed in to the mock the correct order.
+            mockGeocoder.Setup(g => g.Geocode(_existingRequest.Address, _existingRequest.City, _existingRequest.State, _existingRequest.Zip, It.IsAny<string>())).Returns(new List<Address>());
+
+            var handler = new EditRequestCommandHandler(Context, mockGeocoder.Object);
+            var requestId = await handler.Handle(new EditRequestCommand
+            {
+                RequestModel = new EditRequestViewModel { Address = _existingRequest.Address, City = _existingRequest.City, State = _existingRequest.State, Zip = _existingRequest.Zip }
+            });
+
+            mockGeocoder.Verify(x => x.Geocode(_existingRequest.Address, _existingRequest.City, _existingRequest.State, _existingRequest.Zip, It.IsAny<string>()), Times.Once);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
@@ -36,7 +36,8 @@ namespace AllReady.Areas.Admin.Features.Requests
             request.Phone = message.RequestModel.Phone;
 
             //If lat/long not provided, use geocoding API to get them
-            if (request.Latitude == 0 && request.Longitude == 0)
+            //Also, always update lat/long to be safe if this is an update operation since it is unknown whether the address changed or not.
+            if ((request.Latitude == 0 && request.Longitude == 0) || request.RequestId != Guid.Empty)
             {
                 //Assume the first returned address is correct
                 var address = _geocoder.Geocode(request.Address, request.City, request.State, request.Zip, string.Empty)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
@@ -5,6 +5,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Geocoding;
 using System.Linq;
+using AllReady.Extensions;
 
 namespace AllReady.Areas.Admin.Features.Requests
 {
@@ -44,7 +45,7 @@ namespace AllReady.Areas.Admin.Features.Requests
                 request.Longitude = address?.Coordinates.Longitude ?? 0;
             }
 
-            _context.Requests.Add(request);
+            _context.AddOrUpdate(request);
 
             await _context.SaveChangesAsync();
 


### PR DESCRIPTION
Work in this PR

- [x] Leverage the IGeocoder object to fetch the lat/long for the request when it is saved.
- [x] Get Google GeoCoder keys in order to actually test this locally as by default its using the NullObject geocoder
- [x] Create unit tests around this handler
- [x] Explore where a "shared" location for the code that is duplicated between ImportRequestCommandHandler and EditRequestCommandHandler could live/belongs since I don't like the current duplication and creating a base class *GeoCoderRequestCommandHandler doesn't feel right to me (such that the base class could house the shared method. **Decision after exploration - Not worth the effort.**
- [x] Found a bug. If you edit a **Request** after creation, then command handler will explode and cause an HTTP 500 status code. Will fix this bug along with this PR. _I didn't log an issue for this, but can if there is a need to track it (the bug was present before this PR)._
- [x] Only update the lat/long of the **Request** when we detect an address changed when editing a **Request**.

Closes #1398