### PR TITLE
Include more data in volunteers task grid #1520

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/DetailsQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/DetailsQueryHandlerShould.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Tasks;
 using AllReady.Areas.Admin.ViewModels.Task;
 using AllReady.Models;
 using Xunit;
+using AllReady.Areas.Admin.ViewModels.Shared;
 
 namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
 {
@@ -33,7 +35,21 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
                     TimeZoneId = "Central Standard Time"
                 },
                 RequiredSkills = new List<TaskSkill> { new TaskSkill { SkillId = 4, TaskId = 1 } },
-                AssignedVolunteers = new List<TaskSignup> { new TaskSignup { User = new ApplicationUser { Id = "UserId", UserName = "UserName" } } }
+                AssignedVolunteers = new List<TaskSignup>
+                {
+                    new TaskSignup
+                    {
+                        User = new ApplicationUser
+                        {
+                            Id = "UserId",
+                            UserName = "UserName",
+                            FirstName = "FirstName",
+                            LastName = "LastName",
+                            PhoneNumber = "PhoneNumber",
+                            AssociatedSkills = new List<UserSkill> { new UserSkill { Skill = new Skill { Name = "Skill", ParentSkill = new Skill { Name = "Parent skill" } } } }
+                        }
+                    }
+                }
             };
 
             Context.Tasks.Add(task);
@@ -58,7 +74,22 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
             Assert.Equal(result.CampaignName, task.Event.Campaign.Name);
             Assert.Equal(result.TimeZoneId, task.Event.TimeZoneId);
             //Assert.Equal(result.RequiredSkills, task.RequiredSkills);
-            //Assert.Equal(result.AssignedVolunteers, task.AssignedVolunteers.Select(x => new VolunteerViewModel { UserId = x.User.Id, UserName = x.User.UserName, HasVolunteered = true }).ToList());
+            Assert.Equal(result.AssignedVolunteers.Count, task.AssignedVolunteers.Count);
+            for (var i = 0; i < result.AssignedVolunteers.Count; ++i)
+            {
+                var resultVolunteer = result.AssignedVolunteers[i];
+                var expectedVolunteer = task.AssignedVolunteers[i];
+                Assert.Equal(resultVolunteer.UserId, expectedVolunteer.User.Id);
+                Assert.Equal(resultVolunteer.UserName, expectedVolunteer.User.UserName);
+                Assert.True(resultVolunteer.HasVolunteered);
+                Assert.Equal(resultVolunteer.Name, expectedVolunteer.User.Name);
+                Assert.Equal(resultVolunteer.PhoneNumber, expectedVolunteer.User.PhoneNumber);
+                Assert.Equal(resultVolunteer.AssociatedSkills.Count, expectedVolunteer.User.AssociatedSkills.Count);
+                for (var j = 0; j < resultVolunteer.AssociatedSkills.Count; ++j)
+                {
+                    Assert.Equal(resultVolunteer.AssociatedSkills[j].Skill.HierarchicalName, resultVolunteer.AssociatedSkills[j].Skill.HierarchicalName);
+                }
+            }
             //Assert.Equal(result.AllVolunteers, task.Event.UsersSignedUp.Select(x => new VolunteerViewModel { UserId = x.User.Id, UserName = x.User.UserName, HasVolunteered = false }).ToList());
         }
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/DetailsQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/DetailsQueryHandler.cs
@@ -35,7 +35,15 @@ namespace AllReady.Areas.Admin.Features.Tasks
                 CampaignName = task.Event.Campaign.Name,
                 TimeZoneId = task.Event.TimeZoneId,
                 RequiredSkills = task.RequiredSkills,
-                AssignedVolunteers = task.AssignedVolunteers.Select(ts => new VolunteerViewModel { UserId = ts.User.Id, UserName = ts.User.UserName, HasVolunteered = true }).ToList(),
+                AssignedVolunteers = task.AssignedVolunteers.Select(ts => new VolunteerViewModel
+                {
+                    UserId = ts.User.Id,
+                    UserName = ts.User.UserName,
+                    HasVolunteered = true,
+                    Name = ts.User.Name,
+                    PhoneNumber = ts.User.PhoneNumber,
+                    AssociatedSkills = ts.User.AssociatedSkills,
+                }).ToList(),
             };
 
             return model;
@@ -47,7 +55,7 @@ namespace AllReady.Areas.Admin.Features.Tasks
                 .AsNoTracking()
                 .Include(t => t.Event)
                 .Include(t => t.Event.Campaign)
-                .Include(t => t.AssignedVolunteers).ThenInclude(ts => ts.User)
+                .Include(t => t.AssignedVolunteers).ThenInclude(ts => ts.User).ThenInclude(u => u.AssociatedSkills).ThenInclude(s => s.Skill).ThenInclude(s => s.ParentSkill).ThenInclude(s => s.ParentSkill)
                 .Include(t => t.RequiredSkills).ThenInclude(ts => ts.Skill).ThenInclude(s => s.ParentSkill).ThenInclude(s => s.ParentSkill)
                 .SingleOrDefaultAsync(t => t.Id == message.TaskId);
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Shared/VolunteerViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Shared/VolunteerViewModel.cs
@@ -1,4 +1,7 @@
-﻿namespace AllReady.Areas.Admin.ViewModels.Shared
+﻿using AllReady.Models;
+using System.Collections.Generic;
+
+namespace AllReady.Areas.Admin.ViewModels.Shared
 {
     public class VolunteerViewModel
     {
@@ -7,5 +10,8 @@
         public bool HasVolunteered { get; set; }
         public string Status { get; set; }
         public string AdditionalInfo { get; set; }
+        public string PhoneNumber { get; set; }
+        public string Name { get; set; }
+        public List<UserSkill> AssociatedSkills { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Task/Details.cshtml
@@ -60,15 +60,25 @@
                     <button type="button" id="openMessageToVolunteers" class="btn btn-primary" disabled="disabled" autocomplete="off" data-toggle="modal" data-target="#messageVolunteersModal">Message All</button>
                     <table class="table">
                         <tr>
-                            <th>
-                                Volunteer Name
-                            </th>
+                            <th>Volunteer Name</th>
+                            <th>Phone</th>
+                            <th>Skills</th>
+                            <th>E-mail</th>
                         </tr>
                         @foreach (var volunteer in Model.AssignedVolunteers)
                         {
                             <tr>
+                                <td>@volunteer.Name</td>
+                                <td>@volunteer.PhoneNumber</td>
+                                <td>
+                                    <ul>
+                                        @foreach (var associatedSkill in volunteer.AssociatedSkills)
+                                        {
+                                            <li><strong>@associatedSkill.Skill.HierarchicalName</strong></li>
+                                        }
+                                    </ul>
+                                </td>
                                 <td>@volunteer.UserName</td>
-
                             </tr>
                         }
                     </table>


### PR DESCRIPTION
Going in to a tasking page and seeing the volunteers who have signed up, the admin for the org is now able to see the name, phone, skills and email of the volunteers. The address field has not been added because it doesn't (seem to) exist yet.

Issue #1520 