### PR TITLE
Changes for the Site Admin buttons

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
@@ -7,6 +7,7 @@
 <h2>User Admin</h2>
 <div class="container-fluid">
     <div class="row">
+        <div class="col-md-3"></div>
         <div class="col-md-6">
             <table class="table table-responsive table-condensed">
                 <tr>
@@ -49,7 +50,8 @@
                                 <div class="modal fade" id="options-modal" tabindex="-1" role="dialog">
                                     <div class="modal-dialog">
                                         <div class="modal-content">
-                                            <div class="modal-header"><h4>Edit - @user.UserName</h4></div>
+                                            <div class="modal-header"><h4>Edit - @user.UserName</h4>
+                                            </div>
                                             <div class="modal-body">
                                                 <div class="row">
                                                     <div class="col-xs-12 btn-group-vertical">
@@ -89,6 +91,7 @@
                 }
             </table>
         </div>
+        <div class="col-md-3"></div>
     </div>
 </div>
 @section scripts {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
@@ -7,7 +7,7 @@
 <h2>User Admin</h2>
 <div class="container-fluid">
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-6">
             <table class="table table-responsive table-condensed">
                 <tr>
                     <th class="col-md-3 col-sm-4 col-lg-2">
@@ -75,6 +75,9 @@
                                                         }
                                                     </div>
                                                 </div>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn" data-dismiss="modal">Cancel</button>
                                             </div>
                                         </div>
                                     </div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
@@ -53,7 +53,7 @@
                                             <div class="modal-body">
                                                 <div class="row">
                                                     <div class="col-xs-12 btn-group-vertical">
-                                                        <a data-toggle="tooltip" data-placement="top" title="Edit" asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Edit</a>
+                                                        <a data-toggle="tooltip" data-placement="top" title="Manage Skills" asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Manage Skills</a>
                                                         <a data-toggle="tooltip" data-placement="top" title="Reset Password" asp-action="ResetPassword" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Reset Password</a>
                                                         @if (!user.IsUserType(UserType.SiteAdmin) && !user.IsUserType(UserType.OrgAdmin))
                                                         {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
@@ -10,7 +10,7 @@
         <div class="col-md-12">
             <table class="table table-responsive table-condensed">
                 <tr>
-                    <th>
+                    <th class="col-md-3 col-sm-4 col-lg-2">
                         Username
                     </th>
                     <th class="col-md-7 col-sm-8 col-lg-6">
@@ -23,54 +23,67 @@
                         <td>
                             <a asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id">@user.UserName</a>
                             @if (user.UserName == User.Identity.Name)
-                        {
+                            {
                                 <span class="label label-info"><span class="fa fa-user"></span> (You)</span>
-                        }
+                            }
                             @if (user.IsUserType(UserType.SiteAdmin))
-                        {
+                            {
                                 <span class="label label-warning"><span class="fa fa-user-secret"></span> Site</span>
-                        }
+                            }
                             @if (user.IsUserType(UserType.OrgAdmin))
-                        {
+                            {
                                 <span class="label label-default"><span class="fa fa-users"></span> Org</span>
-                        }
+                            }
                             @if (user.IsUserType(UserType.ApiAccess))
-                        {
+                            {
                                 <span class="label label-default"><span class="fa fa-exchange"></span> API</span>
-                        }
+                            }
                             @if (!user.EmailConfirmed)
-                        {
+                            {
                                 <span class="fa fa-exclamation-triangle text-warning" title="Email Address not confirmed"></span>
-                        }
+                            }
                         </td>
                         <td>
                             <div class="btn-toolbar">
-                                <a data-toggle="tooltip" data-placement="top" title="Edit" asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Edit</a>
-                                <a data-toggle="tooltip" data-placement="top" title="Reset Password" asp-action="ResetPassword" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Reset Password</a>
-                                @if (!user.IsUserType(UserType.SiteAdmin) && !user.IsUserType(UserType.OrgAdmin))
-                            {
-                                    <a data-toggle="tooltip" data-placement="top" title="Make Site Admin" asp-action="AssignSiteAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Make Site Admin</a>
-                                    <a data-toggle="tooltip" data-placement="top" title="Make Org Admin" asp-action="AssignOrganizationAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Make Org Admin</a>
-                            }
-                            else if (user.IsUserType(UserType.SiteAdmin))
-                            {
-                                    <a data-toggle="tooltip" data-placement="top" title="Revoke Site Admin" asp-action="RevokeSiteAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Revoke Site Admin</a>
-                            }
-                            else if (user.IsUserType(UserType.OrgAdmin))
-                            {
-                                    <a data-toggle="tooltip" data-placement="top" title="Revoke Org Admin" asp-action="RevokeOrganizationAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Revoke Org Admin</a>
-                            }
-                                @if (!user.IsUserType(UserType.ApiAccess))
-                            {
-                                    <a data-toggle="tooltip" data-placement="top" title="Allow API Access" asp-action="AssignApiAccessRole" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Allow API Access</a>
-                                    <a data-toggle="tooltip" data-placement="top" title="Manage Keys" asp-action="ManageApiKeys" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-warning">Manage Keys</a>
-                            }
+                                <a data-toggle="modal" data-target="#options-modal" href="#" class="btn btn-success">Edit</a>
+                                <div class="modal fade" id="options-modal" tabindex="-1" role="dialog">
+                                    <div class="modal-dialog">
+                                        <div class="modal-content">
+                                            <div class="modal-header"><h4>Edit - @user.UserName</h4></div>
+                                            <div class="modal-body">
+                                                <div class="row">
+                                                    <div class="col-xs-12 btn-group-vertical">
+                                                        <a data-toggle="tooltip" data-placement="top" title="Edit" asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Edit</a>
+                                                        <a data-toggle="tooltip" data-placement="top" title="Reset Password" asp-action="ResetPassword" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Reset Password</a>
+                                                        @if (!user.IsUserType(UserType.SiteAdmin) && !user.IsUserType(UserType.OrgAdmin))
+                                                        {
+                                                            <a data-toggle="tooltip" data-placement="top" title="Make Site Admin" asp-action="AssignSiteAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Make Site Admin</a>
+                                                            <a data-toggle="tooltip" data-placement="top" title="Make Org Admin" asp-action="AssignOrganizationAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Make Org Admin</a>
+                                                        }
+                                                        else if (user.IsUserType(UserType.SiteAdmin))
+                                                        {
+                                                            <a data-toggle="tooltip" data-placement="top" title="Revoke Site Admin" asp-action="RevokeSiteAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Revoke Site Admin</a>
+                                                        }
+                                                        else if (user.IsUserType(UserType.OrgAdmin))
+                                                        {
+                                                            <a data-toggle="tooltip" data-placement="top" title="Revoke Org Admin" asp-action="RevokeOrganizationAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Revoke Org Admin</a>
+                                                        }
+                                                        @if (!user.IsUserType(UserType.ApiAccess))
+                                                        {
+                                                            <a data-toggle="tooltip" data-placement="top" title="Allow API Access" asp-action="AssignApiAccessRole" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Allow API Access</a>
+                                                            <a data-toggle="tooltip" data-placement="top" title="Manage Keys" asp-action="ManageApiKeys" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-warning">Manage Keys</a>
+                                                        }
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
                                 <a data-toggle="tooltip" data-placement="top" title="Delete" asp-action="DeleteUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-danger">Delete</a>
                             </div>
                         </td>
-
                     </tr>
-            }
+                }
             </table>
         </div>
     </div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
@@ -5,75 +5,76 @@
 }
 
 <h2>User Admin</h2>
-
-<div class="row">
-    <div class="col-md-12">
-        <table class="table table-responsive table-condensed">
-            <tr>
-                <th class="col-md-4 col-sm-5 col-lg-3">
-                    Actions
-                </th>
-                <th>
-                    Username
-                </th>
-            </tr>
-            @foreach (var user in Model.Users)
-            {
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <table class="table table-responsive table-condensed">
                 <tr>
-                    <td>
-                        <div class="btn-toolbar">
-                            <a data-toggle="tooltip" data-placement="top" title="Edit" asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success"><span class="fa fa-edit"></span></a>
-                            <a data-toggle="tooltip" data-placement="top" title="Reset Password" asp-action="ResetPassword" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success"><span class="fa fa-recycle"></span></a>
-                            @if (!user.IsUserType(UserType.SiteAdmin) && !user.IsUserType(UserType.OrgAdmin))
+                    <th>
+                        Username
+                    </th>
+                    <th class="col-md-7 col-sm-8 col-lg-6">
+                        Actions
+                    </th>
+                </tr>
+                @foreach (var user in Model.Users)
+                {
+                    <tr>
+                        <td>
+                            <a asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id">@user.UserName</a>
+                            @if (user.UserName == User.Identity.Name)
+                        {
+                                <span class="label label-info"><span class="fa fa-user"></span> (You)</span>
+                        }
+                            @if (user.IsUserType(UserType.SiteAdmin))
+                        {
+                                <span class="label label-warning"><span class="fa fa-user-secret"></span> Site</span>
+                        }
+                            @if (user.IsUserType(UserType.OrgAdmin))
+                        {
+                                <span class="label label-default"><span class="fa fa-users"></span> Org</span>
+                        }
+                            @if (user.IsUserType(UserType.ApiAccess))
+                        {
+                                <span class="label label-default"><span class="fa fa-exchange"></span> API</span>
+                        }
+                            @if (!user.EmailConfirmed)
+                        {
+                                <span class="fa fa-exclamation-triangle text-warning" title="Email Address not confirmed"></span>
+                        }
+                        </td>
+                        <td>
+                            <div class="btn-toolbar">
+                                <a data-toggle="tooltip" data-placement="top" title="Edit" asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Edit</a>
+                                <a data-toggle="tooltip" data-placement="top" title="Reset Password" asp-action="ResetPassword" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Reset Password</a>
+                                @if (!user.IsUserType(UserType.SiteAdmin) && !user.IsUserType(UserType.OrgAdmin))
                             {
-                                <a data-toggle="tooltip" data-placement="top" title="Make Site Admin" asp-action="AssignSiteAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success"><span class="fa fa-user-secret"></span></a>
-                                <a data-toggle="tooltip" data-placement="top" title="Make Org Admin" asp-action="AssignOrganizationAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success"><span class="fa fa-group"></span></a>
+                                    <a data-toggle="tooltip" data-placement="top" title="Make Site Admin" asp-action="AssignSiteAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Make Site Admin</a>
+                                    <a data-toggle="tooltip" data-placement="top" title="Make Org Admin" asp-action="AssignOrganizationAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Make Org Admin</a>
                             }
                             else if (user.IsUserType(UserType.SiteAdmin))
                             {
-                                <a data-toggle="tooltip" data-placement="top" title="Revoke Site Admin" asp-action="RevokeSiteAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success"><span class="fa fa-user-secret"></span></a>
+                                    <a data-toggle="tooltip" data-placement="top" title="Revoke Site Admin" asp-action="RevokeSiteAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Revoke Site Admin</a>
                             }
                             else if (user.IsUserType(UserType.OrgAdmin))
                             {
-                                <a data-toggle="tooltip" data-placement="top" title="Revoke Org Admin" asp-action="RevokeOrganizationAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success"><span class="fa fa-group"></span></a>
+                                    <a data-toggle="tooltip" data-placement="top" title="Revoke Org Admin" asp-action="RevokeOrganizationAdmin" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Revoke Org Admin</a>
                             }
-                            @if (!user.IsUserType(UserType.ApiAccess))
+                                @if (!user.IsUserType(UserType.ApiAccess))
                             {
-                                <a data-toggle="tooltip" data-placement="top" title="Allow API Access" asp-action="AssignApiAccessRole" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success"><span class="fa fa-exchange"></span></a>
-                                <a data-toggle="tooltip" data-placement="top" title="Manage Keys" asp-action="ManageApiKeys" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-warning"><span class="fa fa-key"></span></a>
+                                    <a data-toggle="tooltip" data-placement="top" title="Allow API Access" asp-action="AssignApiAccessRole" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Allow API Access</a>
+                                    <a data-toggle="tooltip" data-placement="top" title="Manage Keys" asp-action="ManageApiKeys" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-warning">Manage Keys</a>
                             }
-                            <a data-toggle="tooltip" data-placement="top" title="Delete" asp-action="DeleteUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-danger"><span class="fa fa-remove"></span></a>
-                        </div>
-                    </td>
-                    <td>
-                        <a asp-action="EditUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id">@user.UserName</a>
-                        @if (user.UserName == User.Identity.Name)
-                        {
-                            <span class="label label-info"><span class="fa fa-user"></span> (You)</span>
-                        }
-                        @if (user.IsUserType(UserType.SiteAdmin))
-                        {
-                            <span class="label label-warning"><span class="fa fa-user-secret"></span> Site</span>
-                        }
-                        @if (user.IsUserType(UserType.OrgAdmin))
-                        {
-                            <span class="label label-default"><span class="fa fa-users"></span> Org</span>
-                        }
-                        @if (user.IsUserType(UserType.ApiAccess))
-                        {
-                            <span class="label label-default"><span class="fa fa-exchange"></span> API</span>
-                        }
-                        @if(!user.EmailConfirmed)
-                        {
-                            <span class="fa fa-exclamation-triangle text-warning" title="Email Address not confirmed"></span>
-                        }
-                    </td>
-                </tr>
+                                <a data-toggle="tooltip" data-placement="top" title="Delete" asp-action="DeleteUser" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-danger">Delete</a>
+                            </div>
+                        </td>
+
+                    </tr>
             }
-        </table>
+            </table>
+        </div>
     </div>
 </div>
-
 @section scripts {
     <script type="text/javascript">
         $(document).ready(function() {


### PR DESCRIPTION
Applies to #1245.

Better late than never! So the changes are as follows:

- Swapped the columns around, it felt better to have the email on the left-hand side and the buttons on the right-hand.
- Swapped all icons for the action titles themselves.
- Moved all buttons apart from two into a modal popup.
- Renamed the Edit button within the modal to "Manage Skills" as that's the only thing that linked page seems to allow you to do.
- Centered the table (3 columns on each side for padding and 6 columns in the grid allocated to the table)
The Page after the changes:

![the page itself](https://cloud.githubusercontent.com/assets/588607/21147575/64dd1a02-c14d-11e6-908b-fb75cc1a5eac.jpg)

The modal when the Edit button is clicked:
![the modal when visible](https://cloud.githubusercontent.com/assets/588607/21147649/9bfab544-c14d-11e6-9fcc-b677fc8d484f.jpg)

Another issue will have to be raised to change the "Admin/Site/EditUser" page, as it's still branded as a generic "Edit" page.
