### PR TITLE
Rename ProviderId to ProviderRequestId on Request model

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Requests/AddApiRequestCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Requests/AddApiRequestCommandHandlerShould.cs
@@ -47,7 +47,7 @@ namespace AllReady.UnitTest.Features.Requests
             var request = Context.Requests.Single(x => x.RequestId == requestId);
 
             Assert.Equal(request.RequestId, requestId);
-            Assert.Equal(request.ProviderId, viewModel.ProviderRequestId);
+            Assert.Equal(request.ProviderRequestId, viewModel.ProviderRequestId);
             Assert.Equal(request.ProviderData, viewModel.ProviderData);
             Assert.Equal(request.Address, viewModel.Address);
             Assert.Equal(request.City, viewModel.City);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Requests/RequestExistsByProviderIdQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Requests/RequestExistsByProviderIdQueryHandlerShould.cs
@@ -11,7 +11,7 @@ namespace AllReady.UnitTest.Features.Requests
         {
             const string providerRequestId = "ProviderId";
 
-            var request = new Request { ProviderId = providerRequestId };
+            var request = new Request { ProviderRequestId = providerRequestId };
             Context.Requests.Add(request);
             Context.SaveChanges();
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/ImportRequestsCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/ImportRequestsCommandHandler.cs
@@ -26,7 +26,7 @@ namespace AllReady.Areas.Admin.Features.Requests
                 request.Source = RequestSource.Csv;
 
                 // todo: do basic data validation
-                if (!_context.Requests.Any(r => r.ProviderId == request.ProviderId))
+                if (!_context.Requests.Any(r => r.ProviderRequestId == request.ProviderRequestId))
                 {
                     //If lat/long not provided, use geocoding API to get them
                     if (request.Latitude == 0 && request.Longitude == 0)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Request/RedCrossRequestMap.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Request/RedCrossRequestMap.cs
@@ -24,7 +24,7 @@ namespace AllReady.Areas.Admin.ViewModels.Request
             Map(r => r.Email).Name("email");
             Map(r => r.DateAdded).Name("date created").Default(DateTime.UtcNow);
             Map(r => r.ProviderData).Name("region");
-            Map(r => r.ProviderId).Name("id");
+            Map(r => r.ProviderRequestId).Name("id");
             Map(r => r.Latitude).Name("latitude").Default(0);
             Map(r => r.Longitude).Name("longitude").Default(0);
         }

--- a/AllReadyApp/Web-App/AllReady/Features/Requests/AddApiRequestCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Requests/AddApiRequestCommandHandler.cs
@@ -30,7 +30,7 @@ namespace AllReady.Features.Requests
             var request = new Request
             {
                 RequestId = NewRequestId(),
-                ProviderId = message.ViewModel.ProviderRequestId,
+                ProviderRequestId = message.ViewModel.ProviderRequestId,
                 ProviderData = message.ViewModel.ProviderData,
                 Address = message.ViewModel.Address,
                 City = message.ViewModel.City,

--- a/AllReadyApp/Web-App/AllReady/Features/Requests/RequestExistsByProviderIdQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Requests/RequestExistsByProviderIdQueryHandler.cs
@@ -15,7 +15,7 @@ namespace AllReady.Features.Requests
 
         public bool Handle(RequestExistsByProviderIdQuery message)
         {
-            return context.Requests.Any(x => x.ProviderId == message.ProviderRequestId);
+            return context.Requests.Any(x => x.ProviderRequestId == message.ProviderRequestId);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Migrations/20161201212218_RenameProviderIdToProviderRequestIdOnRequestModel.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20161201212218_RenameProviderIdToProviderRequestIdOnRequestModel.Designer.cs
@@ -8,9 +8,10 @@ using AllReady.Models;
 namespace AllReady.Migrations
 {
     [DbContext(typeof(AllReadyContext))]
-    partial class AllReadyContextModelSnapshot : ModelSnapshot
+    [Migration("20161201212218_RenameProviderIdToProviderRequestIdOnRequestModel")]
+    partial class RenameProviderIdToProviderRequestIdOnRequestModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
             modelBuilder
                 .HasAnnotation("ProductVersion", "1.0.1")

--- a/AllReadyApp/Web-App/AllReady/Migrations/20161201212218_RenameProviderIdToProviderRequestIdOnRequestModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20161201212218_RenameProviderIdToProviderRequestIdOnRequestModel.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace AllReady.Migrations
+{
+    public partial class RenameProviderIdToProviderRequestIdOnRequestModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProviderId",
+                table: "Request");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProviderRequestId",
+                table: "Request",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ProviderRequestId",
+                table: "Request");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ProviderId",
+                table: "Request",
+                nullable: true);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Models/Request.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Request.cs
@@ -9,8 +9,9 @@ namespace AllReady.Models
 
     public class Request
     {
-        // basic data
         public Guid RequestId { get; set; }
+        // allow for unique identifiers and mapping information
+        public string ProviderRequestId { get; set; } //for RedCross, "serial"
         public string Name { get; set; }
         public string Address { get; set; }
         public string City { get; set; }
@@ -19,21 +20,13 @@ namespace AllReady.Models
         public string Phone { get; set; }
         public string Email { get; set; }
         public RequestStatus Status { get; set; } = RequestStatus.Unassigned;
-
-        /// <summary>
-        /// The source of the request
-        /// </summary>
         public RequestSource Source { get; set; } = RequestSource.Unknown;
 
         // no support yet for spatial types
         public double Latitude { get; set; }
         public double Longitude { get; set; }
 
-        // allow for unique identifiers and mapping information
-        public string ProviderId { get; set; }      // for RedCross, "serial"
-
-        //TODO: mgmccarthy. We might not have to store this in the Request table
-        public string ProviderData { get; set; }    // for Red Cross, "assigned_rc_region"
+        public string ProviderData { get; set; } //for Red Cross, "assigned_rc_region"
 
         public int? EventId { get; set; }
         public Event Event { get; set; }


### PR DESCRIPTION
a simple renaming to make this property intent more explicit.

ProviderId sounds like a unique identifier for the provider of the data, not a unique id per message from that provider.

ProviderRequestId does a better job at conveying the meaning.