### PR TITLE
#1648 - Added 5 unit tests for RemoveRequestCommandHandler

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/RemoveRequestCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Itineraries/RemoveRequestCommandHandlerShould.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+using Moq;
+using AllReady.Models;
+using MediatR;
+using AllReady.Areas.Admin.Features.Itineraries;
+using AllReady.Areas.Admin.Features.Requests;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.Itineraries
+{
+    public class RemoveRequestCommandHandlerShould : InMemoryContextTest
+    {
+        private static readonly Guid Request1Id = new Guid("de4f4639-86ea-419f-96c8-509defa4d9a3");
+        private static readonly Guid Request2Id = new Guid("602b3f58-c8e0-4f59-82b0-f940c1aa1caa");
+        private static readonly Guid Request3Id = new Guid("a7138311-66bf-4135-96a4-7177289c4933");
+
+        protected override void LoadTestData()
+        {
+            var itinerary1 = new Itinerary
+            {
+                Id = 1,
+                Name = "Test Itinerary 1"
+            };
+
+            var request1 = new Request
+            {
+                RequestId = Request1Id,
+                Name = "Request 1",
+                Latitude = 50.8225,
+                Longitude = -0.1372,
+                Status = RequestStatus.Assigned
+            };
+
+            var request2 = new Request
+            {
+                RequestId = Request2Id,
+                Name = "Request 2",
+                Latitude = 10.0000,
+                Longitude = -5.0000,
+                Status = RequestStatus.Completed
+            };
+
+            var request3 = new Request
+            {
+                RequestId = Request3Id,
+                Name = "Request 3",
+                Latitude = 10.0000,
+                Longitude = -5.0000,
+                Status = RequestStatus.Completed
+            };
+
+            var itineraryRequest1 = new ItineraryRequest
+            {
+                RequestId = Request1Id,
+                Request = request1,
+                Itinerary = itinerary1,
+                OrderIndex = 1,
+            };
+
+            var itineraryRequest2 = new ItineraryRequest
+            {
+                RequestId = Request2Id,
+                Request = request2,
+                Itinerary = itinerary1,
+                OrderIndex = 2,
+            };
+
+            var itineraryRequest3 = new ItineraryRequest
+            {
+                RequestId = Request3Id,
+                Request = request3,
+                Itinerary = itinerary1,
+                OrderIndex = 3,
+            };
+
+
+            Context.Add(itinerary1);
+            Context.Add(request1);
+            Context.Add(request2);
+            Context.Add(request3);
+            Context.Add(itineraryRequest1);
+            Context.Add(itineraryRequest2);
+            Context.Add(itineraryRequest3);
+            Context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task RemoveItineraryRequestDoesExist()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            var handler = new RemoveRequestCommandHandler(Context, mockMediator.Object);
+            var succeded = await handler.Handle(new RemoveRequestCommand
+                { ItineraryId = 1, RequestId = Request1Id });
+            Assert.False(Context.ItineraryRequests.Any(x=>x.RequestId == Request1Id));
+        }
+
+        [Fact]
+        public async Task AbortRemoveItineraryRequestDoesnotExist()
+        {
+            var mockMediator = new Mock<IMediator>(MockBehavior.Strict);
+            var handler = new RemoveRequestCommandHandler(Context, mockMediator.Object);
+            var succeded = await handler.Handle(new RemoveRequestCommand
+                { ItineraryId = 1, RequestId = new Guid("0da127ec-e4b6-44df-abd3-8a9ffa685826") });
+        }
+
+
+        [Fact]
+        public async Task AbortRemoveCompletedItineraryRequest()
+        {
+            var mockMediator = new Mock<IMediator>();
+            
+            var handler = new RemoveRequestCommandHandler(Context, mockMediator.Object);
+            var succeded = await handler.Handle(new RemoveRequestCommand
+                { ItineraryId = 1, RequestId = Request2Id });
+            Assert.True(Context.ItineraryRequests.Any(x => x.RequestId == Request1Id));
+        }
+
+        [Fact]
+        public async Task RemoveItineraryRequest_ShouldMoveUpOthers()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            var handler = new RemoveRequestCommandHandler(Context, mockMediator.Object);
+            var succeded = await handler.Handle(new RemoveRequestCommand
+                { ItineraryId = 1, RequestId = Request1Id });
+            Assert.Equal(1, Context.ItineraryRequests.First(x => x.RequestId == Request2Id).OrderIndex);
+            Assert.Equal(2, Context.ItineraryRequests.First(x => x.RequestId == Request3Id).OrderIndex);
+        }
+
+        [Fact]
+        public async Task RemoveItineraryRequest_ShouldUnassignRequest()
+        {
+            var mockMediator = new Mock<IMediator>();
+
+            var handler = new RemoveRequestCommandHandler(Context, mockMediator.Object);
+            var succeded = await handler.Handle(new RemoveRequestCommand
+                { ItineraryId = 1, RequestId = Request1Id });
+            Assert.Equal(RequestStatus.Unassigned, Context.Requests.First(x => x.RequestId == Request1Id).Status);
+        }
+
+
+        // TODO: fix this unit test to be able to check that notification has correct data
+        [Fact(Skip="Need to check how to implement")]	
+        public async Task RemoveItineraryRequest_ShouldSendCorrectNotification()
+        {
+            var mockMediator = new Mock<IMediator>();
+            RequestStatusChangedNotification actualNotification = null;
+            mockMediator.Setup(x => x.PublishAsync(It.IsAny<IAsyncNotification>()))
+                .Callback<IAsyncNotification>(notification => actualNotification = (RequestStatusChangedNotification)notification);
+
+            var handler = new RemoveRequestCommandHandler(Context, mockMediator.Object);
+            var succeded = await handler.Handle(new RemoveRequestCommand
+                { ItineraryId = 1, RequestId = Request1Id });
+            Assert.Equal(RequestStatus.Unassigned, actualNotification.NewStatus);
+            Assert.Equal(RequestStatus.Assigned, actualNotification.OldStatus);
+            Assert.Equal(Request1Id, actualNotification.RequestId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveRequestCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/RemoveRequestCommandHandler.cs
@@ -27,7 +27,6 @@ namespace AllReady.Areas.Admin.Features.Itineraries
                 .ToListAsync();
 
             var requestToRemove = itineraryRequests.FirstOrDefault(r => r.RequestId == message.RequestId);
-            var requestStatus = requestToRemove.Request.Status;
 
             if (requestToRemove == null || requestToRemove.Request.Status == RequestStatus.Completed)
             {
@@ -35,6 +34,7 @@ namespace AllReady.Areas.Admin.Features.Itineraries
             }
 
             // Update the request status
+            var requestStatus = requestToRemove.Request.Status;
             requestToRemove.Request.Status = RequestStatus.Unassigned;
 
             // remove the request to itinerary assignment


### PR DESCRIPTION
I've added 5 unit tests to check various scenarios for removing Itinerary requests. 

I had to edit the commandHandler as there was bug that caused an exception to be raised when the command had a requestId that didn't exist. 

Also, for the "abort" cases should we bother checking that nothing is attempted to be persisted i.e. Context.SaveChangesAsync() is never actually called?

Finally I wasn't able to fully implement a test for checking that the correct info got sent via RequestStatusChangedNotification. Although I suppose that's more of an integration test. I've just set that test to be ignored for now. 

#1648 