### PR TITLE
Use Local TimeZoneInfo in SampleDataGenerator

### DIFF
--- a/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
@@ -16,7 +16,7 @@ namespace AllReady.DataAccess
         private readonly SampleDataSettings _settings;
         private readonly GeneralSettings _generalSettings;
         private readonly UserManager<ApplicationUser> _userManager;
-        private readonly TimeZoneInfo _centralTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Central Standard Time");
+        private readonly TimeZoneInfo _centralTimeZone = TimeZoneInfo.Local;
 
         public SampleDataGenerator(AllReadyContext context, IOptions<SampleDataSettings> options, IOptions<GeneralSettings> generalSettings, UserManager<ApplicationUser> userManager)
         {


### PR DESCRIPTION
This is needed due to TimeZone Id's being different across operating systems and hence "Central Standard Time" does not exist on a mac.