### PR TITLE
Ensuring we only list published campaigns

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Campaigns/FeaturedCampaignQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Campaigns/FeaturedCampaignQueryHandlerShould.cs
@@ -66,21 +66,24 @@ namespace AllReady.UnitTest.Features.Campaigns
             {
                 Name = "This is featured",
                 Featured = true,
-                ManagingOrganization = org                
+                ManagingOrganization = org,
+                Published = true         
             });
 
             Context.Campaigns.Add(new Campaign
             {
                 Name = "This is not featured",
                 Featured = false,
-                ManagingOrganization = org
+                ManagingOrganization = org,
+                Published = true
             });
 
             Context.Campaigns.Add(new Campaign
             {
                 Name = "This is also featured",
                 Featured = true,
-                ManagingOrganization = org
+                ManagingOrganization = org,
+                Published = true
             });
 
             Context.SaveChanges();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Campaigns/FeaturedCampaignQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Campaigns/FeaturedCampaignQueryHandlerShould.cs
@@ -53,6 +53,40 @@ namespace AllReady.UnitTest.Features.Campaigns
             Assert.Null(result);
         }
 
+
+        [Fact]
+        public async Task ReturnNullIfFeaturedCampaignIsNotMarkedAsPublished()
+        {
+            // clear the test data of all campaigns
+            var allCampaigns = Context.Campaigns.ToList();
+            Context.RemoveRange(allCampaigns);
+            Context.SaveChanges();
+
+            var org = new Organization
+            {
+                Name = "Some Organization"
+            };
+
+            Context.Campaigns.Add(new Campaign
+            {
+                Name = "This is featured but not published",
+                Featured = true,
+                ManagingOrganization = org,
+                Published = false
+            });
+
+
+
+            // Arrange
+            var handler = new FeaturedCampaignQueryHandler(Context);
+
+            // Act
+            var result = await handler.Handle(new FeaturedCampaignQuery());
+
+            // Assert
+            Assert.Null(result);
+        }
+
         protected override void LoadTestData()
         {
             var org = new Organization

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Home/ActiveOrUpcomingCampaignsQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Home/ActiveOrUpcomingCampaignsQueryHandlerShould.cs
@@ -1,0 +1,68 @@
+﻿using AllReady.Features.Home;
+using AllReady.Models;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Features.Home
+{
+    public class ActiveOrUpcomingCampaignsQueryHandlerShould : InMemoryContextTest
+    {
+        [Fact]
+        public async Task NotReturnUnPublishedCampaigns()
+        {
+            // Arrange
+            var handler = new ActiveOrUpcomingCampaignsQueryHandler(Context);
+
+            // Act
+            var result = await handler.Handle(new ActiveOrUpcomingCampaignsQuery());
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Count.ShouldBe(2);
+        }
+
+        protected override void LoadTestData()
+        {
+            var org = new Organization
+            {
+                Name = "Some Organization"
+            };
+
+            Context.Organizations.Add(org);
+
+            Context.Campaigns.Add(new Campaign
+            {
+                Name = "This is published",
+                Featured = false,
+                ManagingOrganization = org,
+                Published = true,
+                StartDateTime = DateTime.UtcNow.AddDays(1),
+                EndDateTime = DateTime.UtcNow.AddDays(10)
+            });
+
+            Context.Campaigns.Add(new Campaign
+            {
+                Name = "This is also published",
+                Featured = false,
+                ManagingOrganization = org,
+                Published = true,
+                StartDateTime = DateTime.UtcNow.AddDays(1),
+                EndDateTime = DateTime.UtcNow.AddDays(10)
+            });
+
+            Context.Campaigns.Add(new Campaign
+            {
+                Name = "This is not published",
+                Featured = false,
+                ManagingOrganization = org,
+                Published = false,
+                StartDateTime = DateTime.UtcNow.AddDays(1),
+                EndDateTime = DateTime.UtcNow.AddDays(10)
+            });
+
+            Context.SaveChanges();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
@@ -100,7 +100,8 @@ namespace AllReady.DataAccess
                 TimeZoneId = "Central Standard Time",
                 StartDateTime = AdjustToTimezone(DateTimeOffset.Now.AddMonths(-1), _centralTimeZone),
                 EndDateTime = AdjustToTimezone(DateTimeOffset.Now.AddMonths(3), _centralTimeZone),
-                Location = GetRandom(locations)
+                Location = GetRandom(locations),
+                Published = true
             };
             organization.Campaigns.Add(firePreventionCampaign);
 

--- a/AllReadyApp/Web-App/AllReady/Features/Campaigns/FeaturedCampaignQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Campaigns/FeaturedCampaignQueryHandler.cs
@@ -19,7 +19,7 @@ namespace AllReady.Features.Campaigns
         public async Task<CampaignSummaryViewModel> Handle(FeaturedCampaignQuery message)
         {
             return await _context.Campaigns.AsNoTracking()
-                .Where(c => c.Featured)
+                .Where(c => c.Featured && c.Published)
                 .Include(c => c.ManagingOrganization)
                 .Select(c => new CampaignSummaryViewModel
                 {

--- a/AllReadyApp/Web-App/AllReady/Features/Home/ActiveOrUpcomingCampaignsQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Home/ActiveOrUpcomingCampaignsQueryHandler.cs
@@ -22,7 +22,7 @@ namespace AllReady.Features.Home
         {
             return await _context.Campaigns
                 .AsNoTracking()
-                .Where(campaign => campaign.EndDateTime.UtcDateTime.Date > DateTime.UtcNow.Date && !campaign.Locked)
+                .Where(campaign => campaign.EndDateTime.UtcDateTime.Date > DateTime.UtcNow.Date && !campaign.Locked && campaign.Published)
                 .Select(campaign => new ActiveOrUpcomingCampaign
                 {
                     Id = campaign.Id,


### PR DESCRIPTION
Fixes #1655 

- Updated handlers to properly filter out campaigns based on their published status
- Added unit tests to validate the expected behaviour