### PR TITLE
Fix unit test TaskStatusChangeHandlerShould.VolunteerCompletesTaskFromAssignedStatus

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Tasks/TaskStatusChangeHandlerShould.cs
@@ -6,7 +6,6 @@ using AllReady.Areas.Admin.Features.Tasks;
 using AllReady.Features.Notifications;
 using AllReady.Models;
 using MediatR;
-using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using Xunit;
 using Shouldly;
@@ -18,11 +17,12 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
     {
         private readonly Mock<IMediator> mediator;
         private readonly TaskStatusChangeHandler handler;
+        private readonly DateTime dateTimeUtcNow = DateTime.UtcNow;
 
         public TaskStatusChangeHandlerShould()
         {
             mediator = new Mock<IMediator>();
-            handler = new TaskStatusChangeHandler(Context, mediator.Object);
+            handler = new TaskStatusChangeHandler(Context, mediator.Object) { DateTimeUtcNow = () => dateTimeUtcNow };
         }
 
         protected override void LoadTestData()
@@ -301,7 +301,6 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
         [Fact]
         public async Task VolunteerCompletesTaskFromAssignedStatus()
         {
-            var dateTime = DateTime.UtcNow;
             var task = Context.Tasks.First();
             var user = Context.Users.First();
             var command = new TaskStatusChangeCommand
@@ -320,7 +319,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
             taskSignup.Task.Id.ShouldBe(command.TaskId);
             taskSignup.User.Id.ShouldBe(command.UserId);
             taskSignup.StatusDescription.ShouldBe(command.TaskStatusDescription);
-            taskSignup.StatusDateTimeUtc.ShouldBe(dateTime, TimeSpan.FromSeconds(3));
+            taskSignup.StatusDateTimeUtc.ShouldBe(dateTimeUtcNow);
         }
 
         [Fact]
@@ -376,7 +375,6 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
         [Fact]
         public async Task VolunteerCannotCompleteTaskFromAssignedStatus()
         {
-            var dateTime = DateTime.UtcNow;
             var user = Context.Users.First();
             var task = Context.Tasks.First();
             var command = new TaskStatusChangeCommand
@@ -395,7 +393,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Tasks
             taskSignup.User.Id.ShouldBe(command.UserId);
             taskSignup.Task.Id.ShouldBe(command.TaskId);
             taskSignup.StatusDescription.ShouldBe(command.TaskStatusDescription);
-            taskSignup.StatusDateTimeUtc.ShouldBe(dateTime, TimeSpan.FromSeconds(1));
+            taskSignup.StatusDateTimeUtc.ShouldBe(dateTimeUtcNow);
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskStatusChangeHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/TaskStatusChangeHandler.cs
@@ -10,6 +10,8 @@ namespace AllReady.Areas.Admin.Features.Tasks
 {
     public class TaskStatusChangeHandler : IAsyncRequestHandler<TaskStatusChangeCommand, TaskChangeResult>
     {
+        public Func<DateTime> DateTimeUtcNow = () => DateTime.UtcNow;
+
         private AllReadyContext _context;
         private IMediator _mediator;
 
@@ -59,7 +61,8 @@ namespace AllReady.Areas.Admin.Features.Tasks
             }
 
             taskSignup.Status = message.TaskStatus.ToString();
-            taskSignup.StatusDateTimeUtc = DateTime.UtcNow;
+            //taskSignup.StatusDateTimeUtc = DateTime.UtcNow;
+            taskSignup.StatusDateTimeUtc = DateTimeUtcNow();
             taskSignup.StatusDescription = message.TaskStatusDescription;
 
             await _context.SaveChangesAsync();


### PR DESCRIPTION
and any other unit tests in this class using `TimeSpan.FromSeconds()`...

`TimeSpan.FromSeconds` should never be used in unit tests b/c time is relative to how fast a machine that is able to run a unit test(s)

![image](https://cloud.githubusercontent.com/assets/2428993/20851517/03f016d2-b8af-11e6-87e1-4e64a218d586.png)
