### PR TITLE
Twilio Lookup to Validate Phone Numbers

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/RequestApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/RequestApiControllerTests.cs
@@ -11,6 +11,7 @@ using MediatR;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using Xunit;
+using AllReady.Features.Sms;
 
 namespace AllReady.UnitTest.Controllers
 {
@@ -41,6 +42,8 @@ namespace AllReady.UnitTest.Controllers
             const string providerRequestId = "ProviderRequestId";
 
             var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.IsAny<ValidatePhoneNumberRequest>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true, PhoneNumberE164 = "0000" });
+
             var sut = new RequestApiController(mediator.Object, Mock.Of<IBackgroundJobClient>());
             await sut.Post(new RequestApiViewModel { Status = "new", ProviderRequestId = providerRequestId });
 
@@ -65,7 +68,10 @@ namespace AllReady.UnitTest.Controllers
         public async Task PostEnqueuesProcessApiRequestsJobWithCorrectViewModel()
         {
             var viewModel = new RequestApiViewModel { Status = "new" };
+
             var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.IsAny<ValidatePhoneNumberRequest>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true, PhoneNumberE164 = "0000" });
+
             var backgroundJobClient = new Mock<IBackgroundJobClient>();
 
             var sut = new RequestApiController(mediator.Object, backgroundJobClient.Object);
@@ -79,7 +85,10 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task PostReturns202StatusCode()
         {
-            var sut = new RequestApiController(Mock.Of<IMediator>(), Mock.Of<IBackgroundJobClient>());
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.IsAny<ValidatePhoneNumberRequest>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true, PhoneNumberE164 = "0000" });
+
+            var sut = new RequestApiController(mediator.Object, Mock.Of<IBackgroundJobClient>());
             var result = await sut.Post(new RequestApiViewModel { Status = "new" }) as StatusCodeResult;
 
             Assert.IsType<StatusCodeResult>(result);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Sms/ValidatePhoneNumberRequestHandlerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Sms/ValidatePhoneNumberRequestHandlerTests.cs
@@ -1,0 +1,129 @@
+﻿using AllReady.Features.Sms;
+using AllReady.Services.Sms;
+using Moq;
+using Shouldly;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Features.Sms
+{
+    public class ValidatePhoneNumberRequestHandlerTests
+    {
+        [Fact]
+        public async Task ValidatePhoneNumberRequestHandler_ShouldCallPhoneNumberLookupService_Once()
+        {
+            var lookupService = new Mock<IPhoneNumberLookupService>();
+            lookupService.Setup(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(PhoneNumberLookupResult.FailedLookup).Verifiable();
+
+            var sut = new ValidatePhoneNumberRequestHandler(lookupService.Object);
+
+            await sut.Handle(new ValidatePhoneNumberRequest { PhoneNumber = "0123456789", CountryCode = "us", ValidateType = true });
+
+            lookupService.Verify(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task ValidatePhoneNumberRequestHandler_ShouldCallPhoneNumberLookupService_WithCorrectValues()
+        {
+            string phoneNumber = null;
+            string countryCode = null;
+
+            var lookupService = new Mock<IPhoneNumberLookupService>();
+            lookupService.Setup(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(PhoneNumberLookupResult.FailedLookup)
+                .Callback<string, string>((x, y) => { phoneNumber = x; countryCode = y; })
+                .Verifiable();
+
+            var sut = new ValidatePhoneNumberRequestHandler(lookupService.Object);
+
+            await sut.Handle(new ValidatePhoneNumberRequest { PhoneNumber = "0123456789", CountryCode = "us", ValidateType = true });
+
+            phoneNumber.ShouldBe("0123456789");
+            countryCode.ShouldBe("us");
+        }
+
+        [Fact]
+        public async Task ValidatePhoneNumberRequestHandler_ShouldReturnInvalidPhoneNumberResult_WhenPhoneNumberLookupServicesReturnsFailedLookup()
+        {
+            var lookupService = new Mock<IPhoneNumberLookupService>();
+            lookupService.Setup(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(PhoneNumberLookupResult.FailedLookup);
+
+            var sut = new ValidatePhoneNumberRequestHandler(lookupService.Object);
+
+            var result = await sut.Handle(new ValidatePhoneNumberRequest { PhoneNumber = "0123456789", CountryCode = "us", ValidateType = true });
+
+            result.IsValid.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task ValidatePhoneNumberRequestHandler_ShouldReturnInvalidPhoneNumberResult_WhenPhoneNumberLookupServicesReturnsEmptyPhoneNumber()
+        {
+            var lookupService = new Mock<IPhoneNumberLookupService>();
+            lookupService.Setup(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new PhoneNumberLookupResult(""));
+
+            var sut = new ValidatePhoneNumberRequestHandler(lookupService.Object);
+
+            var result = await sut.Handle(new ValidatePhoneNumberRequest { PhoneNumber = "0123456789", CountryCode = "us", ValidateType = true });
+
+            result.IsValid.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task ValidatePhoneNumberRequestHandler_ShouldReturnInvalidPhoneNumberResult_WhenPhoneNumberLookupServicesReturnsNonMobile_AndValidTypeIsSetToTrue()
+        {
+            var lookupService = new Mock<IPhoneNumberLookupService>();
+            lookupService.Setup(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new PhoneNumberLookupResult("00000", PhoneNumberType.Unknown));
+
+            var sut = new ValidatePhoneNumberRequestHandler(lookupService.Object);
+
+            var result = await sut.Handle(new ValidatePhoneNumberRequest { PhoneNumber = "0123456789", CountryCode = "us", ValidateType = true });
+
+            result.IsValid.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task ValidatePhoneNumberRequestHandler_ShouldReturnValidPhoneNumberResult_WhenPhoneNumberLookupServicesReturnsNonMobile_AndValidTypeIsSetToFalse()
+        {
+            var lookupService = new Mock<IPhoneNumberLookupService>();
+            lookupService.Setup(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new PhoneNumberLookupResult("00000", PhoneNumberType.Unknown));
+
+            var sut = new ValidatePhoneNumberRequestHandler(lookupService.Object);
+
+            var result = await sut.Handle(new ValidatePhoneNumberRequest { PhoneNumber = "0123456789", CountryCode = "us", ValidateType = false });
+
+            result.IsValid.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task ValidatePhoneNumberRequestHandler_ShouldReturnValidPhoneNumberResult_WhenPhoneNumberLookupServicesReturnsMobile_AndValidTypeIsSetToTrue()
+        {
+            var lookupService = new Mock<IPhoneNumberLookupService>();
+            lookupService.Setup(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new PhoneNumberLookupResult("00000", PhoneNumberType.Mobile));
+
+            var sut = new ValidatePhoneNumberRequestHandler(lookupService.Object);
+
+            var result = await sut.Handle(new ValidatePhoneNumberRequest { PhoneNumber = "0123456789", CountryCode = "us", ValidateType = true });
+
+            result.IsValid.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task ValidatePhoneNumberRequestHandler_ShouldReturnCorrectPhoneNumberForAValidResult()
+        {
+            var lookupService = new Mock<IPhoneNumberLookupService>();
+            lookupService.Setup(x => x.LookupNumber(It.IsAny<string>(), It.IsAny<string>()))
+                .ReturnsAsync(new PhoneNumberLookupResult("00000", PhoneNumberType.Mobile));
+
+            var sut = new ValidatePhoneNumberRequestHandler(lookupService.Object);
+
+            var result = await sut.Handle(new ValidatePhoneNumberRequest { PhoneNumber = "0123456789", CountryCode = "us", ValidateType = true });
+
+            result.PhoneNumberE164.ShouldBe("00000");
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/Sms/PhoneNumberLookupResultTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/Sms/PhoneNumberLookupResultTests.cs
@@ -9,7 +9,7 @@ namespace AllReady.UnitTest.Services.Sms
         [Fact]
         public void FailedLookup_ReturnsExpectedPhoneNumberLookupResult()
         {
-            var sut = PhoneNumberLookupResult.FailedLookup();
+            var sut = PhoneNumberLookupResult.FailedLookup;
 
             sut.LookupFailed.ShouldBeTrue();
             sut.PhoneNumberE164.ShouldBeNull();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/Sms/PhoneNumberLookupResultTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/Sms/PhoneNumberLookupResultTests.cs
@@ -1,0 +1,31 @@
+﻿using AllReady.Services.Sms;
+using Shouldly;
+using Xunit;
+
+namespace AllReady.UnitTest.Services.Sms
+{
+    public class PhoneNumberLookupResultTests
+    {
+        [Fact]
+        public void FailedLookup_ReturnsExpectedPhoneNumberLookupResult()
+        {
+            var sut = PhoneNumberLookupResult.FailedLookup();
+
+            sut.LookupFailed.ShouldBeTrue();
+            sut.PhoneNumberE164.ShouldBeNull();
+            sut.Type.ShouldBe(PhoneNumberType.Unknown);
+        }
+
+        [Fact]
+        public void Ctor_SetsCorrectProperties()
+        {
+            var phoneNumber = "+447777123456";
+
+            var sut = new PhoneNumberLookupResult(phoneNumber, PhoneNumberType.Mobile);
+
+            sut.LookupFailed.ShouldBeFalse();
+            sut.PhoneNumberE164.ShouldBe(phoneNumber);
+            sut.Type.ShouldBe(PhoneNumberType.Mobile);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/Sms/TwilioPhoneNumberLookupServiceTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/Sms/TwilioPhoneNumberLookupServiceTests.cs
@@ -1,0 +1,211 @@
+﻿using AllReady.Services.Sms;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using System;
+using System.Threading.Tasks;
+using Twilio.Clients;
+using Twilio.Rest.Lookups.V1;
+using Xunit;
+
+namespace AllReady.UnitTest.Services.Sms
+{
+    public class TwilioPhoneNumberLookupServiceTests
+    {
+        private string TwilioResponseJson = "{\"carrier\": {\"error_code\": null,\"mobile_country_code\": \"310\",\"mobile_network_code\": \"456\",\"name\": \"verizon\",\"type\": \"mobile\"},\"country_code\": \"US\",\"national_format\": \"(510) 867-5309\",\"phone_number\": \"+15108675309\",\"add_ons\": {\"status\": \"successful\",\"message\": null,\"code\": null,\"results\": {}},\"url\": \"https://lookups.twilio.com/v1/PhoneNumbers/phone_number\"}";
+        private string TwilioResponseJsonNoCarrier = "{\"country_code\": \"US\",\"national_format\": \"(510) 867-5309\",\"phone_number\": \"+15108675309\",\"add_ons\": {\"status\": \"successful\",\"message\": null,\"code\": null,\"results\": {}},\"url\": \"https://lookups.twilio.com/v1/PhoneNumbers/phone_number\"}";
+        private string TwilioResponseJsonLandline = "{\"carrier\": {\"error_code\": null,\"mobile_country_code\": \"310\",\"mobile_network_code\": \"456\",\"name\": \"verizon\",\"type\": \"landline\"},\"country_code\": \"US\",\"national_format\": \"(510) 867-5309\",\"phone_number\": \"+15108675309\",\"add_ons\": {\"status\": \"successful\",\"message\": null,\"code\": null,\"results\": {}},\"url\": \"https://lookups.twilio.com/v1/PhoneNumbers/phone_number\"}";
+        private string TwilioResponseJsonVoip = "{\"carrier\": {\"error_code\": null,\"mobile_country_code\": \"310\",\"mobile_network_code\": \"456\",\"name\": \"verizon\",\"type\": \"voip\"},\"country_code\": \"US\",\"national_format\": \"(510) 867-5309\",\"phone_number\": \"+15108675309\",\"add_ons\": {\"status\": \"successful\",\"message\": null,\"code\": null,\"results\": {}},\"url\": \"https://lookups.twilio.com/v1/PhoneNumbers/phone_number\"}";
+
+        [Fact]
+        public async Task LookupNumber_CallsTwilioWrapper()
+        {
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123",Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            await sut.LookupNumber("123456789", "us");
+
+            twilioWrapper.Verify(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task LookupNumber_CallsTwilioWrapper_WithCorrectPhoneNumber()
+        {
+            FetchPhoneNumberOptions fetchOptions = null;
+
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .Callback<FetchPhoneNumberOptions, ITwilioRestClient>((x, y) => fetchOptions = x);
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            await sut.LookupNumber("123456789", "us");
+
+            fetchOptions.PhoneNumber.ToString().ShouldBe(new Twilio.Types.PhoneNumber("123456789").ToString());
+        }
+
+        [Fact]
+        public async Task LookupNumber_CallsTwilioWrapper_WithCorrectType()
+        {
+            FetchPhoneNumberOptions fetchOptions = null;
+
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .Callback<FetchPhoneNumberOptions, ITwilioRestClient>((x, y) => fetchOptions = x);
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            await sut.LookupNumber("123456789", "us");
+
+            fetchOptions.Type[0].ShouldBe("carrier");
+        }
+
+        [Fact]
+        public async Task LookupNumber_CallsTwilioWrapper_WithCorrectCountryCode()
+        {
+            FetchPhoneNumberOptions fetchOptions = null;
+
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .Callback<FetchPhoneNumberOptions, ITwilioRestClient>((x, y) => fetchOptions = x);
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            await sut.LookupNumber("123456789", "us");
+
+            fetchOptions.CountryCode.ShouldBe("us");
+        }
+
+        [Fact]
+        public async Task LookupNumber_ReturnsFailedLokupResult_IfTheTwilioCallFails()
+        {
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .Throws<Exception>();
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            var result = await sut.LookupNumber("123456789", "us");
+
+            result.LookupFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task LookupNumber_ReturnsFailedLokupResult_IfTheTwilioCallReturnsNullPhoneNumberResource()
+        {
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .ReturnsAsync(null);
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            var result = await sut.LookupNumber("123456789", "us");
+
+            result.LookupFailed.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task LookupNumber_ReturnsCorrectPhoneNumberInResult()
+        {
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .ReturnsAsync(PhoneNumberResource.FromJson(TwilioResponseJson));
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            var result = await sut.LookupNumber("123456789", "us");
+
+            result.PhoneNumberE164.ToString().ShouldBe(new Twilio.Types.PhoneNumber("+15108675309").ToString());
+        }
+
+        [Fact]
+        public async Task LookupNumber_ReturnsUnknownType_WhenNoCarrierInfo()
+        {
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .ReturnsAsync(PhoneNumberResource.FromJson(TwilioResponseJsonNoCarrier));
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            var result = await sut.LookupNumber("123456789", "us");
+
+            result.Type.ShouldBe(PhoneNumberType.Unknown);
+        }
+
+        [Fact]
+        public async Task LookupNumber_ReturnsMobileType_WhenResponseIncludesMobileCarrier()
+        {
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .ReturnsAsync(PhoneNumberResource.FromJson(TwilioResponseJson));
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            var result = await sut.LookupNumber("123456789", "us");
+
+            result.Type.ShouldBe(PhoneNumberType.Mobile);
+        }
+
+        [Fact]
+        public async Task LookupNumber_ReturnsLandlineType_WhenResponseIncludesLandlineCarrier()
+        {
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .ReturnsAsync(PhoneNumberResource.FromJson(TwilioResponseJsonLandline));
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            var result = await sut.LookupNumber("123456789", "us");
+
+            result.Type.ShouldBe(PhoneNumberType.Landline);
+        }
+
+        [Fact]
+        public async Task LookupNumber_ReturnsVoipType_WhenResponseIncludesVoipCarrier()
+        {
+            var options = new Mock<IOptions<TwilioSettings>>();
+            options.Setup(x => x.Value).Returns(new TwilioSettings { Sid = "123", Token = "ABC", PhoneNo = "1234567890" });
+
+            var twilioWrapper = new Mock<ITwilioWrapper>();
+            twilioWrapper.Setup(x => x.FetchPhoneNumberResource(It.IsAny<FetchPhoneNumberOptions>(), It.IsAny<ITwilioRestClient>()))
+                .ReturnsAsync(PhoneNumberResource.FromJson(TwilioResponseJsonVoip));
+
+            var sut = new TwilioPhoneNumberLookupService(options.Object, twilioWrapper.Object);
+
+            var result = await sut.LookupNumber("123456789", "us");
+
+            result.Type.ShouldBe(PhoneNumberType.Voip);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/AllReadySettings.cs
+++ b/AllReadyApp/Web-App/AllReady/AllReadySettings.cs
@@ -53,4 +53,11 @@
     {
         public string GoogleDirectionsApiKey { get; set; }
     }
+
+    public class TwilioSettings
+    {
+        public string Sid { get; set; }
+        public string Token { get; set; }
+        public string PhoneNo { get; set; }
+    }
 }

--- a/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
@@ -50,7 +50,7 @@ namespace AllReady.Controllers
             }
 
             // todo - stevejgordon - add code for converting country to country code
-            var validatePhoneNumberResult = await mediator.SendAsync(new ValidatePhoneNumberRequest { PhoneNumber = viewModel.Phone, ValidateType = true, CountryCode = "GB" });
+            var validatePhoneNumberResult = await mediator.SendAsync(new ValidatePhoneNumberRequest { PhoneNumber = viewModel.Phone, ValidateType = true });
 
             if (!validatePhoneNumberResult.IsValid)
             {

--- a/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
@@ -6,6 +6,7 @@ using AllReady.Features.Requests;
 using AllReady.Hangfire.Jobs;
 using AllReady.ViewModels.Requests;
 using Hangfire;
+using AllReady.Features.Sms;
 
 namespace AllReady.Controllers
 {
@@ -47,6 +48,16 @@ namespace AllReady.Controllers
             {
                 return BadRequest();
             }
+
+            // todo - stevejgordon - add code for converting country to country code
+            var validatePhoneNumberResult = await mediator.SendAsync(new ValidatePhoneNumberRequest { PhoneNumber = viewModel.Phone, ValidateType = true, CountryCode = "GB" });
+
+            if (!validatePhoneNumberResult.IsValid)
+            {
+                return BadRequest();
+            }
+
+            viewModel.Phone = validatePhoneNumberResult.PhoneNumberE164;
 
             //this returns control to the caller immediately so the client is not left locked while we figure out if we can service the request
             backgroundjobClient.Enqueue<IProcessApiRequests>(x => x.Process(viewModel));

--- a/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberRequest.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberRequest.cs
@@ -1,0 +1,11 @@
+﻿using MediatR;
+
+namespace AllReady.Features.Sms
+{
+    public class ValidatePhoneNumberRequest : IAsyncRequest<ValidatePhoneNumberResult>
+    {
+        public string PhoneNumber { get; set; }
+        public string CountryCode { get; set; }
+        public bool ValidateType { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberRequestHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberRequestHandler.cs
@@ -1,0 +1,28 @@
+﻿using AllReady.Services.Sms;
+using MediatR;
+using System.Threading.Tasks;
+
+namespace AllReady.Features.Sms
+{
+    public class ValidatePhoneNumberRequestHandler : IAsyncRequestHandler<ValidatePhoneNumberRequest, ValidatePhoneNumberResult>
+    {
+        private readonly IPhoneNumberLookupService _phoneNumberLookupService;
+
+        public ValidatePhoneNumberRequestHandler(IPhoneNumberLookupService phoneNumberLookupService)
+        {
+            _phoneNumberLookupService = phoneNumberLookupService;
+        }
+
+        public async Task<ValidatePhoneNumberResult> Handle(ValidatePhoneNumberRequest request)
+        {
+            var lookupResult = await _phoneNumberLookupService.LookupNumber(request.PhoneNumber, request.CountryCode);
+
+            if (lookupResult.Failed || (request.ValidateType && lookupResult.Type != PhoneNumberType.Mobile) || string.IsNullOrEmpty(request.PhoneNumber))
+            {
+                return new ValidatePhoneNumberResult { IsValid = false };
+            }
+
+            return new ValidatePhoneNumberResult { IsValid = true, PhoneNumberE164 = lookupResult.PhoneNumberE164 };
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberRequestHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberRequestHandler.cs
@@ -17,7 +17,7 @@ namespace AllReady.Features.Sms
         {
             var lookupResult = await _phoneNumberLookupService.LookupNumber(request.PhoneNumber, request.CountryCode);
 
-            if (lookupResult.Failed || (request.ValidateType && lookupResult.Type != PhoneNumberType.Mobile) || string.IsNullOrEmpty(request.PhoneNumber))
+            if (lookupResult.LookupFailed || (request.ValidateType && lookupResult.Type != PhoneNumberType.Mobile) || string.IsNullOrEmpty(request.PhoneNumber))
             {
                 return new ValidatePhoneNumberResult { IsValid = false };
             }

--- a/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberResult.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberResult.cs
@@ -1,0 +1,8 @@
+﻿namespace AllReady.Features.Sms
+{
+    public class ValidatePhoneNumberResult
+    {
+        public bool IsValid { get; set; }
+        public string PhoneNumberE164 { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberResult.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Sms/ValidatePhoneNumberResult.cs
@@ -1,8 +1,18 @@
 ﻿namespace AllReady.Features.Sms
 {
+    /// <summary>
+    /// Represents the result of validating a phone number with an external service
+    /// </summary>
     public class ValidatePhoneNumberResult
     {
+        /// <summary>
+        /// Indicates that the number was considered valid
+        /// </summary>
         public bool IsValid { get; set; }
+
+        /// <summary>
+        /// The phone number in E.164 format. E.164 defines a general format for international telephone numbers.
+        /// </summary>
         public string PhoneNumberE164 { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/FailedPhoneNumberLookupResult.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/FailedPhoneNumberLookupResult.cs
@@ -1,7 +1,0 @@
-﻿namespace AllReady.Services.Sms
-{
-    public class FailedPhoneNumberLookupResult : PhoneNumberLookupResult
-    {
-        public FailedPhoneNumberLookupResult() : base(null) { }
-    }
-}

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/FailedPhoneNumberLookupResult.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/FailedPhoneNumberLookupResult.cs
@@ -1,0 +1,7 @@
+﻿namespace AllReady.Services.Sms
+{
+    public class FailedPhoneNumberLookupResult : PhoneNumberLookupResult
+    {
+        public FailedPhoneNumberLookupResult() : base(null) { }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/FakePhoneNumberLookupService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/FakePhoneNumberLookupService.cs
@@ -12,13 +12,13 @@ namespace AllReady.Services.Sms
         {
             if (Regex.Matches(phoneNumber, @"[a-zA-Z]").Count > 0)
             {
-                return Task.FromResult(PhoneNumberLookupResult.FailedLookup());
+                return Task.FromResult(PhoneNumberLookupResult.FailedLookup);
             }
 
             switch (phoneNumber)
             {
                 case "00000000":
-                    return Task.FromResult(PhoneNumberLookupResult.FailedLookup());
+                    return Task.FromResult(PhoneNumberLookupResult.FailedLookup);
 
                 case "99900000":
                     return Task.FromResult(new PhoneNumberLookupResult(phoneNumber, PhoneNumberType.Landline));

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/FakePhoneNumberLookupService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/FakePhoneNumberLookupService.cs
@@ -1,0 +1,30 @@
+﻿using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace AllReady.Services.Sms
+{
+    /// <summary>
+    /// A fake phone number service that can be used during development. Use 00000000 to return a failed result. Use 99900000 a non mobile result.
+    /// </summary>
+    public class FakePhoneNumberLookupService : IPhoneNumberLookupService
+    {
+        public Task<PhoneNumberLookupResult> LookupNumber(string phoneNumber, string countryCode)
+        {
+            if (Regex.Matches(phoneNumber, @"[a-zA-Z]").Count > 0)
+            {
+                return Task.FromResult(PhoneNumberLookupResult.FailedLookup());
+            }
+
+            switch (phoneNumber)
+            {
+                case "00000000":
+                    return Task.FromResult(PhoneNumberLookupResult.FailedLookup());
+
+                case "99900000":
+                    return Task.FromResult(new PhoneNumberLookupResult(phoneNumber, PhoneNumberType.Landline));
+            }
+
+            return Task.FromResult(new PhoneNumberLookupResult(phoneNumber, PhoneNumberType.Mobile));
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/IPhoneNumberLookupService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/IPhoneNumberLookupService.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+
+namespace AllReady.Services.Sms
+{
+    /// <summary>
+    /// Defines a service that can handle looking up a phone number
+    /// </summary>
+    public interface IPhoneNumberLookupService
+    {
+        /// <summary>
+        /// Looks up a phone number
+        /// </summary>
+        Task<PhoneNumberLookupResult> LookupNumber(string phoneNumber, string countryCode);
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/ITwilioWrapper.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/ITwilioWrapper.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Twilio.Clients;
+using Twilio.Rest.Lookups.V1;
+
+namespace AllReady.Services.Sms
+{
+    /// <summary>
+    /// Wraps the Twilio library code to enable easier testing
+    /// </summary>
+    public interface ITwilioWrapper
+    {
+        Task<PhoneNumberResource> FetchPhoneNumberResource(FetchPhoneNumberOptions fetchOptions, ITwilioRestClient twilioClient);
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/PhoneNumberLookupResult.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/PhoneNumberLookupResult.cs
@@ -5,7 +5,10 @@
     /// </summary>
     public class PhoneNumberLookupResult
     {
-        private PhoneNumberLookupResult() { }
+        private PhoneNumberLookupResult()
+        {
+            LookupFailed = true;
+        }
 
         /// <summary>
         /// Initialise a new <see cref="PhoneNumberLookupResult"/> 
@@ -31,6 +34,9 @@
         /// </summary>
         public PhoneNumberType Type { get; private set; }
 
-        public bool Failed { get; private set; }
+        /// <summary>
+        /// Indicates that the lookup failed to complete
+        /// </summary>
+        public bool LookupFailed { get; private set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/PhoneNumberLookupResult.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/PhoneNumberLookupResult.cs
@@ -19,9 +19,12 @@
             Type = type;
         }
 
-        public static PhoneNumberLookupResult FailedLookup()
+        public static PhoneNumberLookupResult FailedLookup
         {
-            return new PhoneNumberLookupResult();
+            get
+            {
+                return new PhoneNumberLookupResult();
+            }
         }
 
         /// <summary>

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/PhoneNumberLookupResult.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/PhoneNumberLookupResult.cs
@@ -1,0 +1,36 @@
+﻿namespace AllReady.Services.Sms
+{
+    /// <summary>
+    /// The result of a phone number lookup
+    /// </summary>
+    public class PhoneNumberLookupResult
+    {
+        private PhoneNumberLookupResult() { }
+
+        /// <summary>
+        /// Initialise a new <see cref="PhoneNumberLookupResult"/> 
+        /// </summary>
+        public PhoneNumberLookupResult(string e164PhoneNumber, PhoneNumberType type = PhoneNumberType.Unknown)
+        {
+            PhoneNumberE164 = e164PhoneNumber;
+            Type = type;
+        }
+
+        public static PhoneNumberLookupResult FailedLookup()
+        {
+            return new PhoneNumberLookupResult();
+        }
+
+        /// <summary>
+        /// The phone number in E.164 format. E.164 defines a general format for international telephone numbers.
+        /// </summary>
+        public string PhoneNumberE164 { get; private set; }
+
+        /// <summary>
+        /// The type for the phone number - Landline, mobile or VOIP
+        /// </summary>
+        public PhoneNumberType Type { get; private set; }
+
+        public bool Failed { get; private set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/PhoneNumberType.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/PhoneNumberType.cs
@@ -1,0 +1,10 @@
+﻿namespace AllReady.Services.Sms
+{
+    public enum PhoneNumberType
+    {
+        Unknown,
+        Landline,
+        Mobile,
+        Voip
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/TwilioPhoneNumberLookupService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/TwilioPhoneNumberLookupService.cs
@@ -46,7 +46,7 @@ namespace AllReady.Services.Sms
                 // TODO - Logging
             }
 
-            return PhoneNumberLookupResult.FailedLookup();
+            return PhoneNumberLookupResult.FailedLookup;
         }
 
         private static FetchPhoneNumberOptions BuildTwilioRequestOptions(string countryCode, Twilio.Types.PhoneNumber twilioPhoneNumber)
@@ -64,7 +64,7 @@ namespace AllReady.Services.Sms
         private static PhoneNumberLookupResult BuildPhoneNumberLookupResult(PhoneNumberResource phoneNumberResource)
         {
             if (phoneNumberResource == null)
-                return PhoneNumberLookupResult.FailedLookup();
+                return PhoneNumberLookupResult.FailedLookup;
 
             var phoneNumberType = PhoneNumberType.Unknown;
 

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/TwilioPhoneNumberLookupService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/TwilioPhoneNumberLookupService.cs
@@ -6,17 +6,19 @@ using Twilio.Rest.Lookups.V1;
 namespace AllReady.Services.Sms
 {
     /// <summary>
-    /// A service which wraps the Twilio REST API library to lookup phones numbers
+    /// A service which wraps the Twilio REST API library to lookup phone numbers
     /// </summary>
     public class TwilioPhoneNumberLookupService : IPhoneNumberLookupService
     {
         private readonly TwilioSettings _twilioSettings;
         private readonly TwilioRestClient _twilioClient;
+        private readonly ITwilioWrapper _twilioWrapper;
 
-        public TwilioPhoneNumberLookupService(IOptions<TwilioSettings> twilioSettings)
+        public TwilioPhoneNumberLookupService(IOptions<TwilioSettings> twilioSettings, ITwilioWrapper twilioWrapper)
         {
             _twilioSettings = twilioSettings.Value;
             _twilioClient = new TwilioRestClient(_twilioSettings.Sid, _twilioSettings.Token);
+            _twilioWrapper = twilioWrapper;
         }
 
         /// <inheritdoc />
@@ -24,6 +26,7 @@ namespace AllReady.Services.Sms
         {
             if (string.IsNullOrEmpty(countryCode))
             {
+                // we default this to US which matches what Twilio will do if it's missing
                 countryCode = "US";
             }
 
@@ -33,7 +36,7 @@ namespace AllReady.Services.Sms
 
             try
             {
-                var lookupResult = await PhoneNumberResource.FetchAsync(twilioOptions, _twilioClient);
+                var lookupResult = await _twilioWrapper.FetchPhoneNumberResource(twilioOptions, _twilioClient);
 
                 return BuildPhoneNumberLookupResult(lookupResult);
             }

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/TwilioPhoneNumberLookupService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/TwilioPhoneNumberLookupService.cs
@@ -1,0 +1,94 @@
+﻿using Microsoft.Extensions.Options;
+using System.Threading.Tasks;
+using Twilio.Clients;
+using Twilio.Rest.Lookups.V1;
+
+namespace AllReady.Services.Sms
+{
+    /// <summary>
+    /// A service which wraps the Twilio REST API library to lookup phones numbers
+    /// </summary>
+    public class TwilioPhoneNumberLookupService : IPhoneNumberLookupService
+    {
+        private readonly TwilioSettings _twilioSettings;
+        private readonly TwilioRestClient _twilioClient;
+
+        public TwilioPhoneNumberLookupService(IOptions<TwilioSettings> twilioSettings)
+        {
+            _twilioSettings = twilioSettings.Value;
+            _twilioClient = new TwilioRestClient(_twilioSettings.Sid, _twilioSettings.Token);
+        }
+
+        /// <inheritdoc />
+        public async Task<PhoneNumberLookupResult> LookupNumber(string phoneNumber, string countryCode)
+        {
+            if (string.IsNullOrEmpty(countryCode))
+            {
+                countryCode = "US";
+            }
+
+            var twilioPhoneNumber = new Twilio.Types.PhoneNumber(phoneNumber);
+
+            var twilioOptions = BuildTwilioRequestOptions(countryCode, twilioPhoneNumber);
+
+            try
+            {
+                var lookupResult = await PhoneNumberResource.FetchAsync(twilioOptions, _twilioClient);
+
+                return BuildPhoneNumberLookupResult(lookupResult);
+            }
+            catch
+            {
+                // If we reach here then it's likely that the phone number or country code were not valid
+                // TODO - Logging
+            }
+
+            return PhoneNumberLookupResult.FailedLookup();
+        }
+
+        private static FetchPhoneNumberOptions BuildTwilioRequestOptions(string countryCode, Twilio.Types.PhoneNumber twilioPhoneNumber)
+        {
+            var options = new FetchPhoneNumberOptions(twilioPhoneNumber)
+            {
+                CountryCode = countryCode
+            };
+
+            options.Type.Add("carrier");
+
+            return options;
+        }
+
+        private static PhoneNumberLookupResult BuildPhoneNumberLookupResult(PhoneNumberResource phoneNumberResource)
+        {
+            if (phoneNumberResource == null)
+                return PhoneNumberLookupResult.FailedLookup();
+
+            var phoneNumberType = PhoneNumberType.Unknown;
+
+            if (phoneNumberResource.Carrier != null)
+            {
+                var type = phoneNumberResource.Carrier["type"];
+
+                if (!string.IsNullOrEmpty(type))
+                {
+                    switch (type)
+                    {
+                        case "landline":
+                            phoneNumberType = PhoneNumberType.Landline;
+                            break;
+
+                        case "mobile":
+                            phoneNumberType = PhoneNumberType.Mobile;
+                            break;
+
+                        case "voip":
+                            phoneNumberType = PhoneNumberType.Voip;
+                            break;
+                    }
+                }
+            }
+
+            return new PhoneNumberLookupResult(phoneNumberResource.PhoneNumber.ToString(), phoneNumberType);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Services/Sms/TwilioWrapper.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/Sms/TwilioWrapper.cs
@@ -1,0 +1,14 @@
+﻿using System.Threading.Tasks;
+using Twilio.Clients;
+using Twilio.Rest.Lookups.V1;
+
+namespace AllReady.Services.Sms
+{
+    public class TwilioWrapper : ITwilioWrapper
+    {
+        public async Task<PhoneNumberResource> FetchPhoneNumberResource(FetchPhoneNumberOptions fetchOptions, ITwilioRestClient twilioClient)
+        {
+            return await PhoneNumberResource.FetchAsync(fetchOptions, twilioClient);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -202,6 +202,7 @@ namespace AllReady
             if (!string.IsNullOrEmpty(Configuration["Authentication:Twilio:Sid"]) && !string.IsNullOrEmpty(Configuration["Authentication:Twilio:Token"]))
             {
                 services.AddSingleton<IPhoneNumberLookupService, TwilioPhoneNumberLookupService>();
+                services.AddSingleton<ITwilioWrapper, TwilioWrapper>();
             }
             else
             {

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -37,6 +37,7 @@ using AllReady.ModelBinding;
 using Microsoft.AspNetCore.Localization;
 using AllReady.Services.Routing;
 using CsvHelper;
+using AllReady.Services.Sms;
 
 namespace AllReady
 {
@@ -103,6 +104,7 @@ namespace AllReady
             services.Configure<GeneralSettings>(Configuration.GetSection("General"));
             services.Configure<GetASmokeAlarmApiSettings>(Configuration.GetSection("GetASmokeAlarmApiSettings"));
             services.Configure<TwitterAuthenticationSettings>(Configuration.GetSection("Authentication:Twitter"));
+            services.Configure<TwilioSettings>(Configuration.GetSection("Authentication:Twilio"));
             services.Configure<MappingSettings>(Configuration.GetSection("Mapping"));
 
             // Add Identity services to the services container.
@@ -195,6 +197,15 @@ namespace AllReady
                 // this writer service will just write to the default logger
                 services.AddTransient<IQueueStorageService, FakeQueueWriterService>();
                 //services.AddTransient<IQueueStorageService, SmtpEmailSender>();
+            }
+
+            if (!string.IsNullOrEmpty(Configuration["Authentication:Twilio:Sid"]) && !string.IsNullOrEmpty(Configuration["Authentication:Twilio:Token"]))
+            {
+                services.AddSingleton<IPhoneNumberLookupService, TwilioPhoneNumberLookupService>();
+            }
+            else
+            {
+                services.AddSingleton<IPhoneNumberLookupService, FakePhoneNumberLookupService>();                
             }
 
             var containerBuilder = new ContainerBuilder();

--- a/AllReadyApp/Web-App/AllReady/project.json
+++ b/AllReadyApp/Web-App/AllReady/project.json
@@ -39,7 +39,6 @@
     "WindowsAzure.Storage": "4.4.1-preview",
     "MediatR": "2.1.0",
     "Sendgrid": "6.1.0",
-    "Twilio": "4.0.3",
     "Microsoft.Extensions.Logging.Debug": "1.0.1",
     "Autofac": "4.1.0",
     "CsvHelper": "2.15.0.2",
@@ -67,7 +66,8 @@
     "Hangfire.Core": "1.6.7",
     "Hangfire.SqlServer": "1.6.7",
     "Hangfire.Autofac": "2.2.0",
-    "AllReady.Core": "1.0.0-*"  },
+    "AllReady.Core": "1.0.0-*",
+    "Twilio": "5.0.0-rca2"  },
 
   "tools": {
     "Microsoft.AspNetCore.Razor.Tools": "1.0.0-preview2-final",


### PR DESCRIPTION
Fixes #1680

This code adds a service wrapper around the Twilio Rest API client. It uses the Lookup service to validate phone number formats and types.

It also ensures we save the correct E.164 formatted number to ensure our SMS response code can find matching requests.

Includes a faked version of the service for dev use - doesn't require Twilio account.

Currently a WIP for initial feedback and discussion. Needs to be implemented for CSV and manual request creation + unit testing and general checking through. Also needs some code to convert Country strings to ISO format country codes.

Tested against the live Twilio service using a real number and it worked as expected.