### PR TITLE
Make HttpClient static on SendRequestStatusToGetASmokeAlarm

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotification.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotification.cs
@@ -2,7 +2,6 @@
 
 namespace AllReady.Features.Requests
 {
-    //public class ApiRequestProcessedNotification : IAsyncNotification
     public class ApiRequestProcessedNotification : INotification
     {
         public string ProviderRequestId { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotificationHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotificationHandler.cs
@@ -6,7 +6,6 @@ using Hangfire;
 
 namespace AllReady.Features.Requests
 {
-    //TODO: the behavior of this entire class is "todo". Waiting for feedback from GASA folks
     public class ApiRequestProcessedNotificationHandler : INotificationHandler<ApiRequestProcessedNotification>
     {
         private readonly AllReadyContext context;
@@ -20,11 +19,11 @@ namespace AllReady.Features.Requests
 
         public void Handle(ApiRequestProcessedNotification notification)
         {
+            //TODO mgmccarthy: insert code here that will determine whether or not we can service the request
             var request = context.Requests.SingleOrDefault(x => x.ProviderRequestId == notification.ProviderRequestId);
 
             //acceptance is true if we can service the Request or false if can't service it
-            //TODO mgmccarthy:for now, until we can decide which acceptance status to send GASA when we creat an API Request and asisgn it an orgId, we'll send false for everything
-            backgroundJobClient.Enqueue<ISendRequestStatusToGetASmokeAlarm>(x => x.Send(notification.ProviderRequestId, "new", false));
+            backgroundJobClient.Enqueue<ISendRequestStatusToGetASmokeAlarm>(x => x.Send(notification.ProviderRequestId, "new", true));
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/ProcessApiRequests.cs
+++ b/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/ProcessApiRequests.cs
@@ -49,8 +49,10 @@ namespace AllReady.Hangfire.Jobs
                     Source = RequestSource.Api
                 };
 
-                //TODO mgmccarthy: since GASA is not sending us Lat/Long, can we get rid of this code?
+
+                //this is a web service call
                 var address = geocoder.Geocode(viewModel.Address, viewModel.City, viewModel.State, viewModel.Zip, string.Empty).FirstOrDefault();
+
                 request.Latitude = address?.Coordinates.Latitude ?? 0;
                 request.Longitude = address?.Coordinates.Longitude ?? 0;
 

--- a/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/SendRequestStatusToGetASmokeAlarm.cs
+++ b/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/SendRequestStatusToGetASmokeAlarm.cs
@@ -5,17 +5,10 @@ using Microsoft.Extensions.Options;
 
 namespace AllReady.Hangfire.Jobs
 {
-    //TODO mgmccarthy: see if we can run HttpClient statically
-    //http://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/ BUT,
-    //setting HttpClient to singleton/static instance is NOT a true fix. Other work needs to be done in order for a static HttpClient to honor DNS changes
-    //this article explicitly mentinos deployments with Azure and the blue/green swap that happens when you move from Staging to Productoin. If the change in this blog
-    //is not made and HttpClient is run as singleton, you could potentially be posting requests to the wrong environment/server(s)
-    //http://byterot.blogspot.co.uk/2016/07/singleton-httpclient-dns.html
-    //private static readonly HttpClient HttpClient = new HttpClient();
-
     public class SendRequestStatusToGetASmokeAlarm : ISendRequestStatusToGetASmokeAlarm
     {
         private readonly IOptions<GetASmokeAlarmApiSettings> getASmokeAlarmApiSettings;
+        private static readonly HttpClient HttpClient = new HttpClient();
 
         public SendRequestStatusToGetASmokeAlarm(IOptions<GetASmokeAlarmApiSettings> getASmokeAlarmApiSettings)
         {
@@ -29,18 +22,15 @@ namespace AllReady.Hangfire.Jobs
 
             var updateRequestMessage = new { acceptance, status };
 
-            using (var httpClient = new HttpClient())
-            {
-                httpClient.BaseAddress = new Uri(baseAddress);
-                httpClient.DefaultRequestHeaders.Accept.Clear();
-                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                httpClient.DefaultRequestHeaders.Add("Authorization", token);
+            HttpClient.BaseAddress = new Uri(baseAddress);
+            HttpClient.DefaultRequestHeaders.Accept.Clear();
+            HttpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            HttpClient.DefaultRequestHeaders.Add("Authorization", token);
 
-                var response = httpClient.PostAsJsonAsync($"admin/requests/status/{serial}", updateRequestMessage).Result;
+            var response = HttpClient.PostAsJsonAsync($"admin/requests/status/{serial}", updateRequestMessage).Result;
 
-                //Throw HttpRequestException response is not a success code.
-                response.EnsureSuccessStatusCode();
-            }
+            //throw HttpRequestException if response is not a success code.
+            response.EnsureSuccessStatusCode();
         }
     }
 


### PR DESCRIPTION
based on a quick conversation with @stevejgordon and after reading through https://aspnetmonsters.com/2016/08/2016-08-27-httpclientwrong/  (:+1: for "the monsters"), I've made HttpClient static on `SendRequestStatusToGetASmokeAlarm`.

Smoke tested it and it works fine. This will scope the same HttpClient instance for every call to GASA's endpoint to let them know if we will, or will not service an API Request.