### PR TITLE
WIP - Adding notifications table

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Notifications/SendInitialRequestConfirmationsHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Notifications/SendInitialRequestConfirmationsHandler.cs
@@ -4,6 +4,7 @@ using AllReady.Models;
 using AllReady.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using AllReady.Features.Notifications;
 
 namespace AllReady.Areas.Admin.Features.Notifications
 {
@@ -22,12 +23,23 @@ namespace AllReady.Areas.Admin.Features.Notifications
 
         public async Task Handle(RequestsAssignedToItinerary notification)
         {
-            var requestorPhoneNumbers = await context.Requests.Where(x => notification.RequestIds.Contains(x.RequestId)).Select(x => x.Phone).ToListAsync();
+            var requestData = await context.Requests
+                .Where(x => notification.RequestIds.Contains(x.RequestId))
+                .Select(x => new {
+                    phone = x.Phone,
+                    requestId = x.RequestId
+                }).ToListAsync();
+
             var itinerary = await context.Itineraries.SingleAsync(x => x.Id == notification.ItineraryId);
 
             //TODO mgmccarthy: need to convert itinerary.Date to local time of the request's intinerary's campaign's timezone
-            await smsSender.SendSmsAsync(requestorPhoneNumbers, 
+            await smsSender.SendSmsAsync(requestData.Select(x => x.phone).ToList(), 
                 $@"Your request has been scheduled by allReady for {itinerary.Date.Date}. Please respond with ""Y"" to confirm this request or ""N"" to cancel this request.");
+
+            foreach(var item in requestData)
+            {
+                await mediator.PublishAsync(NotificationSentMessage.SmsMessage(NotificationMessageType.InitialItineraryAssignment, item.phone, requestId: item.requestId, responseRequired: true));
+            }
 
             await mediator.PublishAsync(new InitialRequestConfirmationsSent { ItineraryId = itinerary.Id, RequestIds = notification.RequestIds });
         }

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/AddNotificationsRecord.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/AddNotificationsRecord.cs
@@ -1,0 +1,23 @@
+﻿using AllReady.Models;
+using MediatR;
+using System.Threading.Tasks;
+
+namespace AllReady.Features.Notifications
+{
+    public class AddNotificationsRecord : IAsyncNotificationHandler<NotificationSentMessage>
+    {
+        private readonly AllReadyContext _context;
+
+        public AddNotificationsRecord(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task Handle(NotificationSentMessage message)
+        {
+            _context.Notifications.Add(Notification.FromAddNotificationLogMessage(message));
+
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotificationSentMessage.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotificationSentMessage.cs
@@ -45,8 +45,11 @@ namespace AllReady.Features.Notifications
         /// <summary>
         /// Creates a new <see cref="NotificationSentMessage"/> for an Email Message
         /// </summary>
-        public static NotificationSentMessage EmailMessage(NotificationMessageType messageType, Guid? RequestId = null, string userId = null, bool responseRequired = false, string email = null)
+        public static NotificationSentMessage EmailMessage(NotificationMessageType messageType, string email, Guid? RequestId = null, string userId = null, bool responseRequired = false)
         {
+            if (string.IsNullOrEmpty(email))
+                throw new ArgumentNullException(nameof(email));
+
             return new NotificationSentMessage
             {
                 Method = NotificationMethod.Email,

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotificationSentMessage.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotificationSentMessage.cs
@@ -1,0 +1,61 @@
+﻿using AllReady.Models;
+using MediatR;
+using System;
+
+namespace AllReady.Features.Notifications
+{
+    /// <summary>
+    /// A message containing the properties for a notification which has been sent by the system
+    /// </summary>
+    public class NotificationSentMessage : IAsyncNotification
+    {
+        public NotificationMessageType MessageType { get; private set; }
+        public NotificationMethod Method { get; private set; }
+        public string Email { get; private set; }
+        public string Phone { get; private set; }
+        public bool ResponseRequired { get; private set; }
+        public DateTime SentDateTime { get; private set; }
+        public Guid? RequestId { get; private set; }
+        public string UserId { get; private set; }
+
+        private NotificationSentMessage()
+        {
+            SentDateTime = DateTime.UtcNow;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="NotificationSentMessage"/> for an SMS Message
+        /// </summary>
+        public static NotificationSentMessage SmsMessage(NotificationMessageType messageType, string phoneNumber, Guid? requestId = null, string userId = null, bool responseRequired = false)
+        {
+            if (string.IsNullOrEmpty(phoneNumber))
+                throw new ArgumentNullException(nameof(phoneNumber));
+
+            return new NotificationSentMessage
+            {
+                Method = NotificationMethod.Sms,
+                MessageType = messageType,
+                ResponseRequired = responseRequired,
+                Phone = phoneNumber,
+                UserId = userId,
+                RequestId = requestId
+            };
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="NotificationSentMessage"/> for an Email Message
+        /// </summary>
+        public static NotificationSentMessage EmailMessage(NotificationMessageType messageType, Guid? RequestId = null, string userId = null, bool responseRequired = false, string email = null)
+        {
+            return new NotificationSentMessage
+            {
+                Method = NotificationMethod.Email,
+                MessageType = messageType,
+                ResponseRequired = responseRequired,
+                Email = email,
+                UserId = userId,
+                RequestId = RequestId
+            };
+        } 
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20161220185618_AddNotifications.Designer.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20161220185618_AddNotifications.Designer.cs
@@ -1,0 +1,1037 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using AllReady.Models;
+
+namespace AllReady.Migrations
+{
+    [DbContext(typeof(AllReadyContext))]
+    [Migration("20161220185618_AddNotifications")]
+    partial class AddNotifications
+    {
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasAnnotation("ProductVersion", "1.0.2")
+                .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<int>("EventId");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int>("NumberOfVolunteersRequired");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("AllReadyTask");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<int>("AccessFailedCount");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Email")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<bool>("EmailConfirmed");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<bool>("LockoutEnabled");
+
+                    b.Property<DateTimeOffset?>("LockoutEnd");
+
+                    b.Property<string>("NormalizedEmail")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedUserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<string>("PasswordHash");
+
+                    b.Property<string>("PendingNewEmail");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<bool>("PhoneNumberConfirmed");
+
+                    b.Property<string>("SecurityStamp");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.Property<bool>("TwoFactorEnabled");
+
+                    b.Property<string>("UserName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedEmail")
+                        .HasName("EmailIndex");
+
+                    b.HasIndex("NormalizedUserName")
+                        .IsUnique()
+                        .HasName("UserNameIndex");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("ApplicationUser");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignImpactId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<string>("ExternalUrl");
+
+                    b.Property<string>("ExternalUrlText");
+
+                    b.Property<bool>("Featured");
+
+                    b.Property<string>("FullDescription");
+
+                    b.Property<string>("Headline")
+                        .HasAnnotation("MaxLength", 150);
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<bool>("Locked");
+
+                    b.Property<int>("ManagingOrganizationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<bool>("Published");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CampaignImpactId");
+
+                    b.HasIndex("LocationId");
+
+                    b.HasIndex("ManagingOrganizationId");
+
+                    b.HasIndex("OrganizerId");
+
+                    b.ToTable("Campaign");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.Property<int>("CampaignId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.Property<int?>("ContactId1");
+
+                    b.HasKey("CampaignId", "ContactId", "ContactType");
+
+                    b.HasIndex("CampaignId");
+
+                    b.HasIndex("ContactId");
+
+                    b.HasIndex("ContactId1");
+
+                    b.ToTable("CampaignContact");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignImpact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CurrentImpactLevel");
+
+                    b.Property<bool>("Display");
+
+                    b.Property<int>("ImpactType");
+
+                    b.Property<int>("NumericImpactGoal");
+
+                    b.Property<string>("TextualImpactGoal");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("CampaignImpact");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int?>("CampaignId");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CampaignId");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("CampaignSponsors");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ClosestLocation", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<double>("Distance");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+
+                    b.ToTable("ClosestLocation");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Contact", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email");
+
+                    b.Property<string>("FirstName");
+
+                    b.Property<string>("LastName");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Contact");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Event", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<int>("CampaignId");
+
+                    b.Property<string>("Description");
+
+                    b.Property<DateTimeOffset>("EndDateTime");
+
+                    b.Property<int>("EventType");
+
+                    b.Property<string>("Headline")
+                        .HasAnnotation("MaxLength", 150);
+
+                    b.Property<string>("ImageUrl");
+
+                    b.Property<bool>("IsAllowWaitList");
+
+                    b.Property<bool>("IsLimitVolunteers");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("OrganizerId");
+
+                    b.Property<DateTimeOffset>("StartDateTime");
+
+                    b.Property<string>("TimeZoneId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("CampaignId");
+
+                    b.HasIndex("LocationId");
+
+                    b.HasIndex("OrganizerId");
+
+                    b.ToTable("Event");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSkill", b =>
+                {
+                    b.Property<int>("EventId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("EventId", "SkillId");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("SkillId");
+
+                    b.ToTable("EventSkill");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Itinerary", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<DateTime>("Date");
+
+                    b.Property<double>("EndLatitude");
+
+                    b.Property<int?>("EndLocationId");
+
+                    b.Property<double>("EndLongitude");
+
+                    b.Property<int>("EventId");
+
+                    b.Property<string>("Name");
+
+                    b.Property<double>("StartLatitude");
+
+                    b.Property<int?>("StartLocationId");
+
+                    b.Property<double>("StartLongitude");
+
+                    b.Property<bool>("UseStartAddressAsEndAddress");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("EndLocationId");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("StartLocationId");
+
+                    b.ToTable("Itinerary");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>
+                {
+                    b.Property<int>("ItineraryId");
+
+                    b.Property<Guid>("RequestId");
+
+                    b.Property<DateTime>("DateAssigned");
+
+                    b.Property<int>("OrderIndex");
+
+                    b.HasKey("ItineraryId", "RequestId");
+
+                    b.HasIndex("ItineraryId");
+
+                    b.HasIndex("RequestId");
+
+                    b.ToTable("ItineraryRequest");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Location", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address1");
+
+                    b.Property<string>("Address2");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("Country");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("PhoneNumber");
+
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Location");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Notification", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email")
+                        .HasAnnotation("MaxLength", 150);
+
+                    b.Property<string>("MessageType")
+                        .IsRequired()
+                        .HasAnnotation("MaxLength", 75);
+
+                    b.Property<string>("Method")
+                        .IsRequired()
+                        .HasAnnotation("MaxLength", 10);
+
+                    b.Property<string>("PhoneNumber")
+                        .HasAnnotation("MaxLength", 50);
+
+                    b.Property<Guid?>("RequestId");
+
+                    b.Property<bool>("ResponseRequired");
+
+                    b.Property<DateTime>("SentDateTime");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RequestId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("Notification");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("DescriptionHtml");
+
+                    b.Property<int?>("LocationId");
+
+                    b.Property<string>("LogoUrl");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<string>("PrivacyPolicy");
+
+                    b.Property<string>("PrivacyPolicyUrl");
+
+                    b.Property<string>("Summary")
+                        .HasAnnotation("MaxLength", 250);
+
+                    b.Property<string>("WebUrl");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("LocationId");
+
+                    b.ToTable("Organization");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.Property<int>("OrganizationId");
+
+                    b.Property<int>("ContactId");
+
+                    b.Property<int>("ContactType");
+
+                    b.Property<int?>("ContactId1");
+
+                    b.HasKey("OrganizationId", "ContactId", "ContactType");
+
+                    b.HasIndex("ContactId");
+
+                    b.HasIndex("ContactId1");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("OrganizationContact");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeo", b =>
+                {
+                    b.Property<string>("PostalCode");
+
+                    b.Property<string>("City");
+
+                    b.Property<string>("State");
+
+                    b.HasKey("PostalCode");
+
+                    b.ToTable("PostalCodeGeo");
+                });
+
+            modelBuilder.Entity("AllReady.Models.PostalCodeGeoCoordinate", b =>
+                {
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.HasKey("Latitude", "Longitude");
+
+                    b.ToTable("PostalCodeGeoCoordinate");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.Property<Guid>("RequestId")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Address");
+
+                    b.Property<string>("City");
+
+                    b.Property<DateTime>("DateAdded");
+
+                    b.Property<string>("Email");
+
+                    b.Property<int?>("EventId");
+
+                    b.Property<double>("Latitude");
+
+                    b.Property<double>("Longitude");
+
+                    b.Property<string>("Name");
+
+                    b.Property<int?>("OrganizationId");
+
+                    b.Property<string>("Phone");
+
+                    b.Property<string>("ProviderData");
+
+                    b.Property<string>("ProviderRequestId");
+
+                    b.Property<int>("Source");
+
+                    b.Property<string>("State");
+
+                    b.Property<int>("Status");
+
+                    b.Property<string>("Zip");
+
+                    b.HasKey("RequestId");
+
+                    b.HasIndex("EventId");
+
+                    b.HasIndex("OrganizationId");
+
+                    b.ToTable("Request");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Resource", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("CategoryTag");
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("MediaUrl");
+
+                    b.Property<string>("Name");
+
+                    b.Property<DateTime>("PublishDateBegin");
+
+                    b.Property<DateTime>("PublishDateEnd");
+
+                    b.Property<string>("ResourceUrl");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Resource");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Description");
+
+                    b.Property<string>("Name")
+                        .IsRequired();
+
+                    b.Property<int?>("OwningOrganizationId");
+
+                    b.Property<int?>("ParentSkillId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("OwningOrganizationId");
+
+                    b.HasIndex("ParentSkillId");
+
+                    b.ToTable("Skill");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("AdditionalInfo");
+
+                    b.Property<int?>("ItineraryId");
+
+                    b.Property<string>("Status");
+
+                    b.Property<DateTime>("StatusDateTimeUtc");
+
+                    b.Property<string>("StatusDescription");
+
+                    b.Property<int>("TaskId");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ItineraryId");
+
+                    b.HasIndex("TaskId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("TaskSignup");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.Property<int>("TaskId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("TaskId", "SkillId");
+
+                    b.HasIndex("SkillId");
+
+                    b.HasIndex("TaskId");
+
+                    b.ToTable("TaskSkill");
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<int>("SkillId");
+
+                    b.HasKey("UserId", "SkillId");
+
+                    b.HasIndex("SkillId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("UserSkill");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole", b =>
+                {
+                    b.Property<string>("Id");
+
+                    b.Property<string>("ConcurrencyStamp")
+                        .IsConcurrencyToken();
+
+                    b.Property<string>("Name")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.Property<string>("NormalizedName")
+                        .HasAnnotation("MaxLength", 256);
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("NormalizedName")
+                        .HasName("RoleNameIndex");
+
+                    b.ToTable("IdentityRole");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRoleClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("RoleId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RoleId");
+
+                    b.ToTable("IdentityRoleClaim<string>");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserClaim<string>", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("ClaimType");
+
+                    b.Property<string>("ClaimValue");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("IdentityUserClaim<string>");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserLogin<string>", b =>
+                {
+                    b.Property<string>("LoginProvider");
+
+                    b.Property<string>("ProviderKey");
+
+                    b.Property<string>("ProviderDisplayName");
+
+                    b.Property<string>("UserId")
+                        .IsRequired();
+
+                    b.HasKey("LoginProvider", "ProviderKey");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("IdentityUserLogin<string>");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserRole<string>", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<string>("RoleId");
+
+                    b.HasKey("UserId", "RoleId");
+
+                    b.HasIndex("RoleId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("IdentityUserRole<string>");
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserToken<string>", b =>
+                {
+                    b.Property<string>("UserId");
+
+                    b.Property<string>("LoginProvider");
+
+                    b.Property<string>("Name");
+
+                    b.Property<string>("Value");
+
+                    b.HasKey("UserId", "LoginProvider", "Name");
+
+                    b.ToTable("IdentityUserToken<string>");
+                });
+
+            modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
+                {
+                    b.HasOne("AllReady.Models.Event", "Event")
+                        .WithMany("Tasks")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Organization", "Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ApplicationUser", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization")
+                        .WithMany("Users")
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Campaign", b =>
+                {
+                    b.HasOne("AllReady.Models.CampaignImpact", "CampaignImpact")
+                        .WithMany()
+                        .HasForeignKey("CampaignImpactId");
+
+                    b.HasOne("AllReady.Models.Location", "Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.Organization", "ManagingOrganization")
+                        .WithMany("Campaigns")
+                        .HasForeignKey("ManagingOrganizationId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "Organizer")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign", "Campaign")
+                        .WithMany("CampaignContacts")
+                        .HasForeignKey("CampaignId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Contact", "Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany("CampaignContacts")
+                        .HasForeignKey("ContactId1");
+                });
+
+            modelBuilder.Entity("AllReady.Models.CampaignSponsors", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign", "Campaign")
+                        .WithMany("ParticipatingOrganizations")
+                        .HasForeignKey("CampaignId");
+
+                    b.HasOne("AllReady.Models.Organization", "Organization")
+                        .WithMany()
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Event", b =>
+                {
+                    b.HasOne("AllReady.Models.Campaign", "Campaign")
+                        .WithMany("Events")
+                        .HasForeignKey("CampaignId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Location", "Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "Organizer")
+                        .WithMany()
+                        .HasForeignKey("OrganizerId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.EventSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Event", "Event")
+                        .WithMany("RequiredSkills")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Skill", "Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.Itinerary", b =>
+                {
+                    b.HasOne("AllReady.Models.Location", "EndLocation")
+                        .WithMany()
+                        .HasForeignKey("EndLocationId");
+
+                    b.HasOne("AllReady.Models.Event", "Event")
+                        .WithMany("Itineraries")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Location", "StartLocation")
+                        .WithMany()
+                        .HasForeignKey("StartLocationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.ItineraryRequest", b =>
+                {
+                    b.HasOne("AllReady.Models.Itinerary", "Itinerary")
+                        .WithMany("Requests")
+                        .HasForeignKey("ItineraryId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Request", "Request")
+                        .WithMany("Itineraries")
+                        .HasForeignKey("RequestId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.Notification", b =>
+                {
+                    b.HasOne("AllReady.Models.Request", "Request")
+                        .WithMany("Notifications")
+                        .HasForeignKey("RequestId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "User")
+                        .WithMany("Notifications")
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Organization", b =>
+                {
+                    b.HasOne("AllReady.Models.Location", "Location")
+                        .WithMany()
+                        .HasForeignKey("LocationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.OrganizationContact", b =>
+                {
+                    b.HasOne("AllReady.Models.Contact", "Contact")
+                        .WithMany()
+                        .HasForeignKey("ContactId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.Contact")
+                        .WithMany("OrganizationContacts")
+                        .HasForeignKey("ContactId1");
+
+                    b.HasOne("AllReady.Models.Organization", "Organization")
+                        .WithMany("OrganizationContacts")
+                        .HasForeignKey("OrganizationId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.Request", b =>
+                {
+                    b.HasOne("AllReady.Models.Event", "Event")
+                        .WithMany("Requests")
+                        .HasForeignKey("EventId")
+                        .OnDelete(DeleteBehavior.SetNull);
+
+                    b.HasOne("AllReady.Models.Organization", "Organization")
+                        .WithMany("Requests")
+                        .HasForeignKey("OrganizationId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Skill", b =>
+                {
+                    b.HasOne("AllReady.Models.Organization", "OwningOrganization")
+                        .WithMany()
+                        .HasForeignKey("OwningOrganizationId");
+
+                    b.HasOne("AllReady.Models.Skill", "ParentSkill")
+                        .WithMany("ChildSkills")
+                        .HasForeignKey("ParentSkillId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSignup", b =>
+                {
+                    b.HasOne("AllReady.Models.Itinerary", "Itinerary")
+                        .WithMany("TeamMembers")
+                        .HasForeignKey("ItineraryId");
+
+                    b.HasOne("AllReady.Models.AllReadyTask", "Task")
+                        .WithMany("AssignedVolunteers")
+                        .HasForeignKey("TaskId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId");
+                });
+
+            modelBuilder.Entity("AllReady.Models.TaskSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill", "Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.AllReadyTask", "Task")
+                        .WithMany("RequiredSkills")
+                        .HasForeignKey("TaskId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.UserSkill", b =>
+                {
+                    b.HasOne("AllReady.Models.Skill", "Skill")
+                        .WithMany()
+                        .HasForeignKey("SkillId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "User")
+                        .WithMany("AssociatedSkills")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRoleClaim<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole")
+                        .WithMany("Claims")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserClaim<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany("Claims")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserLogin<string>", b =>
+                {
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany("Logins")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityUserRole<string>", b =>
+                {
+                    b.HasOne("Microsoft.AspNetCore.Identity.EntityFrameworkCore.IdentityRole")
+                        .WithMany("Users")
+                        .HasForeignKey("RoleId")
+                        .OnDelete(DeleteBehavior.Cascade);
+
+                    b.HasOne("AllReady.Models.ApplicationUser")
+                        .WithMany("Roles")
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/20161220185618_AddNotifications.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/20161220185618_AddNotifications.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace AllReady.Migrations
+{
+    public partial class AddNotifications : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Notification",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    Email = table.Column<string>(maxLength: 150, nullable: true),
+                    MessageType = table.Column<string>(maxLength: 75, nullable: false),
+                    Method = table.Column<string>(maxLength: 10, nullable: false),
+                    PhoneNumber = table.Column<string>(maxLength: 50, nullable: true),
+                    RequestId = table.Column<Guid>(nullable: true),
+                    ResponseRequired = table.Column<bool>(nullable: false),
+                    SentDateTime = table.Column<DateTime>(nullable: false),
+                    UserId = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Notification", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_Notification_Request_RequestId",
+                        column: x => x.RequestId,
+                        principalTable: "Request",
+                        principalColumn: "RequestId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_Notification_ApplicationUser_UserId",
+                        column: x => x.UserId,
+                        principalTable: "ApplicationUser",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notification_RequestId",
+                table: "Notification",
+                column: "RequestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notification_UserId",
+                table: "Notification",
+                column: "UserId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Notification");
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
+++ b/AllReadyApp/Web-App/AllReady/Migrations/AllReadyContextModelSnapshot.cs
@@ -13,7 +13,7 @@ namespace AllReady.Migrations
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
             modelBuilder
-                .HasAnnotation("ProductVersion", "1.0.1")
+                .HasAnnotation("ProductVersion", "1.0.2")
                 .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
             modelBuilder.Entity("AllReady.Models.AllReadyTask", b =>
@@ -397,6 +397,42 @@ namespace AllReady.Migrations
                     b.HasKey("Id");
 
                     b.ToTable("Location");
+                });
+
+            modelBuilder.Entity("AllReady.Models.Notification", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd();
+
+                    b.Property<string>("Email")
+                        .HasAnnotation("MaxLength", 150);
+
+                    b.Property<string>("MessageType")
+                        .IsRequired()
+                        .HasAnnotation("MaxLength", 75);
+
+                    b.Property<string>("Method")
+                        .IsRequired()
+                        .HasAnnotation("MaxLength", 10);
+
+                    b.Property<string>("PhoneNumber")
+                        .HasAnnotation("MaxLength", 50);
+
+                    b.Property<Guid?>("RequestId");
+
+                    b.Property<bool>("ResponseRequired");
+
+                    b.Property<DateTime>("SentDateTime");
+
+                    b.Property<string>("UserId");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("RequestId");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("Notification");
                 });
 
             modelBuilder.Entity("AllReady.Models.Organization", b =>
@@ -854,9 +890,20 @@ namespace AllReady.Migrations
                         .OnDelete(DeleteBehavior.Cascade);
 
                     b.HasOne("AllReady.Models.Request", "Request")
-                        .WithMany()
+                        .WithMany("Itineraries")
                         .HasForeignKey("RequestId")
                         .OnDelete(DeleteBehavior.Cascade);
+                });
+
+            modelBuilder.Entity("AllReady.Models.Notification", b =>
+                {
+                    b.HasOne("AllReady.Models.Request", "Request")
+                        .WithMany("Notifications")
+                        .HasForeignKey("RequestId");
+
+                    b.HasOne("AllReady.Models.ApplicationUser", "User")
+                        .WithMany("Notifications")
+                        .HasForeignKey("UserId");
                 });
 
             modelBuilder.Entity("AllReady.Models.Organization", b =>

--- a/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/AllReadyContext.cs
@@ -33,6 +33,7 @@ namespace AllReady.Models
         public DbSet<Request> Requests { get; set; }
         public DbSet<Itinerary> Itineraries { get; set; }
         public DbSet<ItineraryRequest> ItineraryRequests { get; set; }
+        public DbSet<Notification> Notifications { get; set; }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -65,6 +66,7 @@ namespace AllReady.Models
             Map(modelBuilder.Entity<Request>());
             Map(modelBuilder.Entity<Itinerary>());
             Map(modelBuilder.Entity<ItineraryRequest>());
+            Map(modelBuilder.Entity<Notification>());
         }
 
         private void Map(EntityTypeBuilder<Request> builder)
@@ -207,5 +209,17 @@ namespace AllReady.Models
             builder.HasKey(x => new { x.ItineraryId, x.RequestId });
         }
 
+        public void Map(EntityTypeBuilder<Notification> builder)
+        {
+            builder.HasKey(x => x.Id);
+            builder.HasOne(x => x.Request).WithMany(x => x.Notifications).HasForeignKey((x => x.RequestId)).IsRequired(false);
+            builder.HasOne(x => x.User).WithMany(x => x.Notifications).HasForeignKey(x => x.UserId).IsRequired(false);
+
+            builder.Property(a => a.MessageType).IsRequired().HasMaxLength(75);
+            builder.Property(a => a.Method).IsRequired().HasMaxLength(10);
+            builder.Property(a => a.SentDateTime).IsRequired();
+            builder.Property(a => a.Email).HasMaxLength(150);
+            builder.Property(a => a.PhoneNumber).HasMaxLength(50);
+        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Models/ApplicationUser.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/ApplicationUser.cs
@@ -25,6 +25,17 @@ namespace AllReady.Models
 
         public string PendingNewEmail { get; set; }
 
+        #region Navigational Properties
+
+        // Navigational Properties used for EF mapping and relationship navigation
+
+        /// <summary>
+        /// A collection of the notifications sent regarding to this user
+        /// </summary>
+        public ICollection<Notification> Notifications { get; set; }
+
+        #endregion
+
         public IEnumerable<ValidationResult> ValidateProfileCompleteness()
         {
             List<ValidationResult> validationResults = new List<ValidationResult>();

--- a/AllReadyApp/Web-App/AllReady/Models/Notification.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Notification.cs
@@ -1,0 +1,134 @@
+﻿using AllReady.Features.Notifications;
+using System;
+
+namespace AllReady.Models
+{
+    /// <summary>
+    /// Holds data about any notifications sent via allReady
+    /// </summary>
+    public class Notification
+    {
+        /// <summary>
+        /// A unique ID for the notification
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// The method for the notification (i.e. email or SMS)
+        /// </summary>
+        /// <remarks>Storing as string (rather than enum) for log readability</remarks>
+        public string Method { get; set; }
+
+        /// <summary>
+        /// The type of message being sent
+        /// </summary>
+        /// <remarks>Storing as string (rather than enum) for log readability</remarks>
+        public string MessageType { get; set; }
+
+        /// <summary>
+        /// The date and time when the message was sent (UTC)
+        /// </summary>
+        public DateTime SentDateTime { get; set; } = DateTime.UtcNow;
+
+        /// <summary>
+        /// If the notification is via SMS we store the recipient phone number (required if SMS type)
+        /// </summary>
+        public string PhoneNumber { get; set; }
+
+        /// <summary>
+        /// If the notification is via email we store the recipient email address (required if Email type)
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// Identifies whether this notification expects the recipient to respond
+        /// </summary>
+        public bool ResponseRequired { get; set; }
+
+        #region Navigational Properties
+
+        // Navigational Properties used for EF mapping and relationship navigation
+
+        /// <summary>
+        /// An optional request id for the notification if the request can be associated back to an <see cref="Request"/> 
+        /// </summary>
+        public Guid? RequestId { get; set; }
+
+        /// <summary>
+        /// An optional <see cref="Request"/> that the notification is associated to
+        /// </summary>
+        public Request Request { get; set; }
+
+        /// <summary>
+        /// An optional user id for the notification if the request can be associated back to an <see cref="ApplicationUser"/> 
+        /// </summary>
+        public string UserId { get; set; }
+
+        /// <summary>
+        /// An optional <see cref="ApplicationUser"/> that the notification is associated to
+        /// </summary>
+        public ApplicationUser User { get; set; }
+
+        #endregion
+
+        /// <summary>
+        /// Creates a new <see cref="Notification"/> instance using the properties from an <see cref="NotificationSentMessage"/> 
+        /// </summary>
+        public static Notification FromAddNotificationLogMessage(NotificationSentMessage message)
+        {
+            return new Notification
+            {
+                Method = message.Method.ToString(),
+                MessageType = message.MessageType.ToString(),
+                SentDateTime = message.SentDateTime,
+                PhoneNumber = message.Phone,
+                Email = message.Email,
+                ResponseRequired = message.ResponseRequired,
+                RequestId = message.RequestId,
+                UserId = message.UserId,
+            };
+        }
+    }
+
+    /// <summary>
+    /// Identifies the possible notification methods that are in use within the application
+    /// </summary>
+    public enum NotificationMethod
+    {
+        /// <summary>
+        /// Message is sent via email system
+        /// </summary>
+        Email,
+
+        /// <summary>
+        /// Message is sent via the mobile/cell phone network (SMS)
+        /// </summary>
+        Sms
+    }
+
+    /// <summary>
+    /// Defines the various messages that can be sent via the application
+    /// </summary>
+    public enum NotificationMessageType
+    {
+        /// <summary>
+        /// A request has been assigned to an itinerary to confirm availability
+        /// </summary>
+        InitialItineraryAssignment,
+
+        /// <summary>
+        /// A 7 day reminder before scheduled request date to re-confirm availability
+        /// </summary>
+        SevenDayReminder,
+
+        /// <summary>
+        /// A 1 day reminder before scheduled request date to re-confirm availability
+        /// </summary>
+        OneDayReminder,
+
+        /// <summary>
+        /// A notification sent on the day of request fullfillment when the prior request has been completed
+        /// </summary>
+        NextRequestForItinerary
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Models/Request.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Request.cs
@@ -37,6 +37,17 @@ namespace AllReady.Models
         public int? OrganizationId { get; set; }
         public Organization Organization { get; set; }
 
+        #region Navigational Properties
+
+        // Navigational Properties used for EF mapping and relationship navigation
+
         public ICollection<ItineraryRequest> Itineraries { get; set; }
+
+        /// <summary>
+        /// A collection of the notifications sent regarding this request
+        /// </summary>
+        public ICollection<Notification> Notifications { get; set; }
+
+        #endregion
     }
 }


### PR DESCRIPTION
This will fix #1647 but needs a little review and further work after I clarify some points with @mgmccarthy.

I have added a notification table to store details of all notifications we send from the application. I have also added a notificationhandler design to handle messages whenever we send a notification. I have tried to make those messages quite easy to reuse and build out using some static methods.

I have linked this into the SendInitialRequestConfirmationsHandler where we fire off initial messages to requesters. This works locally as I expect.

First question for @mgmccarthy and @MisterJames is for any comments on the code so far. The static methods for building up the message and as a helper to convert to a EF model record are a bit different to what we've done elsewhere but I hope, allow us to ensure rules a bit and hide unnecessary internals.

Other questions for @mgmccarthy are around the other three notification points...
You have the classes such as SendRequestConfirmationMessagesADayBeforeAnItineraryDate which are triggered via hangfire. These are currently void methods and are not awaiting for example SendSmsAsync which I'm not sure if gives us any issues?

1. Can we use Mediatr within them? I'd like to leverage my AddNotificationsRecord which is a Mediatr IAsyncNotificationHandler to update the database. Can I just take a dependency on Mediatr in the constructor as normal? Not sure if there's any hangfire specific rules?
2. Assuming we can use Medaitr, can we make change them from regular void methods to async Tasks so that I can await the PublishAsync I'd need to use? Again, not sure if hangfire is okay with that?