### PR TITLE
Initial Polly wrapper for GoogleOptimizeRouteService

### DIFF
--- a/AllReadyApp/Web-App/AllReady/project.json
+++ b/AllReadyApp/Web-App/AllReady/project.json
@@ -62,7 +62,8 @@
     "Microsoft.VisualStudio.Web.BrowserLink.Loader": "14.1.0",
     "WindowsAzure.Storage": "7.1.3-preview",
     "Twilio": "5.0.0-rca2",
-    "SendGrid.NetCore": "1.0.0-rtm-00002"
+    "SendGrid.NetCore": "1.0.0-rtm-00002",
+    "Polly": "5.0.3"
   },
 
   "tools": {


### PR DESCRIPTION
Fixes #1708 

Adds a Polly retry around the call to the Google optimize route API endpoint. We will retry 2 times after the initial attempt on any exception. This could be improved once we have some logging to determine if there are exceptions / return codes that we feel do not warrant a retry.

- Added Polly dependency to the project
- Wrapped the Google API call code with a Retry Policy