### PR TITLE
Fixing issues when volunteering for a task:

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForSignupHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Notifications/NotifyAdminForSignupHandler.cs
@@ -35,7 +35,7 @@ namespace AllReady.Features.Notifications
                 var taskInfo = await _mediator.SendAsync(new TaskDetailForNotificationQuery { TaskId = notification.TaskId, UserId = notification.UserId });
 
                 var campaignContact = taskInfo.CampaignContacts?.SingleOrDefault(tc => tc.ContactType == (int)ContactTypes.Primary);
-                var adminEmail = campaignContact?.Contact.Email;
+                var adminEmail = campaignContact?.Contact?.Email;
                 if (string.IsNullOrWhiteSpace(adminEmail))
                 {
                     return;

--- a/AllReadyApp/Web-App/AllReady/Models/Campaign.cs
+++ b/AllReadyApp/Web-App/AllReady/Models/Campaign.cs
@@ -71,7 +71,7 @@ namespace AllReady.Models
 
         public Location Location { get; set; }
 
-        public List<CampaignContact> CampaignContacts { get; set; }
+        public List<CampaignContact> CampaignContacts { get; set; } = new List<CampaignContact>();
 
         public bool Locked { get; set; }
 


### PR DESCRIPTION
#1506  Fixing a null reference that occurs when volunteering for a campaign that was created with the seed data without a campaign contact. The first ?. can result in a null, thus need the second ?.
Adding a default (empty) list of CampaignContacts to the Campaign EF model to prevent InvalidOperation occurring in an EF query when getting tasks.