### PR TITLE
Ensuring the OrgId is set on every request

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ImportController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ImportController.cs
@@ -13,6 +13,7 @@ using AllReady.Areas.Admin.ViewModels.Import;
 using AllReady.Areas.Admin.ViewModels.Request;
 using AllReady.Features.Requests;
 using AllReady.Security;
+using System.Threading.Tasks;
 
 namespace AllReady.Areas.Admin.Controllers
 {
@@ -46,7 +47,7 @@ namespace AllReady.Areas.Admin.Controllers
 
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public IActionResult Index(IndexViewModel viewModel)
+        public async Task<IActionResult> Index(IndexViewModel viewModel)
         {
             List<ImportRequestViewModel> importRequestViewModels;
 
@@ -102,7 +103,7 @@ namespace AllReady.Areas.Admin.Controllers
 
             if (viewModel.ImportErrors.Count == 0 && viewModel.ValidationErrors.Count == 0)
             {
-                mediator.Send(new ImportRequestsCommand { EventId = viewModel.EventId, ImportRequestViewModels = importRequestViewModels.ToList() });
+                await mediator.SendAsync(new ImportRequestsCommand { EventId = viewModel.EventId, ImportRequestViewModels = importRequestViewModels.ToList() });
                 logger.LogInformation($"{User.Identity.Name} imported file {viewModel.File.Name}");
                 viewModel.ImportSuccess = true;
             }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/EditRequestCommandHandler.cs
@@ -28,14 +28,21 @@ namespace AllReady.Areas.Admin.Features.Requests
 
             var addressChanged = DetermineIfAddressChanged(message, request);
 
+            var orgId = await _context.Events.AsNoTracking()
+             .Include(rec => rec.Campaign)
+             .Where(rec => rec.Id == message.RequestModel.EventId)
+             .Select(rec => rec.Campaign.ManagingOrganizationId)
+             .FirstOrDefaultAsync();
+            
             request.EventId = message.RequestModel.EventId;
+            request.OrganizationId = orgId;
             request.Address = message.RequestModel.Address;
             request.City = message.RequestModel.City;
             request.Name = message.RequestModel.Name;
             request.State = message.RequestModel.State;
             request.Zip = message.RequestModel.Zip;
             request.Email = message.RequestModel.Email;
-            request.Phone = message.RequestModel.Phone;
+            request.Phone = message.RequestModel.Phone;            
 
             //If lat/long not provided or we detect the address changed, then use geocoding API to get the lat/long
             if ((request.Latitude == 0 && request.Longitude == 0) || addressChanged)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/ImportRequestsCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/ImportRequestsCommand.cs
@@ -4,7 +4,7 @@ using AllReady.Areas.Admin.ViewModels.Import;
 
 namespace AllReady.Areas.Admin.Features.Requests
 {
-    public class ImportRequestsCommand : IRequest
+    public class ImportRequestsCommand : IAsyncRequest
     {
         public int EventId { get; set; }
         public List<ImportRequestViewModel> ImportRequestViewModels { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/ImportRequestsCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/ImportRequestsCommandHandler.cs
@@ -3,10 +3,12 @@ using AllReady.Models;
 using Geocoding;
 using MediatR;
 using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using System.Threading.Tasks;
 
 namespace AllReady.Areas.Admin.Features.Requests
 {
-    public class ImportRequestsCommandHandler : RequestHandler<ImportRequestsCommand>
+    public class ImportRequestsCommandHandler : AsyncRequestHandler<ImportRequestsCommand>
     {
         private readonly AllReadyContext context;
         private readonly IGeocoder geocoder;
@@ -19,41 +21,51 @@ namespace AllReady.Areas.Admin.Features.Requests
             this.geocoder = geocoder;
         }
 
-        protected override void HandleCore(ImportRequestsCommand message)
+        protected override async Task HandleCore(ImportRequestsCommand message)
         {
-            var requests = message.ImportRequestViewModels.Select(viewModel => new Request
-            {
-                RequestId = NewRequestId(),
-                ProviderRequestId = viewModel.Id,
-                EventId = message.EventId,
-                ProviderData = viewModel.ProviderData,
-                Address = viewModel.Address,
-                City = viewModel.City,
-                DateAdded = DateTimeUtcNow(),
-                Email = viewModel.Email,
-                Name = viewModel.Name,
-                Phone = viewModel.Phone,
-                State = viewModel.State,
-                Zip = viewModel.Zip,
-                Status = RequestStatus.Unassigned,
-                Source = RequestSource.Csv
-            }).ToList();
-            
-            context.Requests.AddRange(requests);
+            var orgId = await context.Events.AsNoTracking()
+                .Include(rec => rec.Campaign)
+                .Where(rec => rec.Id == message.EventId)
+                .Select(rec => rec.Campaign.ManagingOrganizationId)
+                .FirstOrDefaultAsync();
 
-            //TODO mgmccarthy: eventually move IGeocoder invocations to async using azure. Issue #1626 and #1639
-            foreach (var request in requests)
+            if (orgId > 0)
             {
-                if (request.Latitude == 0 && request.Longitude == 0)
+                var requests = message.ImportRequestViewModels.Select(viewModel => new Request
                 {
-                    //Assume the first returned address is correct
-                    var address = geocoder.Geocode(request.Address, request.City, request.State, request.Zip, string.Empty).FirstOrDefault();
-                    request.Latitude = address?.Coordinates.Latitude ?? 0;
-                    request.Longitude = address?.Coordinates.Longitude ?? 0;
-                }
-            }
+                    OrganizationId = orgId,
+                    RequestId = NewRequestId(),
+                    ProviderRequestId = viewModel.Id,
+                    EventId = message.EventId,
+                    ProviderData = viewModel.ProviderData,
+                    Address = viewModel.Address,
+                    City = viewModel.City,
+                    DateAdded = DateTimeUtcNow(),
+                    Email = viewModel.Email,
+                    Name = viewModel.Name,
+                    Phone = viewModel.Phone,
+                    State = viewModel.State,
+                    Zip = viewModel.Zip,
+                    Status = RequestStatus.Unassigned,
+                    Source = RequestSource.Csv
+                }).ToList();
 
-            context.SaveChanges();
+                context.Requests.AddRange(requests);
+
+                //TODO mgmccarthy: eventually move IGeocoder invocations to async using azure. Issue #1626 and #1639
+                foreach (var request in requests)
+                {
+                    if (request.Latitude == 0 && request.Longitude == 0)
+                    {
+                        //Assume the first returned address is correct
+                        var address = geocoder.Geocode(request.Address, request.City, request.State, request.Zip, string.Empty).FirstOrDefault();
+                        request.Latitude = address?.Coordinates.Latitude ?? 0;
+                        request.Longitude = address?.Coordinates.Longitude ?? 0;
+                    }
+                }
+
+                await context.SaveChangesAsync();
+            }
         }
     }
 }


### PR DESCRIPTION
Adding code so that manually created and CSV imported requests have the OrgId set directly. This adds consistency since all API added requests ill already have the OrgId set.

Also made the ImportRequestsCommandHandler async while working in that area

Fixes #1667

