### PR TITLE
Add an enable/disable setting for Twilio API calls

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -199,16 +199,16 @@ namespace AllReady
                 //services.AddTransient<IQueueStorageService, SmtpEmailSender>();
             }
 
-            if (!string.IsNullOrEmpty(Configuration["Authentication:Twilio:Sid"]) && !string.IsNullOrEmpty(Configuration["Authentication:Twilio:Token"]))
+            if (Configuration["Authentication:Twilio:EnableTwilio"] == "true")
             {
                 services.AddSingleton<IPhoneNumberLookupService, TwilioPhoneNumberLookupService>();
                 services.AddSingleton<ITwilioWrapper, TwilioWrapper>();
             }
             else
             {
-                services.AddSingleton<IPhoneNumberLookupService, FakePhoneNumberLookupService>();                
+                services.AddSingleton<IPhoneNumberLookupService, FakePhoneNumberLookupService>();
             }
-
+            
             var containerBuilder = new ContainerBuilder();
             containerBuilder.RegisterSource(new ContravariantRegistrationSource());
             containerBuilder.RegisterAssemblyTypes(typeof(IMediator).Assembly).AsImplementedInterfaces();

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -72,6 +72,7 @@
       "FromEmail": "[sendgridemailsender]"
     },
     "Twilio": {
+      "EnableTwilio": "false",
       "Sid": "[twiliosid]",
       "Token": "[twiliotoken]",
       "PhoneNo": "[twilionumber]"


### PR DESCRIPTION
Fixes #1702

@stevejgordon, one note on the `FakePhoneNumberLookupService` class. There is implementation in this class that looks like it's still doing work as well as providing instruction on how to use the fake based on input to it.

IMO, we should have no implementation in the fake, it should just return IsValid is true and spit back whatever number is given to it.

If the user needs to test the conditionals surrounding the service, they should get a Twilio API key, change the config to use the real thing, and run the system that way.