### PR TITLE
Fixed use start address as end address check change.

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/EditItineraryCommandHandlerShould.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Itineraries;
 using AllReady.Areas.Admin.ViewModels.Itinerary;
+using Microsoft.EntityFrameworkCore;
 using Xunit;
 
 namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
@@ -36,7 +37,7 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
                 CampaignId = firePrev.Id,
                 StartDateTime = new DateTime(2015, 7, 4, 10, 0, 0).ToUniversalTime(),
                 EndDateTime = new DateTime(2015, 12, 31, 15, 0, 0).ToUniversalTime(),
-                Location = new Location { Id = 1 },
+                Location = new Location { },
                 RequiredSkills = new List<EventSkill>(),
                 EventType = EventType.Itinerary
             };
@@ -45,8 +46,12 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
             {
                 Event = queenAnne,
                 Name = "1st Itinerary",
-                Date = new DateTime(2016, 07, 01)
+                Date = new DateTime(2016, 07, 01),
+                UseStartAddressAsEndAddress = false,
+                StartLocation = new Location {Address1 = "1st Itinerary Start Location"},
+                EndLocation = new Location {Address1 = "1st Itinerary End Location"}
             };
+            itinerary.EndLocation = itinerary.StartLocation;
 
             Context.Events.Add(queenAnne);
             Context.Itineraries.Add(itinerary);
@@ -94,5 +99,86 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
             Assert.True(result == 1);
             Assert.Equal(1, Context.Itineraries.Count());
         }
+
+        [Fact]
+        public async Task AddNewEndLocationWhenUseStartAddressAsEndAddressIsUnchecked()
+        {
+            const string startAddress = "#1 Address";
+            const string endAddress = "#2 Address";
+
+            var initialItinerary = new Itinerary
+            {
+                Id = 2,
+                EventId = 1,
+                Name = "SUT Itinerary",
+                Date = DateTime.Now,
+                UseStartAddressAsEndAddress = true,
+                StartLocation = new Location
+                {
+                    Address1 = startAddress
+                }
+            };
+            initialItinerary.EndLocation = initialItinerary.StartLocation;
+            Context.Itineraries.Add(initialItinerary);
+            Context.SaveChanges();
+            var command = new EditItineraryCommand
+            {
+                Itinerary = new ItineraryEditViewModel
+                {
+                    Id = initialItinerary.Id,
+                    Date = initialItinerary.Date,
+                    UseStartAddressAsEndAddress = false,
+                    StartAddress1 = initialItinerary.StartLocation.Address1,
+                    EndAddress1 = endAddress
+                }
+            };
+
+            var sut = new EditItineraryCommandHandler(Context);
+            var result = await sut.Handle(command);
+
+            var resultItinerary = Context.Itineraries
+                .Include(i => i.StartLocation)
+                .Include(i => i.EndLocation)
+                .Single(i => i.Id == result);
+            Assert.False(resultItinerary.UseStartAddressAsEndAddress);
+            Assert.NotNull(resultItinerary.StartLocation);
+            Assert.NotNull(resultItinerary.EndLocation);
+            Assert.NotSame(resultItinerary.StartLocation, resultItinerary.EndLocation);
+            Assert.Equal(startAddress, resultItinerary.StartLocation.Address1);
+            Assert.Equal(endAddress, resultItinerary.EndLocation.Address1);
+        }
+
+        [Fact]
+        public async Task DeleteEndLocationWhenUseStartAddressAsEndAddressIsChecked()
+        {
+            var initialItinerary = Context.Itineraries
+                .Include(i => i.StartLocation)
+                .Include(i => i.EndLocation)
+                .Single();
+            var endLocation = initialItinerary.EndLocation;
+            var command = new EditItineraryCommand
+            {
+                Itinerary = new ItineraryEditViewModel
+                {
+                    Id = initialItinerary.Id,
+                    Date = initialItinerary.Date,
+                    UseStartAddressAsEndAddress = true,
+                    StartAddress1 = initialItinerary.StartLocation.Address1,
+                    EndAddress1 = initialItinerary.EndLocation.Address1
+                }
+            };
+
+            var sut = new EditItineraryCommandHandler(Context);
+            var result = await sut.Handle(command);
+
+            var resultItinerary = Context.Itineraries
+                .Include(i => i.StartLocation)
+                .Include(i => i.EndLocation)
+                .Single(i => i.Id == result);
+            Assert.True(resultItinerary.UseStartAddressAsEndAddress);
+            Assert.Same(resultItinerary.StartLocation, resultItinerary.EndLocation);
+            Assert.DoesNotContain(endLocation, Context.Locations);
+        }
     }
 }
+

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/EditItineraryCommandHandler.cs
@@ -53,7 +53,6 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                     {
                         if (itinerary.EndLocation == itinerary.StartLocation)
                         {
-                            _context.Locations.Remove(itinerary.EndLocation);
                             itinerary.EndLocation = null;
                         }
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItinerarySummaryQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/ItinerarySummaryQueryHandler.cs
@@ -35,7 +35,8 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                     {
                         Id = i.EventId,
                         StartDateTime = i.Event.StartDateTime,
-                        EndDateTime = i.Event.EndDateTime
+                        EndDateTime = i.Event.EndDateTime,
+                        TimeZoneId = i.Event.TimeZoneId
                     }
                 })
                 .SingleOrDefaultAsync();


### PR DESCRIPTION
Fixes #1569 

I added unit tests for both unchecking the "Same as start address" and checking it on an existing itinerary.