### PR TITLE
List of approved regions for GASA endpoint #1699

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Hangfire/Jobs/ProcessApiRequestsShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Hangfire/Jobs/ProcessApiRequestsShould.cs
@@ -1,13 +1,18 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Features.Requests;
 using AllReady.Hangfire.Jobs;
 using AllReady.Models;
 using AllReady.Services.Mapping;
 using AllReady.Services.Mapping.GeoCoding;
+using AllReady.Services.Mapping.GeoCoding.Models;
 using AllReady.ViewModels.Requests;
 using MediatR;
+using Microsoft.Extensions.Options;
 using Moq;
+using Shouldly;
 using Xunit;
 
 namespace AllReady.UnitTest.Hangfire.Jobs
@@ -35,7 +40,7 @@ namespace AllReady.UnitTest.Hangfire.Jobs
                 ProviderData = "ProviderData"
             };
 
-            var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), Mock.Of<IGeocodeService>())
+            var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), Mock.Of<IGeocodeService>(), Options.Create(new ApprovedRegionsSettings()))
             {
                 NewRequestId = () => requestId,
                 DateTimeUtcNow = () => dateAdded
@@ -59,14 +64,53 @@ namespace AllReady.UnitTest.Hangfire.Jobs
             Assert.Equal(request.Source, RequestSource.Api);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void AssignCorrectValuesToRequestsLatitiudeAndLongitudeWhenIGeocoderReturnedAdressIsNull()
         {
+            var requestId = Guid.NewGuid();
+            var geocoder = new Mock<IGeocodeService>();
+            geocoder.Setup(service => service.GetCoordinatesFromAddress(It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(() => Task.FromResult<Coordinates>(null));
+
+            var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), geocoder.Object,
+                Options.Create(new ApprovedRegionsSettings()))
+            {
+                NewRequestId = () => requestId
+            };
+
+            sut.Process(new RequestApiViewModel());
+
+            var request = Context.Requests.Single(r => r.RequestId == requestId);
+
+            request.Latitude.ShouldBe(0);
+            request.Longitude.ShouldBe(0);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public void AssignCorrectValuesToRequestsLatitiudeAndLongitudeWhenIGeocoderReturnedAdressIsNotNull()
         {
+            var requestId = Guid.NewGuid();
+            var latitude = 20.013;
+            var longitude = 40.058;
+
+            var geocoder = new Mock<IGeocodeService>();
+            geocoder.Setup(service => service.GetCoordinatesFromAddress(It.IsAny<string>(),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(() => Task.FromResult(new Coordinates(latitude, longitude)));
+
+            var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), geocoder.Object,
+                Options.Create(new ApprovedRegionsSettings()))
+            {
+                NewRequestId = () => requestId
+            };
+
+            sut.Process(new RequestApiViewModel());
+
+            var request = Context.Requests.Single(r => r.RequestId == requestId);
+
+            request.Latitude.ShouldBe(latitude);
+            request.Longitude.ShouldBe(longitude);
         }
 
         [Fact]
@@ -75,7 +119,7 @@ namespace AllReady.UnitTest.Hangfire.Jobs
             var requestId = Guid.NewGuid();
             var geoCoder = new Mock<IGeocodeService>();
             var viewModel = new RequestApiViewModel { Address = "address", City = "city", State = "state", Zip = "zip" };
-            var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), geoCoder.Object)
+            var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), geoCoder.Object, Options.Create(new ApprovedRegionsSettings()))
             {
                 NewRequestId = () => requestId
             };
@@ -91,7 +135,7 @@ namespace AllReady.UnitTest.Hangfire.Jobs
             var requestId = Guid.NewGuid();
             var mediator = new Mock<IMediator>();
 
-            var sut = new ProcessApiRequests(Context, mediator.Object, Mock.Of<IGeocodeService>())
+            var sut = new ProcessApiRequests(Context, mediator.Object, Mock.Of<IGeocodeService>(), Options.Create(new ApprovedRegionsSettings()))
             {
                 NewRequestId = () => requestId
             };
@@ -99,6 +143,83 @@ namespace AllReady.UnitTest.Hangfire.Jobs
             sut.Process(new RequestApiViewModel());
 
             mediator.Verify(x => x.Publish(It.Is<ApiRequestProcessedNotification>(y => y.RequestId == requestId)), Times.Once);
+        }
+
+        [Fact]
+        public void PublishApiRequestAddedNotificationWithTrueAcceptanceApprovedRegionsAreDisabled()
+        {
+            var mediator = new Mock<IMediator>();
+
+            var approvedRegions = Options.Create(new ApprovedRegionsSettings
+            {
+                Enabled = false
+            });
+
+            var sut = new ProcessApiRequests(Context, mediator.Object, Mock.Of<IGeocodeService>(), approvedRegions)
+            {
+                NewRequestId = () => Guid.NewGuid()
+            };
+
+            sut.Process(new RequestApiViewModel
+            {
+                ProviderData = "approved_region"
+            });
+
+            mediator.Verify(x => x.Publish(It.Is<ApiRequestProcessedNotification>(y => y.Acceptance == true)), Times.Once);
+        }
+
+        [Fact]
+        public void PublishApiRequestAddedNotificationWithTrueAcceptanceWhenInsideApprovedRegions()
+        {
+            var mediator = new Mock<IMediator>();
+
+            var approvedRegions = Options.Create(new ApprovedRegionsSettings
+            {
+                Enabled = true,
+                Regions = new List<string>
+                {
+                    "approved_region"
+                }
+            });
+
+            var sut = new ProcessApiRequests(Context, mediator.Object, Mock.Of<IGeocodeService>(), approvedRegions)
+            {
+                NewRequestId = () => Guid.NewGuid()
+            };
+
+            sut.Process(new RequestApiViewModel
+            {
+                ProviderData = "approved_region"
+            });
+
+            mediator.Verify(x => x.Publish(It.Is<ApiRequestProcessedNotification>(y => y.Acceptance == true)), Times.Once);
+        }
+
+        [Fact]
+        public void PublishApiRequestAddedNotificationWithFalseAcceptanceWhenOutsideApprovedRegions()
+        {
+            var mediator = new Mock<IMediator>();
+
+            var approvedRegions = Options.Create(new ApprovedRegionsSettings
+            {
+                Enabled = true,
+                Regions = new List<string>
+                {
+                    "approved_region"
+                }
+            });
+
+            var sut = new ProcessApiRequests(Context, mediator.Object, Mock.Of<IGeocodeService>(), approvedRegions)
+            {
+                NewRequestId = () => Guid.NewGuid()
+            };
+
+            sut.Process(new RequestApiViewModel
+            {
+                ProviderData = "non_approved_region"
+            });
+
+            mediator.Verify(x => x.Publish(It.Is<ApiRequestProcessedNotification>(y => y.Acceptance == false)), Times.Once);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/AllReadySettings.cs
+++ b/AllReadyApp/Web-App/AllReady/AllReadySettings.cs
@@ -1,4 +1,6 @@
-﻿namespace AllReady
+﻿using System.Collections.Generic;
+
+namespace AllReady
 {
     public class AzureStorageSettings
     {
@@ -57,5 +59,12 @@
         public string Sid { get; set; }
         public string Token { get; set; }
         public string PhoneNo { get; set; }
+    }
+
+    public class ApprovedRegionsSettings
+    {
+        public bool Enabled { get; set; }
+
+        public List<string> Regions { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/RequestApiController.cs
@@ -39,10 +39,7 @@ namespace AllReady.Controllers
             {
                 return BadRequest();
             }
-
-            //TODO mgmccarthy: valiate the list of regions here for v1 launch that will allow us to determine if we can service the request or not
-            //this will be in the incoming field based on GASA's "assigned_rc_region" which is mapped to RequestApiViewModel.ProviderData on the incoming json request
-
+            
             //if we get here, the incoming request is already in our database with a matching ProviderId ("serial" field for getasmokealarm) and the request was sent with a status of "new"
             if (await mediator.SendAsync(new RequestExistsByProviderIdQuery { ProviderRequestId = viewModel.ProviderRequestId }))
             {

--- a/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotification.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotification.cs
@@ -6,5 +6,7 @@ namespace AllReady.Features.Requests
     public class ApiRequestProcessedNotification : INotification
     {
         public Guid RequestId { get; set; }
+        
+        public bool Acceptance { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotificationHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Requests/ApiRequestProcessedNotificationHandler.cs
@@ -22,7 +22,7 @@ namespace AllReady.Features.Requests
         {
             var request = context.Requests.SingleOrDefault(x => x.RequestId == notification.RequestId);
             //acceptance is true if we can service the Request or false if can't service it 
-            backgroundJobClient.Enqueue<ISendRequestStatusToGetASmokeAlarm>(x => x.Send(request.ProviderRequestId, "new", true));
+            backgroundJobClient.Enqueue<ISendRequestStatusToGetASmokeAlarm>(x => x.Send(request.ProviderRequestId, "new", notification.Acceptance));
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -107,6 +107,8 @@ namespace AllReady
             services.Configure<TwitterAuthenticationSettings>(Configuration.GetSection("Authentication:Twitter"));
             services.Configure<TwilioSettings>(Configuration.GetSection("Authentication:Twilio"));
             services.Configure<MappingSettings>(Configuration.GetSection("Mapping"));
+            services.Configure<ApprovedRegionsSettings>(settings => settings.Enabled = false);
+            services.Configure<ApprovedRegionsSettings>(Configuration.GetSection("ApprovedRegions"));
 
             // Add Identity services to the services container.
             services.AddIdentity<ApplicationUser, IdentityRole>(options =>

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -72,5 +72,18 @@
       "Token": "[twiliotoken]",
       "PhoneNo": "[twilionumber]"
     }
-  }
+  },  
+    "ApprovedRegions": {
+      "Enabled": true,
+      "Regions": ["IDMT",
+        "NDSD",
+        "KSNE",
+        "MINN",
+        "IOWA",
+        "WEMO",
+        "EAMO",
+        "WISC",
+        "CHNI",
+        "CSIL"]
+  } 
 }


### PR DESCRIPTION
Included basic config settings for approved regions per #1699.

Included setting the appropriate acceptance argument on the GASA endpoint call if the region is (un)approved.