### PR TITLE
Correctly show manage keys option for user

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Site/Index.cshtml
@@ -73,6 +73,9 @@
                                                         @if (!user.IsUserType(UserType.ApiAccess))
                                                         {
                                                             <a data-toggle="tooltip" data-placement="top" title="Allow API Access" asp-action="AssignApiAccessRole" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-success">Allow API Access</a>
+                                                        }
+                                                        else
+                                                        {
                                                             <a data-toggle="tooltip" data-placement="top" title="Manage Keys" asp-action="ManageApiKeys" asp-controller="Site" asp-area="Admin" asp-route-userId="@user.Id" class="btn btn-warning">Manage Keys</a>
                                                         }
                                                     </div>


### PR DESCRIPTION
You can only manage keys for a user with API access assigned, but the
manage keys option was only available when the user was not allowed API access.

Fixes #1716