### PR TITLE
Remove "5th" string in ".logo-background" definition. Must be a typo …

### DIFF
--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -23,7 +23,7 @@ body {
     position: relative;
     width: 100vw;
     left: -25px;
-    color: #fff;5th
+    color: #fff;
     padding-bottom: 20px;
     margin-top: -20px;
     margin-bottom: 20px;


### PR DESCRIPTION
…and is causing problems.

Found while working on issue 1411.