### PR TITLE
Fixes #1736: Fixed one test that I previously missed and left "skipped"

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerPhoneNumberTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerPhoneNumberTests.cs
@@ -399,7 +399,7 @@ namespace AllReady.UnitTest.Controllers
             Assert.Equal(phoneNumber, viewModel.PhoneNumber);
         }
 
-        [Fact(Skip = "NotImplemented")]
+        [Fact]
         public async Task VerifyPhoneNumberPostSendsUserByUserIdQueryWithCorrectUserId()
         {
             //Arrange
@@ -408,7 +408,7 @@ namespace AllReady.UnitTest.Controllers
             userManagerMock.Setup(x => x.GetUserId(It.IsAny<ClaimsPrincipal>())).Returns(userId);
             var signInManagerMock = MockHelper.CreateSignInManagerMock(userManagerMock);
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(new ApplicationUser());
+            mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(null);
 
             var controller = new ManageController(userManagerMock.Object, signInManagerMock.Object, mediator.Object);
             controller.SetFakeUser(userId);


### PR DESCRIPTION
Fixes #1736

The previous PR missed one test - `VerifyPhoneNumberPostSendsUserByUserIdQueryWithCorrectUserId` and left it "skipped". Additionally, the test itself failed due to exercising parts of the  `VerifyPhoneNumber` method that aren't mocked.

Test now runs and logic corrected to minimise the execution path through the method under test to focus on "UserByUserIdQueryWithCorrectUserId" testing.