### PR TITLE
Remove any "Returns(Task.FromResult(() => ))" calls in unit tests used in conjunction with "mediator.SendAsync()" and instead use ".ReturnsAsync()"

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/CampaignAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/CampaignAdminControllerTests.cs
@@ -191,8 +191,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             const int newCampaignId = 100;
 
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(x => x.SendAsync(It.IsAny<EditCampaignCommand>()))
-                .Returns((EditCampaignCommand q) => Task.FromResult<int>(newCampaignId));
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<EditCampaignCommand>())).ReturnsAsync(newCampaignId);
 
             var mockImageService = new Mock<IImageService>();
             var sut = new CampaignController(mockMediator.Object, mockImageService.Object);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerTest.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SiteAdminControllerTest.cs
@@ -273,7 +273,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == model.UserId))).ReturnsAsync(user);
-            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Success);
 
             var controller = new SiteController(userManager.Object, null, mediator.Object);
             controller.SetDefaultHttpContext();
@@ -301,10 +301,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
                 Email = "test@testy.com"
             };
 
-            mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == model.UserId)))
-                .ReturnsAsync(user);
-            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>()))
-                .Returns(() => Task.FromResult(IdentityResult.Success));
+            mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == model.UserId))).ReturnsAsync(user);
+            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Success);
 
             var controller = new SiteController(userManager.Object, null, mediator.Object);
             controller.SetFakeHttpRequestSchemeTo(requestScheme);
@@ -336,10 +334,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
                 Email = "test@testy.com"
             };
 
-            mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == model.UserId)))
-                .ReturnsAsync(user);
-            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>()))
-                .Returns(() => Task.FromResult(IdentityResult.Success));
+            mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == model.UserId))).ReturnsAsync(user);
+            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Success);
 
             var controller = new SiteController(userManager.Object, null, mediator.Object);
             controller.SetDefaultHttpContext();
@@ -370,8 +366,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
                 .ReturnsAsync(user);
 
             var userManager = CreateApplicationUserMock();
-            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>()))
-                .Returns(() => Task.FromResult( IdentityResult.Failed(null)));
+            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Failed(null));
 
             var controller = new SiteController(userManager.Object, null, mediator.Object);
             var result = await controller.EditUser(model);
@@ -392,7 +387,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == model.UserId))).ReturnsAsync(user);
 
             var userManager = CreateApplicationUserMock();
-            userManager.Setup(x => x.RemoveClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.RemoveClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Success);
 
             var controller = new SiteController(userManager.Object, null, mediator.Object);
             await controller.EditUser(model);
@@ -412,7 +407,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == model.UserId))).ReturnsAsync(user);
 
             var userManager = CreateApplicationUserMock();
-            userManager.Setup(x => x.RemoveClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Failed(null)));
+            userManager.Setup(x => x.RemoveClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Failed(null));
 
             var controller = new SiteController(userManager.Object, null, mediator.Object);
             var result = await controller.EditUser(model);
@@ -740,10 +735,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
                 Id = "1234"
             };
 
-            mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == user.Id)))
-                .ReturnsAsync(user);
-            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>()))
-                .Returns(() => Task.FromResult(IdentityResult.Success));
+            mediator.Setup(x => x.SendAsync(It.Is<UserByUserIdQuery>(q => q.UserId == user.Id))).ReturnsAsync(user);
+            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Success);
 
             var controller = new SiteController(userManager.Object, null, mediator.Object);
             var result = (RedirectToActionResult) await controller.AssignSiteAdmin(user.Id);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SkillControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/SkillControllerTests.cs
@@ -740,12 +740,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         private static Mock<IMediator> MockMediatorSkillListQuery(out SkillController controller)
         {
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillListQuery>()))
-                .Returns(() => Task.FromResult(SummaryListItems()))
-                .Verifiable();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationNameQuery>()))
-                .Returns(() => Task.FromResult(OrgName))
-                .Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillListQuery>())).ReturnsAsync(SummaryListItems()).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationNameQuery>())).ReturnsAsync(OrgName).Verifiable();
             controller = new SkillController(mockMediator.Object);
             return mockMediator;
         }
@@ -753,11 +749,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         private static Mock<IMediator> MockMediatorSkillCreateQuery(out SkillController controller)
         {
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillListQuery>())).Returns(() => Task.FromResult(SummaryListItems()))
-                .Verifiable();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationSelectListQuery>()))
-                .Returns(() => Task.FromResult<IEnumerable<SelectListItem>>(new List<SelectListItem> { new SelectListItem { Text = "Item 1", Value = "1" } }))
-            .Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillListQuery>())).ReturnsAsync(SummaryListItems()).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationSelectListQuery>())).ReturnsAsync(new List<SelectListItem> { new SelectListItem { Text = "Item 1", Value = "1" }}).Verifiable();
             controller = new SkillController(mockMediator.Object);
             return mockMediator;
         }
@@ -767,11 +760,11 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             if (model == null) model = new SkillEditViewModel { Id = 1, Name = "Name", Description = "Description" };
 
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillEditQuery>())).Returns(() => Task.FromResult(model)).Verifiable();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillListQuery>())).Returns(() => Task.FromResult(SummaryListItems()))
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillEditQuery>())).ReturnsAsync(model).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillListQuery>())).ReturnsAsync(SummaryListItems())
                 .Verifiable();
             mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationSelectListQuery>()))
-                .Returns(() => Task.FromResult<IEnumerable<SelectListItem>>(new List<SelectListItem> { new SelectListItem { Text = "Item 1", Value = "1" } }))
+                .ReturnsAsync(new List<SelectListItem> { new SelectListItem { Text = "Item 1", Value = "1" }})
                 .Verifiable();
             controller = new SkillController(mockMediator.Object);
             return mockMediator;
@@ -780,7 +773,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         private static Mock<IMediator> MockMediatorSkillEditQueryNullModel(out SkillController controller)
         {
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillEditQuery>())).Returns(() => Task.FromResult<SkillEditViewModel>(null)).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillEditQuery>())).ReturnsAsync(null).Verifiable();
             controller = new SkillController(mockMediator.Object);
             return mockMediator;
         }
@@ -790,7 +783,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             if (model == null) model = new SkillDeleteViewModel {  HierarchicalName = "Name" };
 
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillDeleteQuery>())).Returns(() => Task.FromResult(model)).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillDeleteQuery>())).ReturnsAsync(model).Verifiable();
             controller = new SkillController(mockMediator.Object);
             return mockMediator;
         }
@@ -798,7 +791,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         private static Mock<IMediator> MockMediatorSkillDeleteQueryNullModel(out SkillController controller)
         {
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillDeleteQuery>())).Returns(() => Task.FromResult<SkillDeleteViewModel>(null)).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<SkillDeleteQuery>())).ReturnsAsync(null).Verifiable();
             controller = new SkillController(mockMediator.Object);
             return mockMediator;
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AccountControllerTests.cs
@@ -2,7 +2,6 @@
 using System.Threading.Tasks;
 using AllReady.Controllers;
 using AllReady.Models;
-using AllReady.Services;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -305,7 +304,7 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Failed());
 
             var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null, null);
             await sut.Register(model);
@@ -328,8 +327,8 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(It.IsAny<string>());
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
@@ -354,9 +353,9 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings());
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).Returns(() => Task.FromResult(It.IsAny<string>()));
-            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(It.IsAny<string>());
+            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(It.IsAny<string>());
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
@@ -384,9 +383,9 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings());
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).Returns(() => Task.FromResult(It.IsAny<string>()));
-            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(It.IsAny<string>());
+            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(It.IsAny<string>());
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
@@ -427,9 +426,9 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).Returns(() => Task.FromResult(It.IsAny<string>()));
-            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(It.IsAny<string>());
+            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(It.IsAny<string>());
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
@@ -458,16 +457,16 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).Returns(() => Task.FromResult(It.IsAny<string>()));
-            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(It.IsAny<string>());
+            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(It.IsAny<string>());
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
-            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Success);
 
             var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
@@ -488,17 +487,16 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings());
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).Returns(() => Task.FromResult(It.IsAny<string>()));
-            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(It.IsAny<string>());
+            userManager.Setup(x => x.GenerateChangePhoneNumberTokenAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(It.IsAny<string>());
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
-            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), null)).Returns(() => Task.FromResult(It.IsAny<Task>()));
+            userManager.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Success);
 
             var sut = new AccountController(userManager.Object, signInManager.Object, generalSettings.Object, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
@@ -519,7 +517,7 @@ namespace AllReady.UnitTest.Controllers
             var identityResult = IdentityResult.Failed(new IdentityError { Description = "IdentityErrorDescription" });
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(identityResult);
 
             var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null, null);
 
@@ -538,7 +536,7 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings());
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Failed());
 
             var sut = new AccountController(userManager.Object, null, generalSettings.Object, null, null, null, null);
             var result = await sut.Register(model) as ViewResult;
@@ -588,7 +586,6 @@ namespace AllReady.UnitTest.Controllers
         public async Task LogOffRedirectsToCorrectActionAndController()
         {
             var signInManager = MockHelper.CreateSignInManagerMock(MockHelper.CreateUserManagerMock());
-            signInManager.Setup(x => x.SignOutAsync()).Returns(() => Task.FromResult(It.IsAny<Task>()));
 
             var sut = new AccountController(null, signInManager.Object, null, null, null, null, null);
             var result = await sut.LogOff() as RedirectToActionResult;
@@ -633,7 +630,7 @@ namespace AllReady.UnitTest.Controllers
             const string token = "someToken";
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult((ApplicationUser)null));
+            userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(null);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
@@ -649,8 +646,8 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).ReturnsAsync(IdentityResult.Success);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ConfirmEmail(userId, token);
@@ -675,11 +672,11 @@ namespace AllReady.UnitTest.Controllers
                 Email = "test@email.com",
                 EmailConfirmed = true
             };
-            userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).ReturnsAsync(IdentityResult.Success);
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).Returns(() => Task.FromResult(It.IsAny<Unit>()));
+            mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).ReturnsAsync(It.IsAny<Unit>());
 
             var sut = new AccountController(userManager.Object, null, null, null, mediator.Object, null, null);
             sut.SetFakeUser(userId);
@@ -705,14 +702,11 @@ namespace AllReady.UnitTest.Controllers
                 Email = "test@email.com",
                 EmailConfirmed = true
             };
-            userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).ReturnsAsync(IdentityResult.Success);
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(x => x.RefreshSignInAsync(user)).Returns(() => Task.FromResult(It.IsAny<Task>()));
-
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(new RemoveUserProfileIncompleteClaimCommand { UserId = user.Id })).Returns(() => Task.FromResult(It.IsAny<Unit>()));
 
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, mediator.Object, null, null);
             sut.SetFakeUserWithCookieAuthenticationType(userId);
@@ -729,8 +723,8 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Failed()));
+            userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).ReturnsAsync(IdentityResult.Failed());
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
@@ -746,8 +740,8 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByIdAsync(userId)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByIdAsync(userId)).ReturnsAsync(user);
+            userManager.Setup(x => x.ConfirmEmailAsync(user, token)).ReturnsAsync(IdentityResult.Success);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ConfirmEmail(userId, token) as ViewResult;
@@ -803,7 +797,7 @@ namespace AllReady.UnitTest.Controllers
 
             var userManager = MockHelper.CreateUserManagerMock();
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ForgotPassword(vm);
@@ -820,7 +814,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user)).Verifiable();
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user).Verifiable();
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ForgotPassword(vm);
@@ -837,7 +831,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = default(ApplicationUser);
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ForgotPassword(vm) as ViewResult;
@@ -854,8 +848,8 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(false));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).ReturnsAsync(false);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ForgotPassword(vm) as ViewResult;
@@ -872,12 +866,9 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
-            userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
-
-            var emailSender = new Mock<IEmailSender>();
-            emailSender.Setup(x => x.SendEmailAsync(email, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(It.IsAny<Task>()));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).ReturnsAsync(true);
+            userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).ReturnsAsync(It.IsAny<string>());
 
             var sut = new AccountController(userManager.Object, null, null, null, Mock.Of<IMediator>(), null, null);
 
@@ -899,9 +890,9 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
-            userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).ReturnsAsync(true);
+            userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).ReturnsAsync(It.IsAny<string>());
 
             var sut = new AccountController(userManager.Object, null, null, null, Mock.Of<IMediator>(), null, null);
             var urlHelper = new Mock<IUrlHelper>();
@@ -926,9 +917,9 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
-            userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).ReturnsAsync(true);
+            userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).ReturnsAsync(It.IsAny<string>());
 
             var mediator = new Mock<IMediator>();
 
@@ -951,9 +942,9 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).Returns(() => Task.FromResult(true));
-            userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.IsEmailConfirmedAsync(user)).ReturnsAsync(true);
+            userManager.Setup(x => x.GeneratePasswordResetTokenAsync(user)).ReturnsAsync(It.IsAny<string>());
 
             var sut = new AccountController(userManager.Object, null, null, null, Mock.Of<IMediator>(), null, null);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
@@ -1062,8 +1053,8 @@ namespace AllReady.UnitTest.Controllers
 
             var userManager = MockHelper.CreateUserManagerMock();
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ResetPassword(vm);
@@ -1084,8 +1075,8 @@ namespace AllReady.UnitTest.Controllers
 
             var userManager = MockHelper.CreateUserManagerMock();
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ResetPassword(vm);
@@ -1101,8 +1092,8 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
 
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
 
             var result = await sut.ResetPassword(vm) as RedirectToActionResult;
@@ -1119,8 +1110,8 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
             var identityResult = IdentityResult.Failed(new IdentityError { Description = "IdentityErrorDescription" });
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(identityResult);
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             await sut.ResetPassword(vm);
@@ -1136,8 +1127,8 @@ namespace AllReady.UnitTest.Controllers
             var vm = new ResetPasswordViewModel { Email = email };
             var userManager = MockHelper.CreateUserManagerMock();
             var user = new ApplicationUser();
-            userManager.Setup(x => x.FindByNameAsync(email)).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
+            userManager.Setup(x => x.FindByNameAsync(email)).ReturnsAsync(user);
+            userManager.Setup(x => x.ResetPasswordAsync(user, It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Failed());
 
             var sut = new AccountController(userManager.Object, null, null, null, null, null, null);
             var result = await sut.ResetPassword(vm) as ViewResult;
@@ -1376,7 +1367,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var userManager = MockHelper.CreateUserManagerMock();
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
+            signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).ReturnsAsync(default(ExternalLoginInfo));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
 
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null, null, null);
@@ -1391,7 +1382,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var userManager = MockHelper.CreateUserManagerMock();
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).Returns(Task.FromResult(default(ExternalLoginInfo)));
+            signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.Is<string>(xsrf => xsrf == null))).ReturnsAsync(default(ExternalLoginInfo));
             var viewmodel = CreateExternalLoginConfirmationViewModel();
 
             var sut = new AccountController(userManager.Object, signInManager.Object, null, null, null, null, null);
@@ -1405,7 +1396,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task ExternalLoginConfirmationInvokesCreateAsyncWithCorrectUser_WhenExternalLoginInfoIsSuccessful_AndModelStateIsValid()
         {
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(new IdentityResult()));
+            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(new IdentityResult());
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager);
             var viewModel = CreateExternalLoginConfirmationViewModel();
@@ -1497,7 +1488,6 @@ namespace AllReady.UnitTest.Controllers
             var userManager = CreateUserManagerMockWithSucessIdentityResult();
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
-            SetupSignInManagerWithDefaultSignInAsync(signInManager);
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnTrueForLocalUrl(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
@@ -1530,16 +1520,15 @@ namespace AllReady.UnitTest.Controllers
         public async Task ExternalLoginConfirmationAddsIdentityResultErrorsToModelStateError_WhenUserIsCreatedSuccessfully()
         {
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(IdentityResult.Success));
+            userManager.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
             userManager.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>()))
-                .Returns(Task.FromResult(IdentityResult.Failed(
+                .ReturnsAsync(IdentityResult.Failed(
                     new IdentityError { Code = "TestCode1", Description = "TestDescription1" },
                     new IdentityError { Code = "TestCode2", Description = "TestDescription2" }
-                )));
+                ));
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
             SetupSignInManagerWithTestExternalLoginValue(signInManager, "test", "testKey", "testDisplayName");
-            SetupSignInManagerWithDefaultSignInAsync(signInManager);
             var urlHelperMock = CreateUrlHelperMockObject();
             SetupUrlHelperMockToReturnResultBaseOnLineBegining(urlHelperMock);
             var viewModel = CreateExternalLoginConfirmationViewModel();
@@ -1639,8 +1628,8 @@ namespace AllReady.UnitTest.Controllers
         private static Mock<UserManager<ApplicationUser>> CreateUserManagerMockWithSucessIdentityResult()
         {
             var userManagerMock = MockHelper.CreateUserManagerMock();
-            userManagerMock.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(IdentityResult.Success));
-            userManagerMock.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>())).Returns(Task.FromResult(IdentityResult.Success));
+            userManagerMock.Setup(u => u.CreateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
+            userManagerMock.Setup(u => u.AddLoginAsync(It.IsAny<ApplicationUser>(), It.IsAny<ExternalLoginInfo>())).ReturnsAsync(IdentityResult.Success);
 
             return userManagerMock;
         }
@@ -1649,13 +1638,7 @@ namespace AllReady.UnitTest.Controllers
             string displayName = "test")
         {
             signInManager.Setup(s => s.GetExternalLoginInfoAsync(It.IsAny<string>()))
-                .Returns(Task.FromResult(new ExternalLoginInfo(new ClaimsPrincipal(), loginProvider, providerKey, displayName)));
-        }
-
-        private static void SetupSignInManagerWithDefaultSignInAsync(Mock<SignInManager<ApplicationUser>> signInManager)
-        {
-            signInManager.Setup(s => s.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
-                .Returns(Task.FromResult(default(object)));
+                .ReturnsAsync(new ExternalLoginInfo(new ClaimsPrincipal(), loginProvider, providerKey, displayName));
         }
 
         private static ExternalLoginConfirmationViewModel CreateExternalLoginConfirmationViewModel(string email = "test@test.com", string firstName = "FirstName", string lastName = "LastName", string phoneNumber = "(111)111-11-11")

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/AdminControllerTests.cs
@@ -83,7 +83,7 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Failed());
 
             var sut = new AdminController(userManager.Object, null, null, null, generalSettings.Object);
 
@@ -107,9 +107,8 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings { DefaultTimeZone = defaultTimeZone });
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
-            //var sut = new AdminController(userManager.Object, null, Mock.Of<IEmailSender>(), null, null, generalSettings.Object);
             var sut = new AdminController(userManager.Object, null, Mock.Of<IMediator>(), null, generalSettings.Object);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
             sut.Url = Mock.Of<IUrlHelper>();
@@ -131,8 +130,8 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings());
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(It.IsAny<string>());
 
             var sut = new AdminController(userManager.Object, null, Mock.Of<IMediator>(), null, generalSettings.Object);
             sut.SetFakeHttpRequestSchemeTo(requestScheme);
@@ -160,8 +159,8 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings());
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(It.IsAny<string>());
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(callbackUrl);
@@ -184,8 +183,8 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings());
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
-            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).Returns(() => Task.FromResult(It.IsAny<string>()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync((IdentityResult.Success));
+            userManager.Setup(x => x.GenerateEmailConfirmationTokenAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(It.IsAny<string>());
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
@@ -209,7 +208,7 @@ namespace AllReady.UnitTest.Controllers
             var identityResult = IdentityResult.Failed(new IdentityError { Description = "IdentityErrorDescription" });
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(identityResult));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(identityResult);
 
             var sut = new AdminController(userManager.Object, null, null, null, generalSettings.Object);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
@@ -230,7 +229,7 @@ namespace AllReady.UnitTest.Controllers
             generalSettings.Setup(x => x.Value).Returns(new GeneralSettings());
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
+            userManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Failed());
 
             var sut = new AdminController(userManager.Object, null, null, null, generalSettings.Object);
             sut.SetFakeHttpRequestSchemeTo(It.IsAny<string>());
@@ -302,8 +301,8 @@ namespace AllReady.UnitTest.Controllers
             var user = new ApplicationUser();
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).Returns(() => Task.FromResult(user));
-            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
+            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(user);
+            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Failed());
 
             var sut = new AdminController(userManager.Object, null, null, null, null);
             await sut.ConfirmEmail(null, code);
@@ -318,8 +317,8 @@ namespace AllReady.UnitTest.Controllers
             const string userId = "1";
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).Returns(() => Task.FromResult(new ApplicationUser { Id = userId }));
-            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(new ApplicationUser { Id = userId });
+            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var settings = new Mock<IOptions<SampleDataSettings>>();
             settings.Setup(x => x.Value).Returns(new SampleDataSettings());
@@ -347,8 +346,8 @@ namespace AllReady.UnitTest.Controllers
             const string callbackUrl = "callbackUrl";
 
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).Returns(() => Task.FromResult(new ApplicationUser()));
-            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(new ApplicationUser());
+            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var settings = new Mock<IOptions<SampleDataSettings>>();
             settings.Setup(x => x.Value).Returns(new SampleDataSettings { DefaultAdminUsername = defaultAdminUserName });
@@ -371,8 +370,8 @@ namespace AllReady.UnitTest.Controllers
         public async Task ConfirmEmailReturnsCorrectViewWhenUsersConfirmationIsSuccessful()
         {
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).Returns(() => Task.FromResult(new ApplicationUser()));
-            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Success));
+            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(new ApplicationUser());
+            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
@@ -393,8 +392,8 @@ namespace AllReady.UnitTest.Controllers
         public async Task ConfirmEmailReturnsCorrectViewWhenUsersConfirmationIsUnsuccessful()
         {
             var userManager = MockHelper.CreateUserManagerMock();
-            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).Returns(() => Task.FromResult(new ApplicationUser()));
-            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).Returns(() => Task.FromResult(IdentityResult.Failed()));
+            userManager.Setup(x => x.FindByIdAsync(It.IsAny<string>())).ReturnsAsync(new ApplicationUser());
+            userManager.Setup(x => x.ConfirmEmailAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Failed());
 
             var sut = new AdminController(userManager.Object, null, null, null, null);
             var result = await sut.ConfirmEmail("userId", "code") as ViewResult;
@@ -470,7 +469,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
-            signInManager.Setup(x => x.GetTwoFactorAuthenticationUserAsync()).Returns(() => Task.FromResult(applicationUser));
+            signInManager.Setup(x => x.GetTwoFactorAuthenticationUserAsync()).ReturnsAsync(applicationUser);
             userManager.Setup(x => x.GetValidTwoFactorProvidersAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(new List<string>());
 
             var sut = new AdminController(userManager.Object, signInManager.Object, null, null, null);
@@ -492,7 +491,7 @@ namespace AllReady.UnitTest.Controllers
             var userManager = MockHelper.CreateUserManagerMock();
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
 
-            signInManager.Setup(x => x.GetTwoFactorAuthenticationUserAsync()).Returns(() => Task.FromResult(new ApplicationUser()));
+            signInManager.Setup(x => x.GetTwoFactorAuthenticationUserAsync()).ReturnsAsync(new ApplicationUser());
             userManager.Setup(x => x.GetValidTwoFactorProvidersAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(userFactors);
 
             var sut = new AdminController(userManager.Object, signInManager.Object, null, null, null);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerPhoneNumberTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerPhoneNumberTests.cs
@@ -501,7 +501,6 @@ namespace AllReady.UnitTest.Controllers
                                                             It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(x => x.RefreshSignInAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult<object>(null));
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
@@ -535,8 +534,6 @@ namespace AllReady.UnitTest.Controllers
                                                             It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
-                         .Returns(Task.FromResult<object>(null));
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
@@ -573,8 +570,6 @@ namespace AllReady.UnitTest.Controllers
                                                             It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
-                         .Returns(Task.FromResult<object>(null));
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
@@ -728,8 +723,6 @@ namespace AllReady.UnitTest.Controllers
                                                          It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(x => x.SignInAsync(It.IsAny<ApplicationUser>(), It.IsAny<bool>(), It.IsAny<string>()))
-                         .Returns(Task.FromResult<object>(null));
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
@@ -792,7 +785,6 @@ namespace AllReady.UnitTest.Controllers
                                                          It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(x => x.RefreshSignInAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult<object>(null));
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
@@ -823,7 +815,6 @@ namespace AllReady.UnitTest.Controllers
                                                          It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
 
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
-            signInManager.Setup(x => x.RefreshSignInAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult<object>(null));
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerTests.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using AllReady.Controllers;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using Microsoft.Extensions.Options;
 using MediatR;
 using AllReady.ViewModels.Manage;
 using static AllReady.Controllers.ManageController;
@@ -15,7 +13,6 @@ using AllReady.UnitTest.Extensions;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Identity;
 using AllReady.Features.Manage;
-using AllReady.Security;
 
 namespace AllReady.UnitTest.Controllers
 {

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/OrganizationControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/OrganizationControllerTests.cs
@@ -153,14 +153,14 @@ namespace AllReady.UnitTest.Controllers
                 model = new OrganizationViewModel { Id = 1, Name = "Org 1" };
 
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationDetailsQuery>())).Returns(() => Task.FromResult(model)).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationDetailsQuery>())).ReturnsAsync(model).Verifiable();
             controller = new OrganizationController(mockMediator.Object);
         }
 
         private static void MockMediatorOrganizationDetailsQueryNullResult(out OrganizationController controller)
         {
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationDetailsQuery>())).Returns(() => Task.FromResult((OrganizationViewModel)null)).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationDetailsQuery>())).ReturnsAsync(null).Verifiable();
             controller = new OrganizationController(mockMediator.Object);
         }
 
@@ -169,14 +169,14 @@ namespace AllReady.UnitTest.Controllers
             if (model == null) model = new OrganizationPrivacyPolicyViewModel { OrganizationName = "Org 1", Content = null };
 
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationPrivacyPolicyQuery>())).Returns(() => Task.FromResult(model)).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationPrivacyPolicyQuery>())).ReturnsAsync(model).Verifiable();
             controller = new OrganizationController(mockMediator.Object);
         }
 
         private static void MockMediatorOrganizationPrivacyPolicyQueryNullResult(out OrganizationController controller)
         {
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationPrivacyPolicyQuery>())).Returns(() => Task.FromResult((OrganizationPrivacyPolicyViewModel)null)).Verifiable();
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationPrivacyPolicyQuery>())).ReturnsAsync(null).Verifiable();
             controller = new OrganizationController(mockMediator.Object);
         }
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/SmsResponseControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/SmsResponseControllerTests.cs
@@ -124,22 +124,14 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task Index_SendsChangeRequestStatusCommand_WithExpectedValues_WhenUppercaseConfirmBodyPosted()
         {
-            ChangeRequestStatusCommand cmd = null;
-
             var mediatr = new Mock<IMediator>();
             mediatr.Setup(x => x.SendAsync(It.IsAny<FindRequestIdByPhoneNumberQuery>()))
                 .ReturnsAsync(RequestGuid);
-            mediatr.Setup(x => x.SendAsync(It.IsAny<ChangeRequestStatusCommand>()))
-                .Returns(Task.FromResult(Unit.Value))
-                .Callback<ChangeRequestStatusCommand>(x => cmd = x)
-                .Verifiable();
 
             var sut = new SmsResponseController(mediatr.Object, Mock.Of<ISmsSender>());
             await sut.Index(GoodPhoneNumber, UppercaseConfirm);
 
-            mediatr.Verify(x => x.SendAsync(It.IsAny<ChangeRequestStatusCommand>()), Times.Once);
-            cmd.RequestId.ShouldBe(RequestGuid);
-            cmd.NewStatus.ShouldBe(RequestStatus.Confirmed);
+            mediatr.Verify(x => x.SendAsync(It.Is<ChangeRequestStatusCommand>(y => y.RequestId == RequestGuid && y.NewStatus == RequestStatus.Confirmed)), Times.Once);
         }
 
         [Fact]
@@ -164,25 +156,18 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public async Task Index_SendsSmsSendAsync_WithExpectedPhoneNumber_WhenLowercaseConfirmodyPosted()
+        public async Task Index_InvokesSmsSendAsync_WithExpectedPhoneNumber_WhenLowercaseConfirmodyPosted()
         {
-            string smsTo = null;
-
             var mediatr = new Mock<IMediator>();
             mediatr.Setup(x => x.SendAsync(It.IsAny<FindRequestIdByPhoneNumberQuery>()))
                 .ReturnsAsync(RequestGuid);
 
             var smsSender = new Mock<ISmsSender>();
-            smsSender.Setup(x => x.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.FromResult<object>(null))
-                .Callback<string, string>((x, y) => smsTo = x)
-                .Verifiable();
 
             var sut = new SmsResponseController(mediatr.Object, smsSender.Object);
             await sut.Index(GoodPhoneNumber, LowercaseConfirm);
 
-            smsSender.Verify(x => x.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            smsTo.ShouldBe(GoodPhoneNumber);
+            smsSender.Verify(x => x.SendSmsAsync(GoodPhoneNumber, "Thank you for confirming you availability."), Times.Once);
         }
 
         [Fact]
@@ -210,87 +195,57 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task Index_SendsChangeRequestStatusCommand_WithExpectedValues_WhenUppercaseRejectBodyPosted()
         {
-            ChangeRequestStatusCommand cmd = null;
-
             var mediatr = new Mock<IMediator>();
             mediatr.Setup(x => x.SendAsync(It.IsAny<FindRequestIdByPhoneNumberQuery>()))
                 .ReturnsAsync(RequestGuid);
-            mediatr.Setup(x => x.SendAsync(It.IsAny<ChangeRequestStatusCommand>()))
-                .Returns(Task.FromResult(Unit.Value))
-                .Callback<ChangeRequestStatusCommand>(x => cmd = x)
-                .Verifiable();
-
+            
             var sut = new SmsResponseController(mediatr.Object, Mock.Of<ISmsSender>());
             await sut.Index(GoodPhoneNumber, UppercaseReject);
 
-            mediatr.Verify(x => x.SendAsync(It.IsAny<ChangeRequestStatusCommand>()), Times.Once);
-            cmd.RequestId.ShouldBe(RequestGuid);
-            cmd.NewStatus.ShouldBe(RequestStatus.Unassigned);
+            mediatr.Verify(x => x.SendAsync(It.Is<ChangeRequestStatusCommand>(y => y.RequestId == RequestGuid && y.NewStatus == RequestStatus.Unassigned)), Times.Once);
         }
 
         [Fact]
         public async Task Index_SendsChangeRequestStatusCommand_WithExpectedValues_WhenLowercaseRejectBodyPosted()
         {
-            ChangeRequestStatusCommand cmd = null;
-
             var mediatr = new Mock<IMediator>();
             mediatr.Setup(x => x.SendAsync(It.IsAny<FindRequestIdByPhoneNumberQuery>()))
                 .ReturnsAsync(RequestGuid);
-            mediatr.Setup(x => x.SendAsync(It.IsAny<ChangeRequestStatusCommand>()))
-                .Returns(Task.FromResult(Unit.Value))
-                .Callback<ChangeRequestStatusCommand>(x => cmd = x)
-                .Verifiable();
 
             var sut = new SmsResponseController(mediatr.Object, Mock.Of<ISmsSender>());
             await sut.Index(GoodPhoneNumber, LowercaseReject);
 
-            mediatr.Verify(x => x.SendAsync(It.IsAny<ChangeRequestStatusCommand>()), Times.Once);
-            cmd.RequestId.ShouldBe(RequestGuid);
-            cmd.NewStatus.ShouldBe(RequestStatus.Unassigned);
+            mediatr.Verify(x => x.SendAsync(It.Is<ChangeRequestStatusCommand>(y => y.RequestId == RequestGuid && y.NewStatus == RequestStatus.Unassigned)), Times.Once);
         }
 
         [Fact]
-        public async Task Index_SendsSmsSendAsync_WithExpectedPhoneNumber_WhenLowercaseRejectBodyPosted()
+        public async Task Index_InvokesSmsSendAsync_WithExpectedPhoneNumber_WhenLowercaseRejectBodyPosted()
         {
-            string smsTo = null;
-
             var mediatr = new Mock<IMediator>();
             mediatr.Setup(x => x.SendAsync(It.IsAny<FindRequestIdByPhoneNumberQuery>()))
                 .ReturnsAsync(RequestGuid);
 
             var smsSender = new Mock<ISmsSender>();
-            smsSender.Setup(x => x.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.FromResult<object>(null))
-                .Callback<string, string>((x, y) => smsTo = x)
-                .Verifiable();
 
             var sut = new SmsResponseController(mediatr.Object, smsSender.Object);
             await sut.Index(GoodPhoneNumber, LowercaseReject);
 
-            smsSender.Verify(x => x.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            smsTo.ShouldBe(GoodPhoneNumber);
+            smsSender.Verify(x => x.SendSmsAsync(GoodPhoneNumber, "We have canceled your request and once it is rescheduled you will receive further communication."), Times.Once);
         }
 
         [Fact]
         public async Task Index_SendsSmsSendAsync_WithExpectedPhoneNumber_WhenUppercaseRejectBodyPosted()
         {
-            string smsTo = null;
-
             var mediatr = new Mock<IMediator>();
             mediatr.Setup(x => x.SendAsync(It.IsAny<FindRequestIdByPhoneNumberQuery>()))
                 .ReturnsAsync(RequestGuid);
 
             var smsSender = new Mock<ISmsSender>();
-            smsSender.Setup(x => x.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.FromResult<object>(null))
-                .Callback<string, string>((x, y) => smsTo = x)
-                .Verifiable();
 
             var sut = new SmsResponseController(mediatr.Object, smsSender.Object);
             await sut.Index(GoodPhoneNumber, UppercaseReject);
 
-            smsSender.Verify(x => x.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            smsTo.ShouldBe(GoodPhoneNumber);
+            smsSender.Verify(x => x.SendSmsAsync(GoodPhoneNumber, "We have canceled your request and once it is rescheduled you will receive further communication."), Times.Once);
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/SmsResponseControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/SmsResponseControllerTests.cs
@@ -137,22 +137,14 @@ namespace AllReady.UnitTest.Controllers
         [Fact]
         public async Task Index_ChangeRequestStatusCommand_WithExpectedValues_WhenLowercaseConfirmBodyPosted()
         {
-            ChangeRequestStatusCommand cmd = null;
-
             var mediatr = new Mock<IMediator>();
             mediatr.Setup(x => x.SendAsync(It.IsAny<FindRequestIdByPhoneNumberQuery>()))
                 .ReturnsAsync(RequestGuid);
-            mediatr.Setup(x => x.SendAsync(It.IsAny<ChangeRequestStatusCommand>()))
-                .Returns(Task.FromResult(Unit.Value))
-                .Callback<ChangeRequestStatusCommand>(x => cmd = x)
-                .Verifiable();
 
             var sut = new SmsResponseController(mediatr.Object, Mock.Of<ISmsSender>());
             await sut.Index(GoodPhoneNumber, LowercaseConfirm);
 
-            mediatr.Verify(x => x.SendAsync(It.IsAny<ChangeRequestStatusCommand>()), Times.Once);
-            cmd.RequestId.ShouldBe(RequestGuid);
-            cmd.NewStatus.ShouldBe(RequestStatus.Confirmed);
+            mediatr.Verify(x => x.SendAsync(It.Is<ChangeRequestStatusCommand>(y => y.RequestId == RequestGuid && y.NewStatus == RequestStatus.Confirmed)), Times.Once);
         }
 
         [Fact]
@@ -171,25 +163,18 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public async Task Index_SendsSmsSendAsync_WithExpectedPhoneNumber_WhenUppercaseConfirmBodyPosted()
+        public async Task Index_InvokesSmsSendAsync_WithExpectedPhoneNumber_WhenUppercaseConfirmBodyPosted()
         {
-            string smsTo = null;
-
             var mediatr = new Mock<IMediator>();
             mediatr.Setup(x => x.SendAsync(It.IsAny<FindRequestIdByPhoneNumberQuery>()))
                 .ReturnsAsync(RequestGuid);
 
             var smsSender = new Mock<ISmsSender>();
-            smsSender.Setup(x => x.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(Task.FromResult<object>(null))
-                .Callback<string, string>((x, y) => smsTo = x)
-                .Verifiable();
 
             var sut = new SmsResponseController(mediatr.Object, smsSender.Object);
             await sut.Index(GoodPhoneNumber, UppercaseConfirm);
 
-            smsSender.Verify(x => x.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Once);
-            smsTo.ShouldBe(GoodPhoneNumber);
+            smsSender.Verify(x => x.SendSmsAsync(GoodPhoneNumber, "Thank you for confirming you availability."), Times.Once);
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/TaskApiControllerTests.cs
@@ -322,7 +322,7 @@ namespace AllReady.UnitTest.Controllers
         {
             var model = new TaskSignupViewModel();
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model))).Returns(Task.FromResult(new TaskSignupResult()));
+            mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model))).ReturnsAsync(new TaskSignupResult());
 
             var sut = new TaskApiController(mediator.Object, null, null);
             await sut.RegisterTask(model);
@@ -337,11 +337,11 @@ namespace AllReady.UnitTest.Controllers
             var model = new TaskSignupViewModel();
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model)))
-                .Returns(Task.FromResult(new TaskSignupResult
+                .ReturnsAsync(new TaskSignupResult
                 {
                     Status = taskSignUpResultStatus,
                     Task = new AllReadyTask { Id = 1, Name = "Task" }
-                }));
+                });
 
             var sut = new TaskApiController(mediator.Object, null, null);
 
@@ -362,10 +362,10 @@ namespace AllReady.UnitTest.Controllers
             var model = new TaskSignupViewModel();
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model)))
-                .Returns(Task.FromResult(new TaskSignupResult
+                .ReturnsAsync(new TaskSignupResult
                 {
                     Status = taskSignUpResultStatus                    
-                }));
+                });
 
             var sut = new TaskApiController(mediator.Object, null, null);
 
@@ -388,10 +388,10 @@ namespace AllReady.UnitTest.Controllers
             var model = new TaskSignupViewModel();
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model)))
-                .Returns(Task.FromResult(new TaskSignupResult
+                .ReturnsAsync(new TaskSignupResult
                 {
                     Status = taskSignUpResultStatus
-                }));
+                });
 
             var sut = new TaskApiController(mediator.Object, null, null);
 
@@ -414,10 +414,10 @@ namespace AllReady.UnitTest.Controllers
             var model = new TaskSignupViewModel();
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.Is<TaskSignupCommand>(y => y.TaskSignupModel == model)))
-                .Returns(Task.FromResult(new TaskSignupResult
+                .ReturnsAsync(new TaskSignupResult
                 {
                     Status = taskSignUpResultStatus
-                }));
+                });
 
             var sut = new TaskApiController(mediator.Object, null, null);
 
@@ -576,7 +576,7 @@ namespace AllReady.UnitTest.Controllers
             var model = new TaskChangeModel { TaskId = 1, UserId = "1", Status = TaskStatus.Accepted, StatusDescription = "statusDescription" };
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<ChangeTaskStatusCommand>())).Returns(() => Task.FromResult(new TaskChangeResult()));
+            mediator.Setup(x => x.SendAsync(It.IsAny<ChangeTaskStatusCommand>())).ReturnsAsync(new TaskChangeResult());
 
             var sut = new TaskApiController(mediator.Object, null, null);
             await sut.ChangeStatus(model);
@@ -593,7 +593,7 @@ namespace AllReady.UnitTest.Controllers
             const string status = "status";
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<ChangeTaskStatusCommand>())).Returns(() => Task.FromResult(new TaskChangeResult { Status = status }));
+            mediator.Setup(x => x.SendAsync(It.IsAny<ChangeTaskStatusCommand>())).ReturnsAsync(new TaskChangeResult { Status = status });
 
             var sut = new TaskApiController(mediator.Object, null, null);
             sut.SetDefaultHttpContext();
@@ -610,7 +610,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task ChangeStatusReturnsNullForTaskWhenResultTaskIsNull()
         {
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<ChangeTaskStatusCommand>())).Returns(() => Task.FromResult(new TaskChangeResult { Status = "status" }));
+            mediator.Setup(x => x.SendAsync(It.IsAny<ChangeTaskStatusCommand>())).ReturnsAsync(new TaskChangeResult { Status = "status" });
 
             var sut = new TaskApiController(mediator.Object, null, null);
             sut.SetDefaultHttpContext();
@@ -626,7 +626,7 @@ namespace AllReady.UnitTest.Controllers
         public async Task ChangeStatusReturnsTaskViewModelWhenResultTaskIsNotNull()
         {
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<ChangeTaskStatusCommand>())).Returns(() => Task.FromResult(new TaskChangeResult { Task = new AllReadyTask() }));
+            mediator.Setup(x => x.SendAsync(It.IsAny<ChangeTaskStatusCommand>())).ReturnsAsync(new TaskChangeResult { Task = new AllReadyTask() });
 
             var sut = new TaskApiController(mediator.Object, null, null);
             sut.SetDefaultHttpContext();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Hangfire/Jobs/ProcessApiRequestsShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Hangfire/Jobs/ProcessApiRequestsShould.cs
@@ -71,7 +71,7 @@ namespace AllReady.UnitTest.Hangfire.Jobs
             var geocoder = new Mock<IGeocodeService>();
             geocoder.Setup(service => service.GetCoordinatesFromAddress(It.IsAny<string>(),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(() => Task.FromResult<Coordinates>(null));
+                .ReturnsAsync(null);
 
             var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), geocoder.Object,
                 Options.Create(new ApprovedRegionsSettings()))
@@ -97,7 +97,7 @@ namespace AllReady.UnitTest.Hangfire.Jobs
             var geocoder = new Mock<IGeocodeService>();
             geocoder.Setup(service => service.GetCoordinatesFromAddress(It.IsAny<string>(),
                     It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(() => Task.FromResult(new Coordinates(latitude, longitude)));
+                .ReturnsAsync(new Coordinates(latitude, longitude));
 
             var sut = new ProcessApiRequests(Context, Mock.Of<IMediator>(), geocoder.Object,
                 Options.Create(new ApprovedRegionsSettings()))

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/AuthMessageSenderShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/AuthMessageSenderShould.cs
@@ -51,7 +51,8 @@ namespace AllReady.UnitTest.Services
         {
             var mediatorMock = new Mock<IMediator>();
             mediatorMock.Setup(mock => mock.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
-                .Returns(Task.FromResult(new Unit()))
+                .ReturnsAsync(new Unit())
+                //.Returns(Task.FromResult(new Unit()))
                 .Verifiable();
             return mediatorMock;
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Services/AuthMessageSenderShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Services/AuthMessageSenderShould.cs
@@ -52,7 +52,6 @@ namespace AllReady.UnitTest.Services
             var mediatorMock = new Mock<IMediator>();
             mediatorMock.Setup(mock => mock.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
                 .ReturnsAsync(new Unit())
-                //.Returns(Task.FromResult(new Unit()))
                 .Verifiable();
             return mediatorMock;
         }


### PR DESCRIPTION
Fixes #1743