### PR TITLE
#1707 social login error

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -31,12 +31,12 @@ namespace AllReady.UnitTest.Controllers
         public void LoginGetPopulatesViewDataWithTheCorrectTestUrl()
         {
             var sut = AccountController();
-
-            var result = (ViewResult)sut.Login();
+           
+            var result = (ViewResult)sut.Login().Result;
             Assert.Null(result.ViewData["ReturnUrl"]);
 
             const string testUrl = "return url";
-            result = (ViewResult)sut.Login(testUrl);
+            result = (ViewResult)sut.Login(testUrl).Result;
             Assert.Equal(testUrl, result.ViewData["ReturnUrl"]);
         }
 
@@ -95,7 +95,7 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = MockHelper.CreateSignInManagerMock(MockHelper.CreateUserManagerMock());
             signInManager.Setup(x => x.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Failed);
 
-            var sut = new AccountController(null, signInManager.Object, null, mediator.Object, null, null);
+            var sut = new AccountController(null, signInManager.Object, null,null, mediator.Object, null, null);
             await sut.Login(model);
 
             mediator.Verify(x => x.SendAsync(It.Is<ApplicationUserQuery>(y => y.UserName == model.Email)), Times.Once);
@@ -116,7 +116,7 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
             signInManager.Setup(x => x.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Failed);
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, mediator.Object, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null,null, mediator.Object, null, null);
             var result = await sut.Login(new LoginViewModel()) as ViewResult;
 
             Assert.Equal(result.ViewData["Message"], "You must have a confirmed email to log on.");
@@ -138,7 +138,7 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
             signInManager.Setup(x => x.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Failed);
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, mediator.Object, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, mediator.Object, null, null);
             var result = await sut.Login(new LoginViewModel()) as ViewResult;
 
             Assert.Equal(result.ViewData["Message"], "You must have a confirmed email to log on.");
@@ -156,7 +156,7 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = MockHelper.CreateSignInManagerMock(MockHelper.CreateUserManagerMock());
             signInManager.Setup(x => x.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.Failed);
 
-            var sut = new AccountController(null, signInManager.Object, null, mediator.Object, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null, mediator.Object, null, null);
             await sut.Login(model);
 
             signInManager.Verify(x => x.PasswordSignInAsync(model.Email, model.Password, model.RememberMe, false), Times.Once);
@@ -177,7 +177,7 @@ namespace AllReady.UnitTest.Controllers
             var redirectAccountControllerRequests = new Mock<IRedirectAccountControllerRequests>();
             var urlHelper = new Mock<IUrlHelper>();
 
-            var sut = new AccountController(null, signInManager.Object, null, mediator.Object, null, redirectAccountControllerRequests.Object)
+            var sut = new AccountController(null, signInManager.Object, null, null, mediator.Object, null, redirectAccountControllerRequests.Object)
             {
                 Url = urlHelper.Object
             };
@@ -205,7 +205,7 @@ namespace AllReady.UnitTest.Controllers
                 ["RememberMe"] = model.RememberMe
             };
 
-            var sut = new AccountController(null, signInManager.Object, null, mediator.Object, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null, mediator.Object, null, null);
 
             var result = await sut.Login(model, returnUrl) as RedirectToActionResult;
 
@@ -223,7 +223,7 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = MockHelper.CreateSignInManagerMock(MockHelper.CreateUserManagerMock());
             signInManager.Setup(x => x.PasswordSignInAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<bool>())).ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.LockedOut);
 
-            var sut = new AccountController(null, signInManager.Object, null, mediator.Object, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null, mediator.Object, null, null);
 
             var result = await sut.Login(new LoginViewModel()) as ViewResult;
 
@@ -307,7 +307,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null, null);
             await sut.Register(model);
 
             userManager.Verify(x => x.CreateAsync(It.Is<ApplicationUser>(au =>
@@ -333,7 +333,7 @@ namespace AllReady.UnitTest.Controllers
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
 
@@ -360,7 +360,7 @@ namespace AllReady.UnitTest.Controllers
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             var urlHelper = new Mock<IUrlHelper>();
             sut.Url = urlHelper.Object;
@@ -395,7 +395,7 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, mediator.Object, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, mediator.Object, null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -436,7 +436,7 @@ namespace AllReady.UnitTest.Controllers
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -469,7 +469,7 @@ namespace AllReady.UnitTest.Controllers
 
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
             await sut.Register(model);
@@ -500,7 +500,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
             signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), null)).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = urlHelper.Object;
 
@@ -521,7 +521,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
 
-            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null, null);
 
             await sut.Register(new RegisterViewModel());
 
@@ -540,7 +540,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
             userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null);
+            var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null, null);
             var result = await sut.Register(model) as ViewResult;
             var modelResult = result.ViewData.Model as RegisterViewModel;
 
@@ -578,7 +578,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var signInManager = MockHelper.CreateSignInManagerMock(MockHelper.CreateUserManagerMock());
 
-            var sut = new AccountController(null, signInManager.Object, null, null, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null, null, null, null);
             await sut.LogOff();
 
             signInManager.Verify(x => x.SignOutAsync(), Times.Once);
@@ -590,7 +590,7 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = MockHelper.CreateSignInManagerMock(MockHelper.CreateUserManagerMock());
             signInManager.Setup(x => x.SignOutAsync()).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(null, signInManager.Object, null, null, null, null);
+            var sut = new AccountController(null, signInManager.Object, null, null, null, null, null);
             var result = await sut.LogOff() as RedirectToActionResult;
 
             Assert.Equal(result.ActionName, nameof(HomeController.Index));
@@ -619,7 +619,7 @@ namespace AllReady.UnitTest.Controllers
             const string userId = "userId";
             const string token = "someToken";
             var userManager = MockHelper.CreateUserManagerMock();
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
 
             await sut.ConfirmEmail(userId, token);
 
@@ -635,7 +635,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult((ApplicationUser)null));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal("Error", result.ViewName);
@@ -652,7 +652,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ConfirmEmail(userId, token);
 
             userManager.Verify(x => x.ConfirmEmailAsync(It.Is<ApplicationUser>(y => y == user), It.Is<string>(y => y == token)), Times.Once);
@@ -681,7 +681,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).Returns(() => Task.FromResult(It.IsAny<Unit>()));
 
-            var sut = new AccountController(userManager.Object, null, null, mediator.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, mediator.Object, null, null);
             sut.SetFakeUser(userId);
             await sut.ConfirmEmail(userId, token);
 
@@ -714,7 +714,7 @@ namespace AllReady.UnitTest.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).Returns(() => Task.FromResult(It.IsAny<Unit>()));
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, mediator.Object, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, mediator.Object, null, null);
             sut.SetFakeUserWithCookieAuthenticationType(userId);
             await sut.ConfirmEmail(userId, token);
 
@@ -732,7 +732,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal(result.ViewName, "Error");
@@ -749,7 +749,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
 
             Assert.Equal(result.ViewName, "ConfirmEmail");
@@ -805,7 +805,7 @@ namespace AllReady.UnitTest.Controllers
             var user = new ApplicationUser();
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ForgotPassword(vm);
 
             userManager.Verify(m => m.FindByNameAsync(email), Times.Once);
@@ -822,7 +822,7 @@ namespace AllReady.UnitTest.Controllers
             var user = new ApplicationUser();
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user)).Verifiable();
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ForgotPassword(vm);
 
             userManager.Verify(m => m.IsEmailConfirmedAsync(user), Times.Once);
@@ -839,7 +839,7 @@ namespace AllReady.UnitTest.Controllers
             var user = default(ApplicationUser);
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ForgotPassword(vm) as ViewResult;
 
             Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
@@ -857,7 +857,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(false));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ForgotPassword(vm) as ViewResult;
 
             Assert.Equal(result.ViewName, "ForgotPasswordConfirmation");
@@ -879,7 +879,7 @@ namespace AllReady.UnitTest.Controllers
             var emailSender = new Mock<IEmailSender>();
             emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
-            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, Mock.Of<IMediator>(), null, null);
 
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
@@ -903,7 +903,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, Mock.Of<IMediator>(), null, null);
             var urlHelper = new Mock<IUrlHelper>();
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
             sut.Url = urlHelper.Object;
@@ -932,7 +932,7 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
 
-            var sut = new AccountController(userManager.Object, null, null, mediator.Object, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, mediator.Object, null, null);
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(callbackUrl);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
@@ -955,7 +955,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
             userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
 
-            var sut = new AccountController(userManager.Object, null, null, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
             var result = await sut.ForgotPassword(vm) as ViewResult;
@@ -1065,7 +1065,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.FindByNameAsync(email), Times.Once);
@@ -1087,7 +1087,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ResetPassword(vm);
 
             userManager.Verify(m => m.ResetPasswordAsync(user, It.Is<string>(y => y == vm.Code), It.Is<string>(y => y == vm.Password)), Times.Once);
@@ -1103,7 +1103,7 @@ namespace AllReady.UnitTest.Controllers
             var user = new ApplicationUser();
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
 
             var result = await sut.ResetPassword(vm) as RedirectToActionResult;
 
@@ -1122,7 +1122,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ResetPassword(vm);
 
             var errorMessages = sut.ModelState.GetErrorMessages();
@@ -1139,7 +1139,7 @@ namespace AllReady.UnitTest.Controllers
             userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
             userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
 
-            var sut = new AccountController(userManager.Object, null, null, null, null, null);
+            var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ResetPassword(vm) as ViewResult;
 
             Assert.IsType<ViewResult>(result);
@@ -1379,7 +1379,7 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null, null, null);
             sut.SetFakeUser("userId");
             await sut.ExternalLoginConfirmation(viewmodel);
 
@@ -1394,7 +1394,7 @@ namespace AllReady.UnitTest.Controllers
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null, null, null);
             sut.SetFakeUser("userId");
             var result = await sut.ExternalLoginConfirmation(viewmodel) as ViewResult;
 
@@ -1410,7 +1410,7 @@ namespace AllReady.UnitTest.Controllers
             SetupSignInManagerWithTestExternalLoginValue(signInManager);
             var viewModel = CreateExternalLoginConfirmationViewModel();
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, CreateGeneralSettingsMockObject().Object, null, null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, CreateGeneralSettingsMockObject().Object, null, null, null, null);
             sut.SetFakeUser("userId");
 
             await sut.ExternalLoginConfirmation(viewModel);
@@ -1435,7 +1435,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             await sut.ExternalLoginConfirmation(viewModel, "testUrl");
@@ -1505,7 +1505,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>(), null, Mock.Of<IRedirectAccountControllerRequests>());
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, Mock.Of<IRedirectAccountControllerRequests>());
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
 
@@ -1546,7 +1546,7 @@ namespace AllReady.UnitTest.Controllers
             var generalSettings = new Mock<IOptions<GeneralSettings>>();
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = "DefaultTimeZone" });
 
-            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, Mock.Of<IMediator>(), null, null);
+            var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeUser("userId");
             sut.Url = urlHelperMock.Object;
             var result = await sut.ExternalLoginConfirmation(viewModel, "http://localUrl") as ViewResult;
@@ -1626,7 +1626,7 @@ namespace AllReady.UnitTest.Controllers
             var urlHelperMock = new Mock<IUrlHelper>();
             urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => x.StartsWith("http")))).Returns(false);
             urlHelperMock.Setup(mock => mock.IsLocalUrl(It.Is<string>(x => !x.StartsWith("http")))).Returns(true);
-            var controller = new AccountController(userManagerMock.Object, signInManagerMock.Object, Mock.Of<IOptions<GeneralSettings>>(), Mock.Of<IMediator>(), null, null)
+            var controller = new AccountController(userManagerMock.Object, signInManagerMock.Object, Mock.Of<IOptions<GeneralSettings>>(), null, Mock.Of<IMediator>(), null, null)
             {
                 Url = urlHelperMock.Object
             };
@@ -1634,7 +1634,7 @@ namespace AllReady.UnitTest.Controllers
             return controller;
         }
 
-        private static AccountController CreateAccountControllerWithNoInjectedDependencies() => new AccountController(null, null, null, null, null, null);
+        private static AccountController CreateAccountControllerWithNoInjectedDependencies() => new AccountController(null, null, null, null, null, null, null);
 
         private static Mock<UserManager<ApplicationUser>> CreateUserManagerMockWithSucessIdentityResult()
         {

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -44,7 +44,7 @@ namespace AllReady.Controllers
             _mediator = mediator;
             _externalUserInformationProviderFactory = externalUserInformationProviderFactory;
             _redirectAccountControllerRequests = redirectAccountControllerRequests;
-            _externalCookieScheme = identityCookieOptions.Value.ExternalCookieAuthenticationScheme;
+            _externalCookieScheme = identityCookieOptions?.Value.ExternalCookieAuthenticationScheme;
         }
 
         // GET: /Account/Login
@@ -53,7 +53,8 @@ namespace AllReady.Controllers
         public async Task<IActionResult> Login(string returnUrl = null)
         {
             //Ensure we remove any pre-existing external cookie to ensure clean login (https://github.com/aspnet/Templates/pull/662)
-            await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
+            if (_externalCookieScheme != null)
+                await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
             ViewData["ReturnUrl"] = returnUrl;
             return View();
         }

--- a/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/AccountController.cs
@@ -26,11 +26,13 @@ namespace AllReady.Controllers
         private readonly IMediator _mediator;
         private readonly IExternalUserInformationProviderFactory _externalUserInformationProviderFactory;
         private readonly IRedirectAccountControllerRequests _redirectAccountControllerRequests;
+        private readonly string _externalCookieScheme;
 
         public AccountController(
             UserManager<ApplicationUser> userManager,
             SignInManager<ApplicationUser> signInManager,
             IOptions<GeneralSettings> generalSettings,
+            IOptions<IdentityCookieOptions> identityCookieOptions,
             IMediator mediator,
             IExternalUserInformationProviderFactory externalUserInformationProviderFactory,
             IRedirectAccountControllerRequests redirectAccountControllerRequests
@@ -42,13 +44,16 @@ namespace AllReady.Controllers
             _mediator = mediator;
             _externalUserInformationProviderFactory = externalUserInformationProviderFactory;
             _redirectAccountControllerRequests = redirectAccountControllerRequests;
+            _externalCookieScheme = identityCookieOptions.Value.ExternalCookieAuthenticationScheme;
         }
 
         // GET: /Account/Login
         [HttpGet]
         [AllowAnonymous]
-        public IActionResult Login(string returnUrl = null)
+        public async Task<IActionResult> Login(string returnUrl = null)
         {
+            //Ensure we remove any pre-existing external cookie to ensure clean login (https://github.com/aspnet/Templates/pull/662)
+            await HttpContext.Authentication.SignOutAsync(_externalCookieScheme);
             ViewData["ReturnUrl"] = returnUrl;
             return View();
         }

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
+using System.Threading.Tasks;
 using AllReady.Areas.Admin.ViewModels.Validators;
 using AllReady.Areas.Admin.ViewModels.Validators.Task;
 using AllReady.Controllers;
@@ -39,6 +40,7 @@ using Microsoft.AspNetCore.Localization;
 using AllReady.Services.Twitter;
 using CsvHelper;
 using AllReady.Services.Sms;
+using Microsoft.AspNetCore.Authentication.Twitter;
 
 namespace AllReady
 {
@@ -353,6 +355,17 @@ namespace AllReady
                 {
                     ConsumerKey = Configuration["Authentication:Twitter:ConsumerKey"],
                     ConsumerSecret = Configuration["Authentication:Twitter:ConsumerSecret"]
+                    ,
+                    Events = new TwitterEvents()
+                    {
+
+                        OnRemoteFailure = ctx =>
+                        {
+                            ctx.Response.Redirect("/Account/Login");
+                            ctx.HandleResponse();
+                            return Task.FromResult(0);
+                        }
+                    }
                 };
 
                 app.UseTwitterAuthentication(options);

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -40,6 +40,8 @@ using Microsoft.AspNetCore.Localization;
 using AllReady.Services.Twitter;
 using CsvHelper;
 using AllReady.Services.Sms;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication.Twitter;
 
 namespace AllReady
@@ -330,7 +332,11 @@ namespace AllReady
                     AppId = Configuration["Authentication:Facebook:AppId"],
                     AppSecret = Configuration["Authentication:Facebook:AppSecret"],
                     BackchannelHttpHandler = new FacebookBackChannelHandler(),
-                    UserInformationEndpoint = "https://graph.facebook.com/v2.5/me?fields=id,name,email,first_name,last_name"
+                    UserInformationEndpoint = "https://graph.facebook.com/v2.5/me?fields=id,name,email,first_name,last_name",
+                    Events = new OAuthEvents()
+                    {
+                        OnRemoteFailure = ctx => HandleRemoteLoginFailure(ctx)
+                    }
                 };
                 options.Scope.Add("email");
 
@@ -342,7 +348,11 @@ namespace AllReady
                 var options = new MicrosoftAccountOptions
                 {
                     ClientId = Configuration["Authentication:MicrosoftAccount:ClientId"],
-                    ClientSecret = Configuration["Authentication:MicrosoftAccount:ClientSecret"]
+                    ClientSecret = Configuration["Authentication:MicrosoftAccount:ClientSecret"],
+                    Events = new OAuthEvents()
+                    {
+                        OnRemoteFailure = ctx => HandleRemoteLoginFailure(ctx)
+                    }
                 };
 
                 app.UseMicrosoftAccountAuthentication(options);
@@ -359,12 +369,7 @@ namespace AllReady
                     Events = new TwitterEvents()
                     {
 
-                        OnRemoteFailure = ctx =>
-                        {
-                            ctx.Response.Redirect("/Account/Login");
-                            ctx.HandleResponse();
-                            return Task.FromResult(0);
-                        }
+                        OnRemoteFailure = ctx => HandleRemoteLoginFailure(ctx)
                     }
                 };
 
@@ -376,7 +381,11 @@ namespace AllReady
                 var options = new GoogleOptions
                 {
                     ClientId = Configuration["Authentication:Google:ClientId"],
-                    ClientSecret = Configuration["Authentication:Google:ClientSecret"]
+                    ClientSecret = Configuration["Authentication:Google:ClientSecret"],
+                    Events = new OAuthEvents()
+                    {
+                        OnRemoteFailure = ctx => HandleRemoteLoginFailure(ctx)
+                    }
                 };
 
                 app.UseGoogleAuthentication(options);
@@ -410,6 +419,14 @@ namespace AllReady
             {
                 await sampleData.CreateAdminUser();
             }   
+        }
+
+        //Handles remote login failure typically where user doesn't give consent
+        private Task HandleRemoteLoginFailure(FailureContext ctx)
+        {
+            ctx.Response.Redirect("/Account/Login");
+            ctx.HandleResponse();
+            return Task.FromResult(0);
         }
     }
 }


### PR DESCRIPTION
Fixes #1707 - Navigating away from additional information page after using social login no longer leaves the login process in invalid state requiring cookie clean up. Solution is identical to that made to the default account controller template in github (https://github.com/aspnet/Identity/issues/915#issuecomment-238939350)

Additional fixes added to handle remote failure of social logins where user is not authenticated (e.g. cancelled consent), user is now redirected back to login screen instead of crashing.
