### PR TITLE
#1597 - Add method of linking requests to events in the unlinked requ…

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/UnlinkedRequestControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/UnlinkedRequestControllerTests.cs
@@ -1,20 +1,33 @@
-﻿using AllReady.Areas.Admin.Controllers;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AllReady.Areas.Admin.Controllers;
+using AllReady.Areas.Admin.Features.Events;
 using AllReady.Areas.Admin.Features.UnlinkedRequests;
+using AllReady.Areas.Admin.ViewModels.UnlinkedRequests;
+using AllReady.Areas.Admin.ViewModels.Validators;
 using AllReady.UnitTest.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Moq;
 using Xunit;
+using AllReady.Areas.Admin.ViewModels.Itinerary;
+using AllReady.Areas.Admin.ViewModels.Shared;
 
 namespace AllReady.UnitTest.Areas.Admin.Controllers
 {
     public class UnlinkedRequestControllerTests
     {
+        private const int OrganizationId = 1001;
+        private const int EventId = 123;
+
         [Fact]
         public async void ListReturnsRequestUnathorized_WhenUserIsNotAnOrgAdmin()
         {
             var mediator = new Mock<IMediator>();
-            var sut = new UnlinkedRequestController(mediator.Object);
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
             sut.MakeUserNotAnOrgAdmin();
 
             await sut.List();
@@ -24,15 +37,229 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async void ListCallsRequestListItemsQueryWithUsersOrgId_WhenUserIsOrgAdmin()
         {
-            const string orgId = "1001";
-
             var mediator = new Mock<IMediator>();
-            var sut = new UnlinkedRequestController(mediator.Object);
-            sut.MakeUserAnOrgAdmin(orgId);
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
 
             await sut.List();
 
             mediator.Verify(x => x.SendAsync(It.Is<UnlinkedRequestListQuery>(y => y.OrganizationId == 1001)), Times.Once);
+        }
+
+        [Fact]
+        public async void AddRequestsReturnsUnauthorised_WhenUserIsNotAnOrgAdmin()
+        {
+            var mediator = new Mock<IMediator>();
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            var model = new Mock<UnlinkedRequestViewModel>();
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserNotAnOrgAdmin();
+
+            Assert.IsType<UnauthorizedResult>(await sut.AddRequests(model.Object));
+        }
+
+        [Fact]
+        public async void AddReqeustsCallsQueryHandlerWithExpectedOrgId_WhenModelHasValidationErrors()
+        {
+            var errorList = new List<KeyValuePair<string, string>>() {new KeyValuePair<string, string>("test", "error")};
+            var model = new UnlinkedRequestViewModel()
+            {
+                EventId = EventId,
+            };
+            var mediator = BuildValidMockMediator(model);
+
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            validator.Setup(mock => mock.Validate(It.IsAny<UnlinkedRequestViewModel>()))
+                .Returns(errorList);
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
+            await sut.AddRequests(model);
+
+            mediator.Verify(x => x.SendAsync(It.Is<UnlinkedRequestListQuery>(y => y.OrganizationId == 1001)), Times.Once);
+        }
+
+        [Fact]
+        public async void AddReqeustsReturnsExpectedResultType_WhenModelHasValidationErrors()
+        {
+            var errorList = new List<KeyValuePair<string, string>>() {new KeyValuePair<string, string>("test", "error")};
+            var model = BuildValidModel();
+            var mediator = BuildValidMockMediator(model);
+
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            validator.Setup(mock => mock.Validate(It.IsAny<UnlinkedRequestViewModel>()))
+                .Returns(errorList);
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
+           
+            var result = await sut.AddRequests(model);
+            Assert.IsType<ViewResult>(result);
+            Assert.IsType<UnlinkedRequestViewModel>(((ViewResult) result).ViewData.Model);
+            Assert.Equal(((ViewResult) result).ViewName, nameof(sut.List));
+        }
+
+        [Fact]
+        public async void AddReqeustsReturnsExpectedViewName_WhenModelHasValidationErrors()
+        {
+            const string orgId = "1001";
+            var errorList = new List<KeyValuePair<string, string>>() {new KeyValuePair<string, string>("test", "error")};
+            var model = BuildValidModel();
+            var mediator = BuildValidMockMediator(model);
+            
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            validator.Setup(mock => mock.Validate(It.IsAny<UnlinkedRequestViewModel>()))
+                .Returns(errorList);
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(orgId);
+
+            var result = await sut.AddRequests(model);
+            Assert.Equal(((ViewResult) result).ViewName, nameof(sut.List));
+        }
+
+        [Fact]
+        public async void AddReqeustsReturnModelContainsExpectedErrors_WhenModelHasValidationErrors()
+        {
+            var errorList = new List<KeyValuePair<string, string>>()
+            {
+                new KeyValuePair<string, string>("key1", "error1"),
+                new KeyValuePair<string, string>("key2", "error2")
+            };
+            var model = BuildValidModel();
+            var mediator = BuildValidMockMediator(model);
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            validator.Setup(mock => mock.Validate(It.IsAny<UnlinkedRequestViewModel>()))
+                .Returns(errorList);
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
+
+            await sut.AddRequests(model);
+
+            Assert.Equal(sut.ModelState.Count, errorList.Count);
+            Assert.Equal(sut.ModelState.Keys, errorList.Select(error => error.Key));
+            Assert.Equal(
+                sut.ModelState.Select(
+                    error => error.Value.Errors.Select(message => message.ErrorMessage).FirstOrDefault()),
+                errorList.Select(error => error.Value));
+        }
+
+        [Fact]
+        public async void AddReqeustsReturnModelContainsExpectedData_WhenModelHasValidationErrors()
+        {
+            var model = new UnlinkedRequestViewModel { EventId = EventId };
+            var mediator = BuildValidMockMediator(model);
+            var expectedEvents = new List<SelectListItem>()
+            {
+                new SelectListItem {Text = "testItem", Value = "testValue", Selected = true}
+            };
+            var expectedRequests = new List<RequestSelectViewModel>()
+            {
+                new RequestSelectViewModel {Name = "testRequest", Id = Guid.NewGuid()}
+            };
+            mediator.Setup(x => x.SendAsync(It.Is<UnlinkedRequestListQuery>(y => y.OrganizationId == 1001)))
+                .ReturnsAsync(new UnlinkedRequestViewModel()
+                {
+                    Events = expectedEvents,
+                    Requests = expectedRequests
+                });
+
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            validator.Setup(mock => mock.Validate(It.IsAny<UnlinkedRequestViewModel>()))
+                .Returns(new List<KeyValuePair<string, string>>() {new KeyValuePair<string, string>("test", "error")});
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
+          
+
+            var result = (ViewResult) await sut.AddRequests(model);
+            var returnedModel = (UnlinkedRequestViewModel) result.Model;
+            Assert.Equal(returnedModel.Requests, expectedRequests);
+            Assert.Equal(returnedModel.Events, expectedEvents);
+            Assert.Equal(returnedModel.EventId, EventId);
+        }
+
+        [Fact]
+        public async void AddReqeustsCallsCommandHandler_WhenModelStateIsValid()
+        {
+            var model = BuildValidModel();
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.Is<EventSummaryQuery>(y => y.EventId == EventId)))
+                .ReturnsAsync(new EventSummaryViewModel()
+                {
+                    OrganizationId = 1001
+                });
+
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            validator.Setup(mock => mock.Validate(It.IsAny<UnlinkedRequestViewModel>()))
+                .Returns(new List<KeyValuePair<string, string>>());
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
+            await sut.AddRequests(model);
+
+            mediator.Verify(x => x.SendAsync(It.Is<AddRequestsToEventCommand>(y => y.EventId == EventId)), Times.Once);
+        }
+
+        [Fact]
+        public async void AddReqeustsReturnsRedirectResult_WhenModelStateIsValid()
+        {
+            var model = BuildValidModel();
+            var mediator = BuildValidMockMediator(model);
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            validator.Setup(mock => mock.Validate(It.IsAny<UnlinkedRequestViewModel>()))
+                .Returns(new List<KeyValuePair<string, string>>());
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
+
+            var result = await sut.AddRequests(model);
+            Assert.IsType<RedirectToActionResult>(result);
+            Assert.Equal(((RedirectToActionResult)result).ActionName, nameof(sut.List));
+        }
+
+        [Fact]
+        public async void AddReqeustsReturnsBadRequest_WhenEventDoesNotBelongToCurrentOrgId()
+        {
+            var model = BuildValidModel();
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.Is<UnlinkedRequestListQuery>(y => y.OrganizationId == OrganizationId)))
+                .ReturnsAsync(model);
+            mediator.Setup(x => x.SendAsync(It.Is<EventSummaryQuery>(y => y.EventId == EventId)))
+                .ReturnsAsync(new EventSummaryViewModel()
+                {
+                    OrganizationId = 6783
+                });
+            var validator = new Mock<IUnlinkedRequestViewModelValidator>();
+            validator.Setup(mock => mock.Validate(It.IsAny<UnlinkedRequestViewModel>()))
+                .Returns(new List<KeyValuePair<string, string>>());
+            var sut = new UnlinkedRequestController(mediator.Object, validator.Object);
+            sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
+
+            var result = await sut.AddRequests(model);
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+        
+
+        private UnlinkedRequestViewModel BuildValidModel()
+        {
+            return new UnlinkedRequestViewModel()
+            {
+                EventId = EventId,
+                Requests = new List<RequestSelectViewModel>
+                {
+                    new RequestSelectViewModel {Name = "testRequest", Id = Guid.NewGuid(), IsSelected = true},
+                    new RequestSelectViewModel {Name = "testRequest2", Id = Guid.NewGuid(), IsSelected = false},
+                }
+            };
+        }
+
+        private Mock<IMediator> BuildValidMockMediator(UnlinkedRequestViewModel model)
+        {
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.Is<UnlinkedRequestListQuery>(y => y.OrganizationId == OrganizationId)))
+                .ReturnsAsync(model);
+            mediator.Setup(x => x.SendAsync(It.Is<EventSummaryQuery>(y => y.EventId == EventId)))
+                .ReturnsAsync(new EventSummaryViewModel()
+                {
+                    OrganizationId = OrganizationId
+                });
+            return mediator;
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/UnlinkedRequestControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/UnlinkedRequestControllerTests.cs
@@ -214,7 +214,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async void AddReqeustsReturnsBadRequest_WhenEventDoesNotBelongToCurrentOrgId()
+        public async void AddReqeustsReturnsUnauthorizedResult_WhenEventDoesNotBelongToCurrentOrgId()
         {
             var model = BuildValidModel();
             var mediator = new Mock<IMediator>();
@@ -232,7 +232,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             sut.MakeUserAnOrgAdmin(OrganizationId.ToString());
 
             var result = await sut.AddRequests(model);
-            Assert.IsType<BadRequestObjectResult>(result);
+            Assert.IsType<UnauthorizedResult>(result);
         }
         
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/UnlinkedRequests/AddRequestsToEventCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/UnlinkedRequests/AddRequestsToEventCommandHandlerShould.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.UnlinkedRequests;
+using AllReady.Models;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.UnlinkedRequests
+{
+    public class AddRequestsToEventCommandHandlerShould : InMemoryContextTest
+    {
+        [Fact]
+        public async Task ReturnsFalseIfNoEventsReturnedFromContext()
+        {
+            var sut = new AddRequestsToEventCommandHandler(Context);
+
+            var events = new[]
+            {
+                new Event() {Id = 123}
+            };
+
+            var context = Context;
+            context.Events.AddRange(events);
+            context.SaveChanges();
+
+            var succeded = await sut.Handle(new AddRequestsToEventCommand() {EventId = 124});
+
+            Assert.False(succeded);
+        }
+
+        [Fact]
+        public async Task ReturnsFalseIfNoRequestsToUpdateAreFound()
+        {
+            var expectedEventId = 123;
+            var sut = new AddRequestsToEventCommandHandler(Context);
+
+            var events = new[]
+            {
+                new Event() {Id = expectedEventId}
+            };
+            var requests = new[]
+            {
+                new Request() {RequestId = Guid.NewGuid()}
+            };
+
+            var context = Context;
+            context.Requests.AddRange(requests);
+            context.Events.AddRange(events);
+            context.SaveChanges();
+
+            var succeded = await sut.Handle(new AddRequestsToEventCommand()
+            {
+                EventId = expectedEventId,
+                SelectedRequestIds = new List<Guid>() {Guid.NewGuid()}
+            });
+
+            Assert.False(succeded);
+        }
+
+        [Fact]
+        public async Task UpdatesExpectedRequestsWithSelectedEventId_WhenRequestsFound()
+        {
+            const int expectedEventId = 123;
+            var sut = new AddRequestsToEventCommandHandler(Context);
+            var requestId1 = Guid.NewGuid();
+            var requestId2 = Guid.NewGuid();
+            var requestId3 = Guid.NewGuid();
+
+            var events = new[]
+            {
+                new Event() {Id = expectedEventId}
+            };
+            var requests = new[]
+            {
+                new Request() {RequestId = requestId1},
+                new Request() {RequestId = requestId2},
+                new Request() {RequestId = requestId3}
+            };
+
+            var context = Context;
+            context.Requests.AddRange(requests);
+            context.Events.AddRange(events);
+            context.SaveChanges();
+
+            var succeded = await sut.Handle(new AddRequestsToEventCommand()
+            {
+                EventId = expectedEventId,
+                SelectedRequestIds = new List<Guid>() {requestId1, requestId2, requestId3}
+            });
+
+            Assert.True(succeded);
+            Assert.Equal(Context.Requests.Count(), 3);
+            Assert.Equal(Context.Requests.Select(x => x.EventId).ToList(),
+                new List<int?>() {expectedEventId, expectedEventId, expectedEventId});
+            Assert.Equal(Context.Requests.Select(x => x.RequestId).ToList(),
+                new List<Guid>() {requestId1, requestId2, requestId3});
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/UnlinkedRequestController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/UnlinkedRequestController.cs
@@ -1,5 +1,9 @@
-﻿using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Areas.Admin.Features.Events;
 using AllReady.Areas.Admin.Features.UnlinkedRequests;
+using AllReady.Areas.Admin.ViewModels.UnlinkedRequests;
+using AllReady.Areas.Admin.ViewModels.Validators;
 using AllReady.Security;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
@@ -12,10 +16,12 @@ namespace AllReady.Areas.Admin.Controllers
     public class UnlinkedRequestController : Controller
     {
         private readonly IMediator _mediator;
+        private readonly IUnlinkedRequestViewModelValidator _modelValidator;
 
-        public UnlinkedRequestController(IMediator mediator)
+        public UnlinkedRequestController(IMediator mediator, IUnlinkedRequestViewModelValidator modelValidator)
         {
             _mediator = mediator;
+            _modelValidator = modelValidator;
         }
 
         // GET: Admin/UnlinkedRequest/List
@@ -23,16 +29,62 @@ namespace AllReady.Areas.Admin.Controllers
         [ActionName("List")]
         public async Task<IActionResult> List()
         {
-            var orgId = User.GetOrganizationId();
             if (!User.IsOrganizationAdmin())
             {
                 return Unauthorized();
             }
 
+            var orgId = User.GetOrganizationId();
+
             return View(await _mediator.SendAsync(new UnlinkedRequestListQuery()
             {
                 OrganizationId = orgId.GetValueOrDefault()
             }));
+        }
+
+        [HttpPost]
+        [ActionName("AddRequests")]
+        public async Task<IActionResult> AddRequests(UnlinkedRequestViewModel model)
+        {
+            var organizationId = User.GetOrganizationId();
+            if (!organizationId.HasValue || !User.IsOrganizationAdmin(organizationId.Value))
+            {
+                return Unauthorized();
+            }
+            
+            var errors = _modelValidator.Validate(model);
+            errors.ToList().ForEach(e => ModelState.AddModelError(e.Key, e.Value));
+
+            if (ModelState.IsValid)
+            {
+                var eventSummary = await _mediator.SendAsync(new EventSummaryQuery()
+                {
+                    EventId = model.EventId
+                });
+
+                if (eventSummary == null || eventSummary.OrganizationId != organizationId.Value)
+                {
+                    return BadRequest("Selected event doesn't belong to the current users organization Id");
+                }
+
+                await _mediator.SendAsync(new AddRequestsToEventCommand
+                {
+                    EventId = model.EventId,
+                    SelectedRequestIds = model.Requests.Where(req => req.IsSelected).Select(req => req.Id).ToList()
+                });
+                return RedirectToAction(nameof(List));
+            }
+
+            var orgId = User.GetOrganizationId();
+            var queryResponse = await _mediator.SendAsync(new UnlinkedRequestListQuery()
+            {
+                OrganizationId = orgId.GetValueOrDefault()
+            });
+
+            model.Requests = queryResponse.Requests;        
+            model.Events = queryResponse.Events;
+
+            return View(nameof(List), model);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/UnlinkedRequestController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/UnlinkedRequestController.cs
@@ -64,7 +64,7 @@ namespace AllReady.Areas.Admin.Controllers
 
                 if (eventSummary == null || eventSummary.OrganizationId != organizationId.Value)
                 {
-                    return BadRequest("Selected event doesn't belong to the current users organization Id");
+                    return Unauthorized();
                 }
 
                 await _mediator.SendAsync(new AddRequestsToEventCommand

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/UnlinkedRequests/AddRequestsToEventCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/UnlinkedRequests/AddRequestsToEventCommand.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.UnlinkedRequests
+{
+    public class AddRequestsToEventCommand : IAsyncRequest<bool>
+    {
+        public int EventId { get; set; }
+        public List<Guid> SelectedRequestIds { get; set; }
+    }
+}   

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/UnlinkedRequests/AddRequestsToEventCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/UnlinkedRequests/AddRequestsToEventCommandHandler.cs
@@ -1,0 +1,43 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+
+namespace AllReady.Areas.Admin.Features.UnlinkedRequests
+{
+    public class AddRequestsToEventCommandHandler : IAsyncRequestHandler<AddRequestsToEventCommand, bool>
+    {
+        private readonly AllReadyContext _context;
+
+        public AddRequestsToEventCommandHandler(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<bool> Handle(AddRequestsToEventCommand message)
+        {
+            var selectedEvent = await _context.Events
+                .Where(x => x.Id == message.EventId)
+                .Select(x => new {x.Id, x.Name})
+                .SingleOrDefaultAsync();
+
+            // todo: enhance this with a error message so the controller can better respond to the issue
+            if (selectedEvent == null) return false;
+
+            var requestsToUpdate = await _context.Requests.AsAsyncEnumerable()
+                .Where(r => message.SelectedRequestIds.Contains(r.RequestId))
+                .ToList();
+
+            // todo: we should enhance the returned object to include a message so that the controller can provide better feedback to the user
+            if (!requestsToUpdate.Any()) return false;
+
+            requestsToUpdate.ForEach(request => request.EventId = selectedEvent.Id);
+
+            await _context.SaveChangesAsync();
+
+            return true;
+        }
+    }
+}       

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/UnlinkedRequests/UnlinkedRequestListQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/UnlinkedRequests/UnlinkedRequestListQuery.cs
@@ -1,10 +1,9 @@
-﻿using System.Collections.Generic;
-using AllReady.Areas.Admin.ViewModels.UnlinkedRequests;
+﻿using AllReady.Areas.Admin.ViewModels.UnlinkedRequests;
 using MediatR;
 
 namespace AllReady.Areas.Admin.Features.UnlinkedRequests
 {
-    public class UnlinkedRequestListQuery : IAsyncRequest<List<UnlinkedRequestViewModel>>
+    public class UnlinkedRequestListQuery : IAsyncRequest<UnlinkedRequestViewModel>
     {
         public int OrganizationId { get; set; }
     }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/UnlinkedRequests/UnlinkedRequestListQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/UnlinkedRequests/UnlinkedRequestListQueryHandler.cs
@@ -1,35 +1,55 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
+using AllReady.Areas.Admin.ViewModels.Itinerary;
 using AllReady.Areas.Admin.ViewModels.UnlinkedRequests;
 using AllReady.Models;
 using MediatR;
+using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.EntityFrameworkCore;
 
 namespace AllReady.Areas.Admin.Features.UnlinkedRequests
 {
-    public class UnlinkedRequestListQueryHandler : IAsyncRequestHandler<UnlinkedRequestListQuery, List<UnlinkedRequestViewModel>>
+    public class UnlinkedRequestListQueryHandler :
+        IAsyncRequestHandler<UnlinkedRequestListQuery, UnlinkedRequestViewModel>
     {
         private readonly AllReadyContext _context;
+
         public UnlinkedRequestListQueryHandler(AllReadyContext context)
         {
             _context = context;
         }
-        public async Task<List<UnlinkedRequestViewModel>> Handle(UnlinkedRequestListQuery message)
+
+        public async Task<UnlinkedRequestViewModel> Handle(UnlinkedRequestListQuery message)
         {
-            return await 
-                _context.Requests
+            var requests = await _context.Requests
                 .AsNoTracking()
                 .Where(r => r.OrganizationId == message.OrganizationId && !r.EventId.HasValue)
-                .Select(r => new UnlinkedRequestViewModel
+                .Select(r => new RequestSelectViewModel()
                 {
+                    Id = r.RequestId,
                     Name = r.Name,
                     Address = r.Address,
                     City = r.City,
                     DateAdded = r.DateAdded,
-                    Zip = r.Zip
+                    Postcode = r.Zip
                 })
                 .ToListAsync();
+
+            var events = await _context.Events
+                .AsNoTracking()    
+                .Where(e => e.Campaign.ManagingOrganizationId == message.OrganizationId)
+                .Select(e => new SelectListItem
+                    {
+                        Value = e.Id.ToString(),
+                        Text = $"{e.Campaign.ManagingOrganization.Name} > {e.Campaign.Name} > {e.Name}"
+                    }
+                ).ToListAsync();
+
+            return new UnlinkedRequestViewModel()
+            {
+                Requests = requests,
+                Events = events
+            };
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/UnlinkedRequests/UnlinkedRequestViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/UnlinkedRequests/UnlinkedRequestViewModel.cs
@@ -1,13 +1,13 @@
-﻿using System;
+﻿using System.Collections.Generic;
+using AllReady.Areas.Admin.ViewModels.Itinerary;
+using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace AllReady.Areas.Admin.ViewModels.UnlinkedRequests
 {
     public class UnlinkedRequestViewModel
-    {
-        public string Name { get; set; }
-        public string Address { get; set; }
-        public string City { get; set; }
-        public string Zip { get; set; }
-        public DateTime DateAdded { get; set; }
+    {   
+        public List<RequestSelectViewModel> Requests { get; set; } = new List<RequestSelectViewModel>();
+        public List<SelectListItem> Events { get; set; } = new List<SelectListItem>();
+        public int EventId { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Validators/UnlinkedRequestViewModelValidator.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Validators/UnlinkedRequestViewModelValidator.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using AllReady.Areas.Admin.ViewModels.UnlinkedRequests;
+
+namespace AllReady.Areas.Admin.ViewModels.Validators
+{
+    public interface IUnlinkedRequestViewModelValidator
+    {
+        List<KeyValuePair<string, string>> Validate(UnlinkedRequestViewModel model);
+    }
+
+    public class UnlinkedRequestViewModelValidator : IUnlinkedRequestViewModelValidator
+    {
+        public List<KeyValuePair<string, string>> Validate(UnlinkedRequestViewModel model)
+        {
+            var result = new List<KeyValuePair<string, string>>();
+
+            if (model.EventId < 1)
+            {
+                result.Add(new KeyValuePair<string, string>(nameof(model.EventId), "You must select an event"));
+            }
+            if (!model.Requests.Any(req => req.IsSelected))
+            {
+                result.Add(new KeyValuePair<string, string>(nameof(model.Requests), "You must select at least one request"));
+            }
+            return result;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/UnlinkedRequest/List.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/UnlinkedRequest/List.cshtml
@@ -1,4 +1,5 @@
-@model IEnumerable<AllReady.Areas.Admin.ViewModels.UnlinkedRequests.UnlinkedRequestViewModel>
+@using AllReady.Services
+@model AllReady.Areas.Admin.ViewModels.UnlinkedRequests.UnlinkedRequestViewModel
 
 @{ ViewBag.Title = "Unlinked Requests"; }
 <div class="row">
@@ -8,35 +9,58 @@
         </h2>
     </div>
 </div>
-
-<div class="row">
-    <div class="col-md-12">
-        @if (Model.Any())
-            {
-            <table class="table">
-                <tr>
-                    <th>Request Name</th>
-                    <th>Address</th>
-                    <th>City</th>
-                    <th>Postcode</th>
-                    <th>Date Added</th>
-                </tr>
-                @foreach (var req in Model)
-                {
-                    <tr>
-                        <td>@req.Name</td>
-                        <td>@req.Address</td>
-                        <td>@req.City</td>
-                        <td>@req.Zip</td>
-                        <td>@req.DateAdded</td>
-                    </tr>
-                }
-            </table>
-        }
-        else
-        {
-            <br />
-                <p>There are no requests to display</p>
-        }
+<form asp-area="Admin" asp-controller="UnlinkedRequest" asp-action="AddRequests">
+    <div class="form-group">
+        Select an Event:
+        <div class="row">
+            <div class="col-md-2">
+                <select asp-for="EventId" asp-items="@Model.Events" class="form-control">
+                    <option value="0">-- Select --</option>
+                </select>
+                <span asp-validation-for="EventId" class="text-danger"></span>
+            </div>
+            <div class="col-md-4">
+                <button type="submit" class="btn btn-primary submit-form">Add Selected Requests</button>
+                <a asp-action="List" asp-controller="UnlinkedRequest" asp-area="Admin" class="btn btn-default">Cancel</a>
+            </div>
+        </div>
     </div>
-</div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <span asp-validation-for="Requests" class="text-danger"></span>
+            @if (Model.Requests.Any())
+            {
+                <table class="table">
+                    <tr>
+                        <th></th>
+                        <th>Request Name</th>
+                        <th>Address</th>
+                        <th>City</th>
+                        <th>Postcode</th>
+                        <th>Date Added</th>
+                    </tr>
+                    @for (var i = 0; i < Model.Requests.Count(); i++)
+                    {
+                        <tr>
+                            <td>
+                                @Html.HiddenFor(model => model.Requests[i].Id)
+                                @Html.CheckBoxFor(model => model.Requests[i].IsSelected)
+                            </td>
+                            <td>@Model.Requests[i].Name</td>
+                            <td>@Model.Requests[i].Address</td>
+                            <td>@Model.Requests[i].City</td>
+                            <td>@Model.Requests[i].Postcode</td>
+                            <td>@Model.Requests[i].DateAdded</td>
+                        </tr>
+                    }
+                </table>
+            }
+            else
+            {
+                <br/>
+                <p>There are no requests to display</p>
+            }
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
Closes #1597 

In the 'Unlinked Requests' screen that available to Org admins, I've added the ability to link the requests to an event.

I've added a new combo box containing all events and a checkbox column into the request list as shown below:
![image](https://cloud.githubusercontent.com/assets/24384148/22029290/fba84df4-dcd1-11e6-90e3-9877469d387a.png)

The add button should have the appropriate form validation on submit - i.e. if the user hasn't selected an event and/or at least one request they should get a message telling them this. 

This screen could probably use a bit of FED love in future to make the validation a bit slicker!  
