### PR TITLE
Only set bounds if there are locations passed in.

### DIFF
--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/site.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/site.js
@@ -81,7 +81,7 @@ function addRequestPins(bingMap, requestData) {
         locations.push(location);
         var order = index + 1;
         var pin = new Microsoft.Maps.Pushpin(location, { title: data.name, color: data.color, text: order.toString() });
-        bingMap.entities.push(pin);        
+        bingMap.entities.push(pin);
     });
     var rect = Microsoft.Maps.LocationRect.fromLocations(locations);
     bingMap.setView({ bounds: rect, padding: 80 });
@@ -92,7 +92,7 @@ function setMapCenterAndZoom(bingMap, microsoftMapsLocations) {
     options.zoom = 10;
     if (microsoftMapsLocations.length === 1) {
         options.center = microsoftMapsLocations[0];
-    } else {
+    } else if(microsoftMapsLocations.length > 1) {
         options.bounds = Microsoft.Maps.LocationRect.fromLocations(microsoftMapsLocations);
         options.padding = 50;
     }


### PR DESCRIPTION
Fixes #1658

Bing Maps was throwing an error when there were no locations passed into the function that calculates the initial bounds for the map.