### PR TITLE
Changed ProviderRequestId to RequestId on ApiRequestProcessedNotification

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Hangfire/Jobs/ProcessApiRequestsShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Hangfire/Jobs/ProcessApiRequestsShould.cs
@@ -58,13 +58,36 @@ namespace AllReady.UnitTest.Hangfire.Jobs
             Assert.Equal(request.Source, RequestSource.Api);
         }
 
-        [Fact]
-        public void PublishApiRequestAddedNotificationWithTheCorrectProviderRequestId()
+        [Fact(Skip = "NotImplemented")]
+        public void AssignCorrectValuesToRequestsLatitiudeAndLongitudeWhenIGeocoderReturnedAdressIsNull()
         {
-            const string providerRequestId = "ProviderRequestId";
-            var requestId = Guid.NewGuid();
-            var viewModel = new RequestApiViewModel { ProviderRequestId = providerRequestId };
+        }
 
+        [Fact(Skip = "NotImplemented")]
+        public void AssignCorrectValuesToRequestsLatitiudeAndLongitudeWhenIGeocoderReturnedAdressIsNotNull()
+        {
+        }
+
+        [Fact]
+        public void InvokeIGeocoderWithTheCorrectParameters()
+        {
+            var requestId = Guid.NewGuid();
+            var geoCoder = new Mock<IGeocoder>();
+            var viewModel = new RequestApiViewModel { Address = "address", City = "city", State = "state", Zip = "zip" };
+            var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), geoCoder.Object)
+            {
+                NewRequestId = () => requestId
+            };
+
+            sut.Process(viewModel);
+
+            geoCoder.Verify(x => x.Geocode(viewModel.Address, viewModel.City, viewModel.State, viewModel.Zip, string.Empty), Times.Once);
+        }
+
+        [Fact]
+        public void PublishApiRequestAddedNotificationWithTheCorrectRequestId()
+        {
+            var requestId = Guid.NewGuid();
             var mediator = new Mock<IMediator>();
 
             var sut = new ProcessApiRequests(Context, mediator.Object, Mock.Of<IGeocoder>())
@@ -72,9 +95,9 @@ namespace AllReady.UnitTest.Hangfire.Jobs
                 NewRequestId = () => requestId
             };
 
-            sut.Process(viewModel);
+            sut.Process(new RequestApiViewModel());
 
-            mediator.Verify(x => x.Publish(It.Is<ApiRequestProcessedNotification>(y => y.ProviderRequestId == providerRequestId)), Times.Once);
+            mediator.Verify(x => x.Publish(It.Is<ApiRequestProcessedNotification>(y => y.RequestId == requestId)), Times.Once);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotification.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotification.cs
@@ -1,9 +1,10 @@
-﻿using MediatR;
+﻿using System;
+using MediatR;
 
 namespace AllReady.Features.Requests
 {
     public class ApiRequestProcessedNotification : INotification
     {
-        public string ProviderRequestId { get; set; }
+        public Guid RequestId { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotificationHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotificationHandler.cs
@@ -19,11 +19,11 @@ namespace AllReady.Features.Requests
 
         public void Handle(ApiRequestProcessedNotification notification)
         {
-            //TODO mgmccarthy: insert code here that will determine whether or not we can service the request
-            var request = context.Requests.SingleOrDefault(x => x.ProviderRequestId == notification.ProviderRequestId);
+            //TODO mgmccarthy: insert the list of regions here for v1 launch that will allow us to determine if we can service the request or not
 
+            var request = context.Requests.SingleOrDefault(x => x.RequestId == notification.RequestId);
             //acceptance is true if we can service the Request or false if can't service it
-            backgroundJobClient.Enqueue<ISendRequestStatusToGetASmokeAlarm>(x => x.Send(notification.ProviderRequestId, "new", true));
+            backgroundJobClient.Enqueue<ISendRequestStatusToGetASmokeAlarm>(x => x.Send(request.ProviderRequestId, "new", true));
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/ProcessApiRequests.cs
+++ b/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/ProcessApiRequests.cs
@@ -26,7 +26,7 @@ namespace AllReady.Hangfire.Jobs
 
         public void Process(RequestApiViewModel viewModel)
         {
-            //since this is job code now, it needs to be idempotent, this could be re-tried by Hangire if it fails
+            //since this is Hangfire job code, it needs to be idempotent, this could be re-tried if there is a failure
             var requestExists = context.Requests.Any(x => x.ProviderRequestId == viewModel.ProviderRequestId);
             if (!requestExists)
             {
@@ -49,17 +49,15 @@ namespace AllReady.Hangfire.Jobs
                     Source = RequestSource.Api
                 };
 
-
-                //this is a web service call
+                //FYI, this is a web service call
                 var address = geocoder.Geocode(viewModel.Address, viewModel.City, viewModel.State, viewModel.Zip, string.Empty).FirstOrDefault();
-
                 request.Latitude = address?.Coordinates.Latitude ?? 0;
                 request.Longitude = address?.Coordinates.Longitude ?? 0;
 
                 context.Add(request);
                 context.SaveChanges();
 
-                mediator.Publish(new ApiRequestProcessedNotification { ProviderRequestId = viewModel.ProviderRequestId });
+                mediator.Publish(new ApiRequestProcessedNotification { RequestId = request.RequestId });
             }   
         }
     }

--- a/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/SendRequestStatusToGetASmokeAlarm.cs
+++ b/AllReadyApp/Web-App/AllReady/Hangfire/Jobs/SendRequestStatusToGetASmokeAlarm.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Net.Http.Headers;
 using Microsoft.Extensions.Options;
 


### PR DESCRIPTION
a simple change that publishes the internal RequestId on ApiRequestProcessedNotification instead of the provider-supplied id. All handlers should use the internal request id to look up the Request to get any information it needs to do work.

Also added some more unit tests for ProcessApiRequestsShould