### PR TITLE
Adding ability to edit itinerary

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -86,6 +86,24 @@ namespace AllReady.Areas.Admin.Controllers
             return BadRequest();
         }
 
+        [Route("Admin/Itinerary/Edit/{id}")]
+        public async Task<IActionResult> Edit(int id)
+        {
+            var itinerary = await _mediator.SendAsync(new EditItineraryQuery { ItineraryId = id });
+            if (itinerary == null)
+            {
+                return BadRequest();
+            }
+
+            if (!User.IsOrganizationAdmin(itinerary.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            return View(itinerary);
+        }
+
+
         [HttpPost]
         [Route("Admin/Itinerary/AddTeamMember")]
         [ValidateAntiForgeryToken]

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -125,6 +125,8 @@ namespace AllReady.Areas.Admin.Controllers
                 return Unauthorized();
             }
 
+            model.Date = itinerary.Date; // we currently don't allow the date to be changed via edit
+
             // todo - sgordon: add additional validation for address scenarios - enhance this later
             var errors = _itineraryValidator.Validate(model, itinerary.EventSummary);
             errors.ToList().ForEach(e => ModelState.AddModelError(e.Key, e.Value));

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryQuery.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Areas.Admin.ViewModels.Itinerary;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class EditItineraryQuery : IAsyncRequest<ItineraryEditViewModel>
+    {
+        public int ItineraryId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryQueryHandler.cs
@@ -1,0 +1,39 @@
+﻿using AllReady.Areas.Admin.ViewModels.Itinerary;
+using AllReady.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class EditItineraryQueryHandler : IAsyncRequestHandler<EditItineraryQuery, ItineraryEditViewModel>
+    {
+        private readonly AllReadyContext _context;
+        private readonly IMediator _mediator;
+
+        public EditItineraryQueryHandler(AllReadyContext context, IMediator mediator)
+        {
+            _context = context;
+            _mediator = mediator;
+        }
+
+        public async Task<ItineraryEditViewModel> Handle(EditItineraryQuery message)
+        {
+            return await _context.Itineraries.AsNoTracking()
+                .Include(rec => rec.Event).ThenInclude(rec => rec.Campaign)
+                .Select(rec => new ItineraryEditViewModel
+                {
+                    Id = rec.Id,
+                    Name = rec.Name,
+                    Date = rec.Date,
+                    EventId = rec.EventId,
+                    OrganizationId = rec.Event.Campaign.ManagingOrganizationId,
+                    EventName = rec.Event.Name,
+                    CampaignId = rec.Event.CampaignId,
+                    CampaignName = rec.Event.Campaign.Name
+                })
+                .SingleOrDefaultAsync();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItinerarySummaryQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItinerarySummaryQuery.cs
@@ -1,0 +1,10 @@
+﻿using AllReady.Areas.Admin.ViewModels.Itinerary;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class ItinerarySummaryQuery : IAsyncRequest<ItinerarySummaryViewModel>
+    {
+        public int ItineraryId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItinerarySummaryQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItinerarySummaryQueryHandler.cs
@@ -1,0 +1,46 @@
+﻿using AllReady.Models;
+using MediatR;
+using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Areas.Admin.ViewModels.Itinerary;
+using AllReady.Areas.Admin.ViewModels.Shared;
+using Microsoft.EntityFrameworkCore;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    public class ItinerarySummaryQueryHandler : IAsyncRequestHandler<ItinerarySummaryQuery, ItinerarySummaryViewModel>
+    {
+        private readonly AllReadyContext _context;
+
+        public ItinerarySummaryQueryHandler(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<ItinerarySummaryViewModel> Handle(ItinerarySummaryQuery message)
+        {
+            var itineraryDetails = await _context.Itineraries
+                .AsNoTracking()
+                .Include(x => x.Event)
+                    .ThenInclude(x => x.Campaign)
+                        .ThenInclude(x => x.ManagingOrganization)
+                .Where(a => a.Id == message.ItineraryId)
+                .Select(i => new ItinerarySummaryViewModel
+                {
+                    Id = i.Id,
+                    Name = i.Name,
+                    Date = i.Date,
+                    OrganizationId = i.Event.Campaign.ManagingOrganizationId,
+                    EventSummary = new EventSummaryViewModel
+                    {
+                        Id = i.EventId,
+                        StartDateTime = i.Event.StartDateTime,
+                        EndDateTime = i.Event.EndDateTime
+                    }
+                })
+                .SingleOrDefaultAsync();
+
+            return itineraryDetails;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Itinerary/ItineraryEditViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Itinerary/ItineraryEditViewModel.cs
@@ -9,11 +9,21 @@ namespace AllReady.Areas.Admin.ViewModels.Itinerary
 
         public int EventId { get; set; }
 
+        public int OrganizationId { get; set; }
+
+        public int CampaignId { get; set; }
+
+        public string CampaignName { get; set; }
+
+        public string EventName { get; set; }
+
         [Required]
         public string Name { get; set; }
 
         [Required]
         [DataType(DataType.Date)]
         public DateTime Date { get; set; }
+        
+        // todo - address
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Itinerary/ItineraryEditViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Itinerary/ItineraryEditViewModel.cs
@@ -23,7 +23,44 @@ namespace AllReady.Areas.Admin.ViewModels.Itinerary
         [Required]
         [DataType(DataType.Date)]
         public DateTime Date { get; set; }
-        
-        // todo - address
+
+        [Display(Name = "Address line 1")]
+        public string StartAddress1 { get; set; }
+
+        [Display(Name = "Address line 2")]
+        public string StartAddress2 { get; set; }
+
+        [Display(Name = "City")]
+        public string StartCity { get; set; }
+
+        [Display(Name = "State")]
+        public string StartState { get; set; }
+
+        [Display(Name = "Postal Code")]
+        public string StartPostalCode { get; set; }
+
+        [Display(Name = "Country")]
+        public string StartCountry { get; set; }
+
+        [Display(Name = "Address line 1")]
+        public string EndAddress1 { get; set; }
+
+        [Display(Name = "Address line 2")]
+        public string EndAddress2 { get; set; }
+
+        [Display(Name = "City")]
+        public string EndCity { get; set; }
+
+        [Display(Name = "State")]
+        public string EndState { get; set; }
+
+        [Display(Name = "Postal Code")]
+        public string EndPostalCode { get; set; }
+
+        [Display(Name = "Country")]
+        public string EndCountry { get; set; }
+
+        [Display(Name = "Same as start address")]
+        public bool UseStartAddressAsEndAddress { get; set; } = true;
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Itinerary/ItinerarySummaryViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Itinerary/ItinerarySummaryViewModel.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using AllReady.Areas.Admin.ViewModels.Shared;
+
+namespace AllReady.Areas.Admin.ViewModels.Itinerary
+{
+    /// <summary>
+    /// Defines summary information for an itinerary
+    /// </summary>
+    public class ItinerarySummaryViewModel
+    {
+        /// <summary>
+        /// The ID of the itinerary being displayed
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// The name of the itinerary being displayed
+        /// </summary>
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// The date on which the itinerary will take place
+        /// </summary>
+        public DateTime Date { get; set; }
+
+        /// <summary>
+        /// The ID of the Organization who owns the itinerary
+        /// </summary>
+        public int OrganizationId { get; set; }
+
+        /// <summary>
+        /// Summary information for the event. By default this only loads the id and the start and end dates
+        /// </summary>
+        public EventSummaryViewModel EventSummary { get; set; }
+
+        /// <summary>
+        /// The date on which the itinerary will take place (in date long string format)
+        /// </summary>
+        public string DisplayDate => Date.ToLongDateString();
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -19,9 +19,8 @@
     <div class="col-md-12">
         <h2>
             @Model.Name
-            @*<a asp-area="Admin" asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
-                <a asp-area="Admin" asp-controller="Itinerary" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>*@
-        </h2>
+            <a asp-area="Admin" asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
+        </h2>        
         <p>Scheduled for @Model.DisplayDate</p>
     </div>
 </div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Edit.cshtml
@@ -1,0 +1,56 @@
+@using System.Threading.Tasks
+@model AllReady.Areas.Admin.ViewModels.Itinerary.ItineraryEditViewModel
+
+<div class="row">
+    <div class="col-12">
+        <ol class="breadcrumb">
+            <li><a asp-controller="Campaign" asp-action="Index" asp-area="Admin">Campaigns</a></li>
+            <li><a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.CampaignId" asp-area="Admin">@Model.CampaignName</a></li>
+            <li><a asp-controller="Event" asp-action="Details" asp-route-id="@Model.EventId" asp-area="Admin">@Model.EventName</a></li>
+            <li><a asp-controller="Itinerary" asp-action="Details" asp-route-id="@Model.Id" asp-area="Admin">@Model.Name</a></li>
+            <li>Edit</li>
+        </ol>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-12">
+        <h2>Edit Itinerary - @Model.Name</h2>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-12">
+        <form asp-controller="Itinerary" asp-action="Edit" asp-area="Admin" method="post">
+            <div class="form-horizontal row">
+                <hr />
+                <div class="form-horizontal col-lg-6 pull-left">
+                    <div asp-validation-summary="All" class="text-danger"></div>
+                    <input type="hidden" asp-for="Id" />
+
+                    <div class="form-group">
+                        <label asp-for="Name" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="Name" class="form-control" />
+                            <span asp-validation-for="Name" class="text-danger"></span>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="Date" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="Date" class="form-control" value="@Model.Date.ToString("yyyy-MM-dd")" />
+                            <span asp-validation-for="Date" class="text-danger"></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-md-12">
+                    <button type="submit" value="Save" class="btn btn-default submit-form">Save</button>
+                    <a asp-action="Details" asp-route-id="@Model.Id" class="btn btn-default">Cancel</a>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Edit.cshtml
@@ -22,6 +22,7 @@
 <div class="row">
     <div class="col-12">
         <form asp-controller="Itinerary" asp-action="Edit" asp-area="Admin" method="post">
+
             <div class="form-horizontal row">
                 <hr />
                 <div class="form-horizontal col-lg-6 pull-left">
@@ -44,6 +45,100 @@
                     </div>
                 </div>
             </div>
+
+            <h3>Route Optimization</h3>
+            <p>Supply a start / end address for the itinerary so that requests can be organized by an optimal route and direction informaiton can be generated.</p>
+            <hr/>
+            <h4>Start Address</h4>
+            <div class="form-horizontal row">
+                <div class="form-horizontal col-lg-6 pull-left">
+                    <div class="form-group">
+                        <label asp-for="StartAddress1" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="StartAddress1" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="StartAddress2" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="StartAddress2" class="form-control" />
+
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="StartCity" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="StartCity" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="StartState" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="StartState" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="StartPostalCode" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="StartPostalCode" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="StartCountry" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="StartCountry" class="form-control" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <h4>End Address</h4>
+            <div class="form-group">
+                <label asp-for="UseStartAddressAsEndAddress" class="control-label col-md-2"></label>
+                <div class="col-md-10">
+                    <input asp-for="UseStartAddressAsEndAddress" class="form-control" />
+                </div>
+            </div>
+            <div class="form-horizontal row">
+                <div class="form-horizontal col-lg-6 pull-left">
+                    <div class="form-group">
+                        <label asp-for="EndAddress1" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="EndAddress1" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="EndAddress2" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="EndAddress2" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="EndCity" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="EndCity" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="EndState" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="EndState" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="EndPostalCode" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="EndPostalCode" class="form-control" />
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="EndCountry" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input asp-for="EndCountry" class="form-control" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <br/>
 
             <div class="row">
                 <div class="col-md-12">

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Edit.cshtml
@@ -36,13 +36,6 @@
                             <span asp-validation-for="Name" class="text-danger"></span>
                         </div>
                     </div>
-                    <div class="form-group">
-                        <label asp-for="Date" class="control-label col-md-2"></label>
-                        <div class="col-md-10">
-                            <input asp-for="Date" class="form-control" value="@Model.Date.ToString("yyyy-MM-dd")" />
-                            <span asp-validation-for="Date" class="text-danger"></span>
-                        </div>
-                    </div>
                 </div>
             </div>
 

--- a/AllReadyApp/Web-App/AllReady/Migrations/20161107192158_ItineraryAddresses.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20161107192158_ItineraryAddresses.Designer.cs
@@ -1,0 +1,979 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using AllReady.Models;
+
+namespace AllReady.Migrations
+{
+    [DbContext(typeof(AllReadyContext))]
+    [Migration("20161107192158_ItineraryAddresses")]
+    partial class ItineraryAddresses
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.0.1")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<int>("EventId");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("AllReadyTask");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PendingNewEmail");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasName("EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .IsUnique()
+                        .HasName("UserNameIndex");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("ApplicationUser");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignImpactId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<string>("ExternalUrl");
+
+                    b.Property<string>("ExternalUrlText");
+
+                    b.Property<bool>("Featured");
+
+                    b.Property<string>("FullDescription");
+
+                    b.Property<string>("Headline")
+                        .HasAnnotation("MaxLength", 150);
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<bool>("Locked");
+
+                    b.Property<int>("ManagingOrganizationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CampaignImpactId");
+
+                    b.HasIndex("LocationId");
+
+                    b.HasIndex("ManagingOrganizationId");
+
+                    b.HasIndex("OrganizerId");
+
+                    b.ToTable("Campaign");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.Property<int>("CampaignId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.Property<int?>("ContactId1");
+
+                    b.HasKey("CampaignId", "ContactId", "ContactType");
+
+                    b.HasIndex("CampaignId");
+
+                    b.HasIndex("ContactId");
+
+                    b.HasIndex("ContactId1");
+
+                    b.ToTable("CampaignContact");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignImpact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CurrentImpactLevel");
+
+                    b.Property<bool>("Display");
+
+                    b.Property<int>("ImpactType");
+
+                    b.Property<int>("NumericImpactGoal");
+
+                    b.Property<string>("TextualImpactGoal");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CampaignImpact");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignId");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CampaignId");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("CampaignSponsors");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ClosestLocation", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<double>("Distance");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+
+                    b.ToTable("ClosestLocation");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Contact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Contact");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Event", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CampaignId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<int>("EventType");
+
+                    b.Property<string>("Headline")
+                        .HasAnnotation("MaxLength", 150);
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CampaignId");
+
+                    b.HasIndex("LocationId");
+
+                    b.HasIndex("OrganizerId");
+
+                    b.ToTable("Event");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSkill", b =>
+                {
+                    b.Property<int>("EventId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("EventId", "SkillId");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("SkillId");
+
+                    b.ToTable("EventSkill");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Itinerary", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime>("Date");
+
+                    b.Property<double>("EndLatitude");
+
+                    b.Property<int?>("EndLocationId");
+
+                    b.Property<double>("EndLongitude");
+
+                    b.Property<int>("EventId");
+
+                    b.Property<string>("Name");
+
+                    b.Property<double>("StartLatitude");
+
+                    b.Property<int?>("StartLocationId");
+
+                    b.Property<double>("StartLongitude");
+
+                    b.Property<bool>("UseStartAddressAsEndAddress");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EndLocationId")
+                        .IsUnique();
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("StartLocationId")
+                        .IsUnique();
+
+                    b.ToTable("Itinerary");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>
+                {
+                    b.Property<int>("ItineraryId");
+
+                    b.Property<Guid>("RequestId");
+
+                    b.Property<DateTime>("DateAssigned");
+
+                    b.Property<int>("OrderIndex");
+
+                    b.HasKey("ItineraryId", "RequestId");
+
+                    b.HasIndex("ItineraryId");
+
+                    b.HasIndex("RequestId");
+
+                    b.ToTable("ItineraryRequest");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Location", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address1");
+
+                    b.Property<string>("Address2");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("Country");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Location");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("DescriptionHtml");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("LogoUrl");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("PrivacyPolicy");
+
+                    b.Property<string>("PrivacyPolicyUrl");
+
+                    b.Property<string>("Summary")
+                        .HasAnnotation("MaxLength", 250);
+
+                    b.Property<string>("WebUrl");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("LocationId");
+
+                    b.ToTable("Organization");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.Property<int>("OrganizationId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.Property<int?>("ContactId1");
+
+                    b.HasKey("OrganizationId", "ContactId", "ContactType");
+
+                    b.HasIndex("ContactId");
+
+                    b.HasIndex("ContactId1");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("OrganizationContact");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeo", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+
+                    b.ToTable("PostalCodeGeo");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeoCoordinate", b =>
+                {
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.HasKey("Latitude", "Longitude");
+
+                    b.ToTable("PostalCodeGeoCoordinate");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.Property<Guid>("RequestId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address");
+
+                    b.Property<string>("City");
+
+                    b.Property<DateTime>("DateAdded");
+
+                    b.Property<string>("Email");
+
+                    b.Property<int?>("EventId");
+
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("Phone");
+
+                    b.Property<string>("ProviderData");
+
+                    b.Property<string>("ProviderId");
+
+                    b.Property<int>("Source");
+
+                    b.Property<string>("State");
+
+                    b.Property<int>("Status");
+
+                    b.Property<string>("Zip");
+
+                    b.HasKey("RequestId");
+
+                    b.HasIndex("EventId");
+
+                    b.ToTable("Request");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Resource", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("CategoryTag");
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("MediaUrl");
+
+                    b.Property<string>("Name");
+
+                    b.Property<DateTime>("PublishDateBegin");
+
+                    b.Property<DateTime>("PublishDateEnd");
+
+                    b.Property<string>("ResourceUrl");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Resource");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int?>("OwningOrganizationId");
+
+                    b.Property<int?>("ParentSkillId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("OwningOrganizationId");
+
+                    b.HasIndex("ParentSkillId");
+
+                    b.ToTable("Skill");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<int?>("ItineraryId");
+
+                    b.Property<string>("Status");
+
+                    b.Property<DateTime>("StatusDateTimeUtc");
+
+                    b.Property<string>("StatusDescription");
+
+                    b.Property<int>("TaskId");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ItineraryId");
+
+                    b.HasIndex("TaskId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("TaskSignup");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.Property<int>("TaskId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("TaskId", "SkillId");
+
+                    b.HasIndex("SkillId");
+
+                    b.HasIndex("TaskId");
+
+                    b.ToTable("TaskSkill");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("UserId", "SkillId");
+
+                    b.HasIndex("SkillId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("UserSkill");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Name")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .HasName("RoleNameIndex");
+
+                    b.ToTable("IdentityRole");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("RoleId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("IdentityRoleClaim<string>");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("IdentityUserClaim<string>");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider");
+
+                    b.Property<string>("ProviderKey");
+
+                    b.Property<string>("ProviderDisplayName");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("IdentityUserLogin<string>");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<string>("RoleId");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("IdentityUserRole<string>");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserToken<string>", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<string>("LoginProvider");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("Value");
+
+                    b.HasKey("UserId", "LoginProvider", "Name");
+
+                    b.ToTable("IdentityUserToken<string>");
+                });
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.HasOne("AllReady.Models.Event", "Event")
+                        .WithMany("Tasks")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Organization", "Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany("Users")
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.HasOne("AllReady.Models.CampaignImpact", "CampaignImpact")
+                        .WithMany()
+                        .HasForeignKey("CampaignImpactId");
+
+                    b.HasOne("AllReady.Models.Location", "Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.Organization", "ManagingOrganization")
+                        .WithMany("Campaigns")
+                        .HasForeignKey("ManagingOrganizationId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "Organizer")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign", "Campaign")
+                        .WithMany("CampaignContacts")
+                        .HasForeignKey("CampaignId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Contact", "Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany("CampaignContacts")
+                        .HasForeignKey("ContactId1");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign", "Campaign")
+                        .WithMany("ParticipatingOrganizations")
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Organization", "Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Event", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign", "Campaign")
+                        .WithMany("Events")
+                        .HasForeignKey("CampaignId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Location", "Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "Organizer")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Event", "Event")
+                        .WithMany("RequiredSkills")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Skill", "Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.Itinerary", b =>
+                {
+                    b.HasOne("AllReady.Models.Location", "EndLocation")
+                        .WithOne()
+                        .HasForeignKey("AllReady.Models.Itinerary", "EndLocationId");
+
+                    b.HasOne("AllReady.Models.Event", "Event")
+                        .WithMany("Itineraries")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Location", "StartLocation")
+                        .WithOne()
+                        .HasForeignKey("AllReady.Models.Itinerary", "StartLocationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>
+                {
+                    b.HasOne("AllReady.Models.Itinerary", "Itinerary")
+                        .WithMany("Requests")
+                        .HasForeignKey("ItineraryId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Request", "Request")
+                        .WithMany("Itineraries")
+                        .HasForeignKey("RequestId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.HasOne("AllReady.Models.Location", "Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Contact", "Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany("OrganizationContacts")
+                        .HasForeignKey("ContactId1");
+
+                    b.HasOne("AllReady.Models.Organization", "Organization")
+                        .WithMany("OrganizationContacts")
+                        .HasForeignKey("OrganizationId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.HasOne("AllReady.Models.Event", "Event")
+                        .WithMany("Requests")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.SetNull);
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization", "OwningOrganization")
+                        .WithMany()
+                        .HasForeignKey("OwningOrganizationId");
+
+                    b.HasOne("AllReady.Models.Skill", "ParentSkill")
+                        .WithMany("ChildSkills")
+                        .HasForeignKey("ParentSkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.HasOne("AllReady.Models.Itinerary", "Itinerary")
+                        .WithMany("TeamMembers")
+                        .HasForeignKey("ItineraryId");
+
+                    b.HasOne("AllReady.Models.AllReadyTask", "Task")
+                        .WithMany("AssignedVolunteers")
+                        .HasForeignKey("TaskId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill", "Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.AllReadyTask", "Task")
+                        .WithMany("RequiredSkills")
+                        .HasForeignKey("TaskId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill", "Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "User")
+                        .WithMany("AssociatedSkills")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole")
+                        .WithMany("Claims")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany("Claims")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany("Logins")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole")
+                        .WithMany("Users")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany("Roles")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20161107192158_ItineraryAddresses.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20161107192158_ItineraryAddresses.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace AllReady.Migrations
+{
+    public partial class ItineraryAddresses : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "EndLatitude",
+                table: "Itinerary",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "EndLocationId",
+                table: "Itinerary",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "EndLongitude",
+                table: "Itinerary",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<double>(
+                name: "StartLatitude",
+                table: "Itinerary",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StartLocationId",
+                table: "Itinerary",
+                nullable: true);
+
+            migrationBuilder.AddColumn<double>(
+                name: "StartLongitude",
+                table: "Itinerary",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "UseStartAddressAsEndAddress",
+                table: "Itinerary",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Itinerary_EndLocationId",
+                table: "Itinerary",
+                column: "EndLocationId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Itinerary_StartLocationId",
+                table: "Itinerary",
+                column: "StartLocationId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Itinerary_Location_EndLocationId",
+                table: "Itinerary",
+                column: "EndLocationId",
+                principalTable: "Location",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Itinerary_Location_StartLocationId",
+                table: "Itinerary",
+                column: "StartLocationId",
+                principalTable: "Location",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Itinerary_Location_EndLocationId",
+                table: "Itinerary");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Itinerary_Location_StartLocationId",
+                table: "Itinerary");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Itinerary_EndLocationId",
+                table: "Itinerary");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Itinerary_StartLocationId",
+                table: "Itinerary");
+
+            migrationBuilder.DropColumn(
+                name: "EndLatitude",
+                table: "Itinerary");
+
+            migrationBuilder.DropColumn(
+                name: "EndLocationId",
+                table: "Itinerary");
+
+            migrationBuilder.DropColumn(
+                name: "EndLongitude",
+                table: "Itinerary");
+
+            migrationBuilder.DropColumn(
+                name: "StartLatitude",
+                table: "Itinerary");
+
+            migrationBuilder.DropColumn(
+                name: "StartLocationId",
+                table: "Itinerary");
+
+            migrationBuilder.DropColumn(
+                name: "StartLongitude",
+                table: "Itinerary");
+
+            migrationBuilder.DropColumn(
+                name: "UseStartAddressAsEndAddress",
+                table: "Itinerary");
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
@@ -323,13 +323,33 @@ namespace AllReady.Migrations
 
                     b.Property<DateTime>("Date");
 
+                    b.Property<double>("EndLatitude");
+
+                    b.Property<int?>("EndLocationId");
+
+                    b.Property<double>("EndLongitude");
+
                     b.Property<int>("EventId");
 
                     b.Property<string>("Name");
 
+                    b.Property<double>("StartLatitude");
+
+                    b.Property<int?>("StartLocationId");
+
+                    b.Property<double>("StartLongitude");
+
+                    b.Property<bool>("UseStartAddressAsEndAddress");
+
                     b.HasKey("Id");
 
+                    b.HasIndex("EndLocationId")
+                        .IsUnique();
+
                     b.HasIndex("EventId");
+
+                    b.HasIndex("StartLocationId")
+                        .IsUnique();
 
                     b.ToTable("Itinerary");
                 });
@@ -808,10 +828,18 @@ namespace AllReady.Migrations
 
             modelBuilder.Entity("AllReady.Models.Itinerary", b =>
                 {
+                    b.HasOne("AllReady.Models.Location", "EndLocation")
+                        .WithOne()
+                        .HasForeignKey("AllReady.Models.Itinerary", "EndLocationId");
+
                     b.HasOne("AllReady.Models.Event", "Event")
                         .WithMany("Itineraries")
                         .HasForeignKey("EventId")
                         .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Location", "StartLocation")
+                        .WithOne()
+                        .HasForeignKey("AllReady.Models.Itinerary", "StartLocationId");
                 });
 
             modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
@@ -198,6 +198,8 @@ namespace AllReady.Models
             builder.HasKey(x => x.Id);
             builder.HasMany(x => x.Requests).WithOne(x => x.Itinerary).HasForeignKey((x => x.ItineraryId));
             builder.HasMany(x => x.TeamMembers).WithOne(x => x.Itinerary).HasForeignKey(x => x.ItineraryId).IsRequired(false);
+            builder.HasOne(x => x.StartLocation).WithOne().IsRequired(false);
+            builder.HasOne(x => x.EndLocation).WithOne().IsRequired(false);
         }
 
         public void Map(EntityTypeBuilder<ItineraryRequest> builder)

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
@@ -198,8 +198,8 @@ namespace AllReady.Models
             builder.HasKey(x => x.Id);
             builder.HasMany(x => x.Requests).WithOne(x => x.Itinerary).HasForeignKey((x => x.ItineraryId));
             builder.HasMany(x => x.TeamMembers).WithOne(x => x.Itinerary).HasForeignKey(x => x.ItineraryId).IsRequired(false);
-            builder.HasOne(x => x.StartLocation).WithOne().IsRequired(false);
-            builder.HasOne(x => x.EndLocation).WithOne().IsRequired(false);
+            builder.HasOne(x => x.StartLocation);
+            builder.HasOne(x => x.EndLocation);
         }
 
         public void Map(EntityTypeBuilder<ItineraryRequest> builder)

--- a/AllReadyApp/Web-App/AllReady/Models/Itinerary.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Itinerary.cs
@@ -8,9 +8,65 @@ namespace AllReady.Models
     /// </summary>
     public class Itinerary
     {
+        /// <summary>
+        /// The itinerary id
+        /// </summary>
         public int Id { get; set; }
+
+        /// <summary>
+        /// The date on which the itinerary is scheduled to occur
+        /// </summary>
         public DateTime Date { get; set; }
+
+        /// <summary>
+        /// A name to help identity the itinerary
+        /// </summary>
         public string Name { get; set; }
+
+        /// <summary>
+        /// The id of the start location record
+        /// </summary>
+        public int? StartLocationId { get; set; }
+
+        /// <summary>
+        /// A navigation property to the location record for the start address
+        /// </summary>
+        public Location StartLocation { get; set; }
+
+        /// <summary>
+        /// The longitude of the start address
+        /// </summary>
+        public double StartLongitude { get; set; }
+
+        /// <summary>
+        /// The latitude of the start address
+        /// </summary>
+        public double StartLatitude { get; set; }
+
+        /// <summary>
+        /// The id of the end location record
+        /// </summary>
+        public int? EndLocationId { get; set; }
+
+        /// <summary>
+        /// A navigation property to the location record for the end address
+        /// </summary>
+        public Location EndLocation { get; set; }
+
+        /// <summary>
+        /// The longitude of the end address
+        /// </summary>
+        public double EndLongitude { get; set; }
+
+        /// <summary>
+        /// The latitude of the end address
+        /// </summary>
+        public double EndLatitude { get; set; }
+
+        /// <summary>
+        /// Indicates that the start address should be used for the end address also
+        /// </summary>
+        public bool UseStartAddressAsEndAddress { get; set; }
 
         public int EventId { get; set; }
         public Event Event { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Models/Location.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Location.cs
@@ -1,4 +1,6 @@
-﻿using AllReady.Areas.Admin.ViewModels.Shared;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.Text;
+using AllReady.Areas.Admin.ViewModels.Shared;
 using AllReady.ViewModels.Shared;
 
 namespace AllReady.Models
@@ -14,6 +16,26 @@ namespace AllReady.Models
         public string Name { get; set; }
         public string PhoneNumber { get; set; }
         public string Country { get; set; } = "USA";
+
+        [NotMapped]
+        public string FullAddress
+        {
+            get
+            {
+                var address = new StringBuilder();
+
+                if (!string.IsNullOrWhiteSpace(Address1)) address.Append(Address1).Append(",");
+                if (!string.IsNullOrWhiteSpace(Address2)) address.Append(Address2).Append(",");
+                if (!string.IsNullOrWhiteSpace(City)) address.Append(City).Append(",");
+                if (!string.IsNullOrWhiteSpace(State)) address.Append(State).Append(",");
+                if (!string.IsNullOrWhiteSpace(PostalCode)) address.Append(PostalCode).Append(",");
+                if (!string.IsNullOrWhiteSpace(Country)) address.Append(Country);
+
+                if (address[address.Length - 1].Equals(',')) address = address.Remove(address.Length - 1, 1);
+
+                return address.ToString();
+            }
+        }
     }
 
     public static class LocationExtensions


### PR DESCRIPTION
Fixes #1331 

This is an initial quick pass to enable editing an itinerary. The main purpose is to allow a start/end address to be set for an itinerary to the be used in my work for issue #1102 

I'll continue with that issue once this is merged.

Note: I've not included unit tests for the edit itinerary handler yet. I'll open a follow up issue for that.
The validation also needs tweaking to validate the addresses as well. Again, I'll follow that up in a new issue.