### PR TITLE
Change VerifyUserToken to use same purpose as GenerateUserToken

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/Middleware/TokenProtectedResource.cs
@@ -43,7 +43,7 @@ namespace AllReady.Security.Middleware
                 var token = headers.FirstOrDefault(h => h.Key == "ApiToken").Value;
 
                 var user = await manager.FindByNameAsync(apiUser);
-                var authorized = await manager.VerifyUserTokenAsync(user, "Default", "api-request-injest", token);
+                var authorized = await manager.VerifyUserTokenAsync(user, "Default", TokenTypes.ApiKey, token);
 
                 if (!authorized)
                 {


### PR DESCRIPTION
- There was a mismatch between the two tokens which meant the verification failed, changed the code in TokenProtectedResource to use TokenTypes.ApiKey and the token is then verified correctly.

Closes #1586