### PR TITLE
Added unit tests for NotifyAdminForTaskSignupStatusChangeHandler

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandlerShould.cs
@@ -40,36 +40,6 @@ namespace AllReady.UnitTest.Features.Notifications
         }
 
         [Fact]
-        public async void UsesUserEmailAsSubjectWhenFirstAndLastNameAreNulls()
-        {
-            const int taskSignupId = 1001;
-            const int taskId = 12314;
-            const string email = "kmad@allready.com";
-            const string userEmail = "damk@allready.com";
-
-            var mediator = new Mock<IMediator>();
-            NotifyVolunteersViewModel viewModel = null;
-            mediator.Setup(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
-                .ReturnsAsync(new Unit())
-                .Callback<IAsyncRequest>(request => viewModel = ((NotifyVolunteersCommand)request).ViewModel);
-
-            var options = new Mock<IOptions<GeneralSettings>>();
-            options.Setup(o => o.Value).Returns(new GeneralSettings { SiteBaseUrl = "allready.com" });
-
-            var notification = new TaskSignupStatusChanged { SignupId = taskSignupId };
-
-            var context = Context;
-            var taskSignup = CreateTaskSignup(taskSignupId, taskId, email, userMail: userEmail);
-            context.TaskSignups.Add(taskSignup);
-            context.SaveChanges();
-
-            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
-            await target.Handle(notification);
-
-            viewModel.Subject.ShouldBe($"{userEmail}");
-        }
-
-        [Fact]
         public async void UsesUserFirstAndLastNameAsSubjectWhenProvided()
         {
             const int taskSignupId = 1001;

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandlerShould.cs
@@ -70,38 +70,6 @@ namespace AllReady.UnitTest.Features.Notifications
         }
 
         [Fact]
-        public async void UsesUserEmailAsSubjectWhenFirstAndLastNameAreEmpty()
-        {
-            const int taskSignupId = 1001;
-            const int taskId = 12314;
-            const string email = "kmad@allready.com";
-            const string firstName = "";
-            const string lastName = "";
-            const string userEmail = "damk@allready.com";
-
-            var mediator = new Mock<IMediator>();
-            NotifyVolunteersViewModel viewModel = null;
-            mediator.Setup(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
-                .ReturnsAsync(new Unit())
-                .Callback<IAsyncRequest>(request => viewModel = ((NotifyVolunteersCommand)request).ViewModel);
-
-            var options = new Mock<IOptions<GeneralSettings>>();
-            options.Setup(o => o.Value).Returns(new GeneralSettings { SiteBaseUrl = "allready.com" });
-
-            var notification = new TaskSignupStatusChanged { SignupId = taskSignupId };
-
-            var context = Context;
-            var taskSignup = CreateTaskSignup(taskSignupId, taskId, email, firstName, lastName, userEmail);
-            context.TaskSignups.Add(taskSignup);
-            context.SaveChanges();
-
-            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
-            await target.Handle(notification);
-
-            viewModel.Subject.ShouldBe($"{userEmail}");
-        }
-
-        [Fact]
         public async void UsesUserFirstAndLastNameAsSubjectWhenProvided()
         {
             const int taskSignupId = 1001;

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandlerShould.cs
@@ -1,0 +1,252 @@
+﻿using System.Collections.Generic;
+using AllReady.Features.Notifications;
+using AllReady.Models;
+using MediatR;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shouldly;
+using Xunit;
+
+namespace AllReady.UnitTest.Features.Notifications
+{
+    public class NotifyAdminForTaskSignupStatusChangeHandlerShould : InMemoryContextTest
+    {
+        [Fact]
+        public async void PassANotifyVolunteersCommandToTheMediatorWhenEmailIsProvided()
+        {
+            const int taskSignupId = 1001;
+            const int taskId = 12314;
+            const string email = "kmad@allready.com";
+            const string userMail = "damk@allready.com";
+
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
+                .ReturnsAsync(new Unit());
+
+            var options = new Mock<IOptions<GeneralSettings>>();
+            options.Setup(o => o.Value).Returns(new GeneralSettings {SiteBaseUrl = "allready.com"});
+
+            var notification = new TaskSignupStatusChanged {SignupId = taskSignupId};
+
+            var context = Context;
+            var taskSignup = CreateTaskSignup(taskSignupId, taskId, email, userMail: userMail);
+            context.TaskSignups.Add(taskSignup);
+            context.SaveChanges();
+
+            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
+            await target.Handle(notification);
+
+            mediator.VerifyAll();
+        }
+
+        [Fact]
+        public async void UsesUserEmailAsSubjectWhenFirstAndLastNameAreNulls()
+        {
+            const int taskSignupId = 1001;
+            const int taskId = 12314;
+            const string email = "kmad@allready.com";
+            const string userEmail = "damk@allready.com";
+
+            var mediator = new Mock<IMediator>();
+            NotifyVolunteersViewModel viewModel = null;
+            mediator.Setup(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
+                .ReturnsAsync(new Unit())
+                .Callback<IAsyncRequest>(request => viewModel = ((NotifyVolunteersCommand)request).ViewModel);
+
+            var options = new Mock<IOptions<GeneralSettings>>();
+            options.Setup(o => o.Value).Returns(new GeneralSettings { SiteBaseUrl = "allready.com" });
+
+            var notification = new TaskSignupStatusChanged { SignupId = taskSignupId };
+
+            var context = Context;
+            var taskSignup = CreateTaskSignup(taskSignupId, taskId, email, userMail: userEmail);
+            context.TaskSignups.Add(taskSignup);
+            context.SaveChanges();
+
+            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
+            await target.Handle(notification);
+
+            viewModel.Subject.ShouldBe($"{userEmail}");
+        }
+
+        [Fact]
+        public async void UsesUserEmailAsSubjectWhenFirstAndLastNameAreEmpty()
+        {
+            const int taskSignupId = 1001;
+            const int taskId = 12314;
+            const string email = "kmad@allready.com";
+            const string firstName = "";
+            const string lastName = "";
+            const string userEmail = "damk@allready.com";
+
+            var mediator = new Mock<IMediator>();
+            NotifyVolunteersViewModel viewModel = null;
+            mediator.Setup(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
+                .ReturnsAsync(new Unit())
+                .Callback<IAsyncRequest>(request => viewModel = ((NotifyVolunteersCommand)request).ViewModel);
+
+            var options = new Mock<IOptions<GeneralSettings>>();
+            options.Setup(o => o.Value).Returns(new GeneralSettings { SiteBaseUrl = "allready.com" });
+
+            var notification = new TaskSignupStatusChanged { SignupId = taskSignupId };
+
+            var context = Context;
+            var taskSignup = CreateTaskSignup(taskSignupId, taskId, email, firstName, lastName, userEmail);
+            context.TaskSignups.Add(taskSignup);
+            context.SaveChanges();
+
+            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
+            await target.Handle(notification);
+
+            viewModel.Subject.ShouldBe($"{userEmail}");
+        }
+
+        [Fact]
+        public async void UsesUserFirstAndLastNameAsSubjectWhenProvided()
+        {
+            const int taskSignupId = 1001;
+            const int taskId = 12314;
+            const string email = "kmad@allready.com";
+            const string firstName = "Simon";
+            const string lastName = "Says";
+            const string userEmail = "damk@allready.com";
+
+            var mediator = new Mock<IMediator>();
+            NotifyVolunteersViewModel viewModel = null;
+            mediator.Setup(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
+                .ReturnsAsync(new Unit())
+                .Callback<IAsyncRequest>(request => viewModel = ((NotifyVolunteersCommand)request).ViewModel);
+
+            var options = new Mock<IOptions<GeneralSettings>>();
+            options.Setup(o => o.Value).Returns(new GeneralSettings { SiteBaseUrl = "allready.com" });
+
+            var notification = new TaskSignupStatusChanged { SignupId = taskSignupId };
+
+            var context = Context;
+            var taskSignup = CreateTaskSignup(taskSignupId, taskId, email, firstName, lastName, userEmail);
+            context.TaskSignups.Add(taskSignup);
+            context.SaveChanges();
+
+            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
+            await target.Handle(notification);
+
+            mediator.VerifyAll();
+            viewModel.Subject.ShouldBe($"{firstName} {lastName}");
+        }
+
+        [Fact]
+        public async void NotPassANotifyVolunteersCommandToTheMediatorWhenEmailIsEmpty()
+        {
+            const int taskSignupId = 1001;
+            const int taskId = 12314;
+            const string email = "";
+
+            var mediator = new Mock<IMediator>();
+            var options = new Mock<IOptions<GeneralSettings>>();
+
+            var notification = new TaskSignupStatusChanged { SignupId = taskSignupId };
+
+            var context = Context;
+            var taskSignup = CreateTaskSignup(taskSignupId, taskId, email);
+            context.TaskSignups.Add(taskSignup);
+            context.SaveChanges();
+
+            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
+            await target.Handle(notification);
+
+            mediator.Verify(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()), Times.Never);
+        }
+
+        [Fact]
+        public async void NotPassANotifyVolunteersCommandToTheMediatorWhenCampaignContactIsNull()
+        {
+            const int taskSignupId = 1001;
+            const int taskId = 12314;
+
+            var mediator = new Mock<IMediator>();
+            var options = new Mock<IOptions<GeneralSettings>>();
+
+            var notification = new TaskSignupStatusChanged { SignupId = taskSignupId };
+
+            var context = Context;
+            var taskSignup = CreateTaskSignupWithoutCampaignContact(taskSignupId, taskId);
+            context.TaskSignups.Add(taskSignup);
+            context.SaveChanges();
+
+            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
+            await target.Handle(notification);
+
+            mediator.Verify(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()), Times.Never);
+        }
+
+        [Fact]
+        public async void NotPassANotifyVolunteersCommandToTheMediatorWhenCampaignContactsIsNull()
+        {
+            const int taskSignupId = 1001;
+            const int taskId = 12314;
+
+            var mediator = new Mock<IMediator>();
+            var options = new Mock<IOptions<GeneralSettings>>();
+
+            var notification = new TaskSignupStatusChanged { SignupId = taskSignupId };
+
+            var context = Context;
+            var taskSignup = CreateTaskSignupWithoutCampaignContacts(taskSignupId, taskId);
+            context.TaskSignups.Add(taskSignup);
+            context.SaveChanges();
+
+            var target = new NotifyAdminForTaskSignupStatusChangeHandler(context, mediator.Object, options.Object);
+            await target.Handle(notification);
+
+            mediator.Verify(m => m.SendAsync(It.IsAny<NotifyVolunteersCommand>()), Times.Never);
+        }
+
+        private static TaskSignup CreateTaskSignup(int taskSignupId, int taskId , string email, string firstName = null, string lastName = null, string userMail = null)
+        {
+            var taskSignup = new TaskSignup
+            {
+                Id = taskSignupId,
+                User = new ApplicationUser
+                {
+                    FirstName = firstName,
+                    LastName = lastName,
+                    Email = userMail
+                },
+                Task = new AllReadyTask
+                {
+                    Id = taskId,
+                    Event = new AllReady.Models.Event
+                    {
+                        Campaign = new Campaign
+                        {
+                            CampaignContacts = new List<CampaignContact>
+                            {
+                                new CampaignContact
+                                {
+                                    ContactType = (int) ContactTypes.Primary,
+                                    Contact = new Contact { Email = email }
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+
+            return taskSignup;
+        }
+
+        private static TaskSignup CreateTaskSignupWithoutCampaignContact(int taskSignupId, int taskId, string firstName = null, string lastName = null, string userMail = null)
+        {
+            var taskSignup = CreateTaskSignup(taskSignupId, taskId, null, firstName, lastName, userMail);
+            taskSignup.Task.Event.Campaign.CampaignContacts = new List<CampaignContact>();
+            return taskSignup;
+        }
+
+        private static TaskSignup CreateTaskSignupWithoutCampaignContacts(int taskSignupId, int taskId, string firstName = null, string lastName = null, string userMail = null)
+        {
+            var taskSignup = CreateTaskSignup(taskSignupId, taskId, null, firstName, lastName, userMail);
+            taskSignup.Task.Event.Campaign = new Campaign();
+            return taskSignup;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandler.cs
@@ -43,7 +43,7 @@ namespace AllReady.Features.Notifications
             {
                 var link = $"View event: http://{_options.Value.SiteBaseUrl}/Admin/Task/Details/{taskSignup.Task.Id}";
 
-                var subject = !string.IsNullOrEmpty(volunteer.FirstName) && !string.IsNullOrEmpty(volunteer.LastName)
+                var subject = volunteer.FirstName != null && volunteer.LastName != null
                     ? $"{volunteer.FirstName} {volunteer.LastName}"
                     : volunteer.Email;
 

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandler.cs
@@ -43,10 +43,6 @@ namespace AllReady.Features.Notifications
             {
                 var link = $"View event: http://{_options.Value.SiteBaseUrl}/Admin/Task/Details/{taskSignup.Task.Id}";
 
-                var subject = volunteer.FirstName != null && volunteer.LastName != null
-                    ? $"{volunteer.FirstName} {volunteer.LastName}"
-                    : volunteer.Email;
-
                 var message = $@"A volunteer's status has changed for a task.
                     Volunteer: {volunteer.Name} ({volunteer.Email})
                     New status: {taskSignup.Status}
@@ -61,7 +57,7 @@ namespace AllReady.Features.Notifications
                         EmailMessage = message,
                         HtmlMessage = message,
                         EmailRecipients = new List<string> { adminEmail },
-                        Subject = subject
+                        Subject = $"{volunteer.FirstName} {volunteer.LastName}"
                     }
                 };
 

--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForTaskSignupStatusChangeHandler.cs
@@ -43,7 +43,9 @@ namespace AllReady.Features.Notifications
             {
                 var link = $"View event: http://{_options.Value.SiteBaseUrl}/Admin/Task/Details/{taskSignup.Task.Id}";
 
-                var subject = volunteer.FirstName != null && volunteer.LastName != null ? $"{volunteer.FirstName} {volunteer.LastName}" : volunteer.Email;
+                var subject = !string.IsNullOrEmpty(volunteer.FirstName) && !string.IsNullOrEmpty(volunteer.LastName)
+                    ? $"{volunteer.FirstName} {volunteer.LastName}"
+                    : volunteer.Email;
 
                 var message = $@"A volunteer's status has changed for a task.
                     Volunteer: {volunteer.Name} ({volunteer.Email})


### PR DESCRIPTION
Added unit tests for NotifyAdminForTaskSignupStatusChangeHandler and changed a subject's format to a user mail when a first name and a last name of a user are empty.

Closes #861 