### PR TITLE
Use case-sensitive path for showModal.js

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Event/_EventScripts.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/_EventScripts.cshtml
@@ -34,5 +34,5 @@
     <script type="text/javascript" src="~/js/ko.bindings.js"></script>
     <script type="text/javascript" src="~/lib/knockout-mapping/knockout.mapping.js"></script>
     <script type="text/javascript" src="~/js/event.js"></script>
-    <script type="text/javascript" src="~/js/showmodal.js"></script>
+    <script type="text/javascript" src="~/js/showModal.js"></script>
     <script type="text/javascript" src="http://ecn.dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=7.0"></script>


### PR DESCRIPTION
Linux is case-sensitive, so reference to showmodal.js results in a 404.

This was stopping the Volunteer modal from displaying when clicking the Volunteer button on a task in an event.