### PR TITLE
Filtering the list of Active or Upcoming Campaigns

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/HomeControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/HomeControllerTests.cs
@@ -1,20 +1,17 @@
 ﻿using AllReady.Controllers;
 using AllReady.Features.Campaigns;
+using AllReady.Features.Home;
+using AllReady.ViewModels.Home;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
+using Shouldly;
+using System.Collections.Generic;
 using System.Threading.Tasks;
-using AllReady.Features.Home;
 using Xunit;
 
 namespace AllReady.UnitTest.Controllers
 {
-    using System.Collections.Generic;
-
-    using AllReady.ViewModels.Home;
-
-    using Shouldly;
-
     public class HomeControllerTests
     {
         [Fact]

--- a/AllReadyApp/Web-App/AllReady/Controllers/HomeController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/HomeController.cs
@@ -1,6 +1,7 @@
 ﻿using AllReady.Features.Campaigns;
 using AllReady.Features.Home;
 using AllReady.ViewModels.Home;
+
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;

--- a/AllReadyApp/Web-App/AllReady/Controllers/HomeController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/HomeController.cs
@@ -1,9 +1,9 @@
 ﻿using AllReady.Features.Campaigns;
+using AllReady.Features.Home;
+using AllReady.ViewModels.Home;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
-using AllReady.Features.Home;
-using AllReady.ViewModels.Home;
 
 namespace AllReady.Controllers
 {
@@ -23,6 +23,12 @@ namespace AllReady.Controllers
                 FeaturedCampaign = await mediator.SendAsync(new FeaturedCampaignQuery()),
                 ActiveOrUpcomingCampaigns = await mediator.SendAsync(new ActiveOrUpcomingCampaignsQuery())
             };
+
+            if (model.HasFeaturedCampaign)
+            {
+                var indexOfFeaturedCampaign = model.ActiveOrUpcomingCampaigns.FindIndex(s => s.Id == model.FeaturedCampaign.Id);
+                model.ActiveOrUpcomingCampaigns.RemoveAt(indexOfFeaturedCampaign);
+            }
 
             return View(model);
         }


### PR DESCRIPTION
The current implementation takes into account the fact that multiple campaigns can be flagged as Featured. So instead of just excluding all featured campaigns, the changes will only exclude the currently returned featured campaign. I reckon some more defensive or compensation-type logic will have to be included when a campaign is flagged as Featured, so that one and only one will be featured at any given time.

Closes #1608 