### PR TITLE
Adding tooltip and placeholder text for External Link

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
@@ -106,7 +106,7 @@
                 <p><cite>Optional link to an outside page</cite></p>
             </div>
             <div class="col-md-10">
-                <input asp-for="ExternalUrl" class="form-control" />
+                <input asp-for="ExternalUrl" class="form-control" placeholder="e.g. http://www.htbox.org" title="Please supply the full URL including the protocol http:// or https://" data-toggle="tooltip" />
                 <span asp-validation-for="ExternalUrl" class="text-danger"></span>
             </div>
         </div>
@@ -318,4 +318,10 @@
         <script src="~/lib/system.js/dist/system.js"></script>
         <script src="~/js/Admin/Campaign/Edit/Main.js"></script>
     }
+
+    <script>
+    $(document).ready(function(){
+        $('[data-toggle="tooltip"]').tooltip();
+    });
+    </script>
 }


### PR DESCRIPTION
Fixes #1498 

I've added a placeholder and bootstrap tooltip to this field which appears as follows

![image](https://cloud.githubusercontent.com/assets/3669103/21131520/0ab6a61a-c107-11e6-9cde-6715ce3e9ada.png)
