### PR TITLE
Change ProcessApiRequests to use .Add instead of .AddOrUpdate

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using AllReady.Attributes;
 using Microsoft.AspNetCore.Mvc;
 using MediatR;
@@ -51,22 +50,6 @@ namespace AllReady.Controllers
 
             //https://httpstatuses.com/202
             return StatusCode(202);
-
-            //for reporting errors back for the BadRequests, we should stick to Google's Json style guid for errors:
-            //https://google.github.io/styleguide/jsoncstyleguide.xml?showone=error#Reserved_Property_Names_in_the_error_object
-            //here's an example for field validation
-            //{
-            //    "error":
-            //    {
-            //        "code": 400
-            //        "message": "field validation failed",
-            //        "errors": [
-            //            { "ProvierId":"empty or null"},
-            //            { "Name":"empty or null"},
-            //            { "Email":"not valid email address"}
-            //        ]
-            //    }
-            //}
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/ProcessApiRequests.cs
+++ b/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/ProcessApiRequests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using AllReady.Extensions;
 using AllReady.Features.Requests;
 using AllReady.Models;
 using AllReady.ViewModels.Requests;
@@ -55,7 +54,7 @@ namespace AllReady.Hangfire.Jobs
                 request.Latitude = address?.Coordinates.Latitude ?? 0;
                 request.Longitude = address?.Coordinates.Longitude ?? 0;
 
-                context.AddOrUpdate(request);
+                context.Add(request);
                 context.SaveChanges();
 
                 mediator.Publish(new ApiRequestProcessedNotification { ProviderRequestId = viewModel.ProviderRequestId });


### PR DESCRIPTION
this is a fix for using .Add instead of .AddOrUpdate. .AddOrUpdate was "leftover" from a previous implementation when we would need to handle updates to Requests that were created by GASA. Now we only accept the incoming Requests with a status of `new`