### PR TITLE
Find and fix any unit tests that need to change to async

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/CampaignControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/CampaignControllerTests.cs
@@ -17,20 +17,20 @@ namespace AllReady.UnitTest.Controllers
     public class CampaignControllerTests
     {
         [Fact]
-        public void IndexSendsCampaignIndexQuery()
+        public async Task IndexSendsCampaignIndexQuery()
         {
             var mockMediator = new Mock<IMediator>();
             var sut = new CampaignController(mockMediator.Object);
-            sut.Index();
+            await sut.Index();
 
-            mockMediator.Verify(m => m.Send(It.IsAny<UnlockedCampaignsQuery>()), Times.Once);
+            mockMediator.Verify(m => m.SendAsync(It.IsAny<UnlockedCampaignsQuery>()), Times.Once);
         }
 
         [Fact]
-        public void IndexReturnsAView()
+        public async Task IndexReturnsAView()
         {
             var sut = new CampaignController(Mock.Of<IMediator>());
-            var result = sut.Index();
+            var result = await sut.Index();
 
             Assert.IsType<ViewResult>(result);
         }
@@ -174,26 +174,26 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public void GetReturnsTheCorrectViewModel()
+        public async Task GetReturnsTheCorrectViewModel()
         {
             var mockedMediator = new Mock<IMediator>();
-            mockedMediator.Setup(m => m.Send(It.IsAny<UnlockedCampaignsQuery>())).Returns(new List<CampaignViewModel>());
+            mockedMediator.Setup(m => m.SendAsync(It.IsAny<UnlockedCampaignsQuery>())).ReturnsAsync(new List<CampaignViewModel>());
 
             var sut = new CampaignController(mockedMediator.Object);
-            var result = sut.Get();
+            var result = await sut.Get();
 
             Assert.IsType<List<CampaignViewModel>>(result);
         }
 
         [Fact]
-        public void GetSendsCampaignGetQuery()
+        public async Task GetSendsCampaignGetQuery()
         {
             var mockedMediator = new Mock<IMediator>();
 
             var sut = new CampaignController(mockedMediator.Object);
-            sut.Get();
+            await sut.Get();
 
-            mockedMediator.Verify(m => m.Send(It.IsAny<UnlockedCampaignsQuery>()), Times.Once);
+            mockedMediator.Verify(m => m.SendAsync(It.IsAny<UnlockedCampaignsQuery>()), Times.Once);
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventApiControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/EventApiControllerTests.cs
@@ -17,23 +17,23 @@ namespace AllReady.UnitTest.Controllers
     public class EventApiControllerTests
     {
         [Fact]
-        public void GetSendsEventsWithUnlockedCampaignsQuery()
+        public async Task GetSendsEventsWithUnlockedCampaignsQuery()
         {
             var mediator = new Mock<IMediator>();
             var sut = new EventApiController(mediator.Object);
-            sut.Get();
+            await sut.Get();
 
-            mediator.Verify(x => x.Send(It.IsAny<EventsWithUnlockedCampaignsQuery>()), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.IsAny<EventsWithUnlockedCampaignsQuery>()), Times.Once);
         }
 
         [Fact]
-        public void GetReturnsCorrectModel()
+        public async Task GetReturnsCorrectModel()
         {
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.Send(It.IsAny<EventsWithUnlockedCampaignsQuery>())).Returns(new List<EventViewModel>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventsWithUnlockedCampaignsQuery>())).ReturnsAsync(new List<EventViewModel>());
 
             var sut = new EventApiController(mediator.Object);
-            var results = sut.Get();
+            var results = await sut.Get();
 
             Assert.IsType<List<EventViewModel>>(results);
         }
@@ -70,18 +70,6 @@ namespace AllReady.UnitTest.Controllers
 
             Assert.IsType<EventViewModel>(result);
         }
-
-        //TODO: come back to these two tests until you hear back from Tony Surma about returning null instead of retruning HttpNotFound
-        //GetByIdReturnsNullWhenEventIsNotFoundById ???
-        //[Fact]
-        //public void GetByIdReturnsHttpNotFoundWhenEventIsNotFoundById()
-        //{
-        //    var controller = new EventApiController(Mock.Of<IAllReadyDataAccess>(), null)
-        //        .SetFakeUser("1");
-
-        //    var result = controller.Get(It.IsAny<int>());
-        //    Assert.IsType<NotFoundResult>(result);
-        //}
 
         [Fact]
         public void GetByIdHasHttpGetAttributeWithCorrectTemplate()
@@ -122,45 +110,45 @@ namespace AllReady.UnitTest.Controllers
         }
 
         [Fact]
-        public void GetEventsByDateRangeSendsEventByDateRangeQueryWithCorrectDates()
+        public async Task GetEventsByDateRangeSendsEventByDateRangeQueryWithCorrectDates()
         {
             var may = new DateTimeOffset(2016, 5, 1, 0, 0, 0, new TimeSpan());
             var june = new DateTimeOffset(2016, 6, 1, 0, 0, 0, new TimeSpan());
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.Send(It.IsAny<EventByDateRangeQuery>())).Returns(new List<EventViewModel>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventByDateRangeQuery>())).ReturnsAsync(new List<EventViewModel>());
 
             var sut = new EventApiController(mediator.Object);
-            sut.GetEventsByDateRange(may, june);
+            await sut.GetEventsByDateRange(may, june);
 
-            mediator.Verify(x => x.Send(It.Is<EventByDateRangeQuery>(y => y.StartDate == may && y.EndDate == june)), Times.Once);
+            mediator.Verify(x => x.SendAsync(It.Is<EventByDateRangeQuery>(y => y.StartDate == may && y.EndDate == june)), Times.Once);
         }
 
 
         [Fact]
-        public void GetEventsByDateRangeReturnsNoContentWhenEventsIsNull()
+        public async Task GetEventsByDateRangeReturnsNoContentWhenEventsIsNull()
         {
             var may = new DateTimeOffset(2016, 5, 1, 0, 0, 0, new TimeSpan());
             var june = new DateTimeOffset(2016, 6, 1, 0, 0, 0, new TimeSpan());
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.Send(It.IsAny<EventByDateRangeQuery>())).Returns((List<EventViewModel>)null);
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventByDateRangeQuery>())).ReturnsAsync((List<EventViewModel>)null);
 
             var sut = new EventApiController(mediator.Object);
-            var result = sut.GetEventsByDateRange(may, june);
+            var result = await sut.GetEventsByDateRange(may, june);
 
             Assert.IsType<NoContentResult>(result);
         }
 
 
         [Fact]
-        public void GetEventsByDateRangeReturnsJsonWhenEventsIsNotNull()
+        public async Task GetEventsByDateRangeReturnsJsonWhenEventsIsNotNull()
         {
             var may = new DateTimeOffset(2016, 5, 1, 0, 0, 0, new TimeSpan());
             var june = new DateTimeOffset(2016, 6, 1, 0, 0, 0, new TimeSpan());
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.Send(It.IsAny<EventByDateRangeQuery>())).Returns(new List<EventViewModel>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<EventByDateRangeQuery>())).ReturnsAsync(new List<EventViewModel>());
 
             var sut = new EventApiController(mediator.Object);
-            var result = sut.GetEventsByDateRange(may, june);
+            var result = await sut.GetEventsByDateRange(may, june);
 
             Assert.IsType<JsonResult>(result);
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerPhoneNumberTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerPhoneNumberTests.cs
@@ -122,7 +122,6 @@ namespace AllReady.UnitTest.Controllers
             var signInManagerMock = MockHelper.CreateSignInManagerMock(userManager);
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<SendAccountSecurityTokenSms>())).ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManagerMock.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -151,7 +150,6 @@ namespace AllReady.UnitTest.Controllers
             var signInManagerMock = MockHelper.CreateSignInManagerMock(userManager);
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<SendAccountSecurityTokenSms>())).ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManagerMock.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -261,7 +259,6 @@ namespace AllReady.UnitTest.Controllers
             var signInManagerMock = MockHelper.CreateSignInManagerMock(userManager);
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<SendAccountSecurityTokenSms>())).ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManagerMock.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -290,7 +287,6 @@ namespace AllReady.UnitTest.Controllers
             var signInManagerMock = MockHelper.CreateSignInManagerMock(userManager);
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<SendAccountSecurityTokenSms>())).ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManagerMock.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -471,8 +467,6 @@ namespace AllReady.UnitTest.Controllers
             var signInManagerMock = MockHelper.CreateSignInManagerMock(userManager);
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<RemoveUserProfileIncompleteClaimCommand>()))
-                    .ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManagerMock.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -504,8 +498,6 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<RemoveUserProfileIncompleteClaimCommand>()))
-                    .ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManager.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -537,8 +529,6 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<RemoveUserProfileIncompleteClaimCommand>()))
-                    .ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManager.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -573,8 +563,6 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<RemoveUserProfileIncompleteClaimCommand>()))
-                    .ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManager.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -726,8 +714,6 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<RemoveUserProfileIncompleteClaimCommand>()))
-                    .ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManager.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -758,8 +744,6 @@ namespace AllReady.UnitTest.Controllers
             var signInManager = MockHelper.CreateSignInManagerMock(userManager);
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<RemoveUserProfileIncompleteClaimCommand>()))
-                    .ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManager.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -788,8 +772,6 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<RemoveUserProfileIncompleteClaimCommand>()))
-                    .ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManager.Object, mediator.Object);
             controller.SetFakeUser(userId);
@@ -818,8 +800,6 @@ namespace AllReady.UnitTest.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<UserByUserIdQuery>())).ReturnsAsync(user);
-            mediator.Setup(x => x.SendAsync(It.IsAny<RemoveUserProfileIncompleteClaimCommand>()))
-                    .ReturnsAsync(new Unit());
 
             var controller = new ManageController(userManager.Object, signInManager.Object, mediator.Object);
             controller.SetFakeUser(userId);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Campaigns/UnlockedCampaignsQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Campaigns/UnlockedCampaignsQueryHandlerShould.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using AllReady.Features.Campaigns;
 using AllReady.Models;
 using AllReady.ViewModels.Campaign;
@@ -9,7 +10,7 @@ namespace AllReady.UnitTest.Features.Campaigns
     public class UnlockedCampaignsQueryHandlerShould : InMemoryContextTest
     {
         [Fact]
-        public void ReturnTheCorrectData()
+        public async Task ReturnTheCorrectData()
         {
             var campaigns = new List<Campaign>
             {
@@ -21,16 +22,16 @@ namespace AllReady.UnitTest.Features.Campaigns
             Context.SaveChanges();
 
             var sut = new UnlockedCampaignsQueryHandler(Context);
-            var results = sut.Handle(new UnlockedCampaignsQuery());
+            var results = await sut.Handle(new UnlockedCampaignsQuery());
 
             Assert.Equal(campaigns[0].Id, results[0].Id);
         }
 
         [Fact]
-        public void ReturnTheCorrectViewModel()
+        public async Task ReturnTheCorrectViewModel()
         {
             var sut = new UnlockedCampaignsQueryHandler(Context);
-            var results = sut.Handle(new UnlockedCampaignsQuery());
+            var results = await sut.Handle(new UnlockedCampaignsQuery());
 
             Assert.IsType<List<CampaignViewModel>>(results);
         }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Event/EventsByDateRangeQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Event/EventsByDateRangeQueryHandlerShould.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Features.Events;
 using Xunit;
 
@@ -23,7 +24,7 @@ namespace AllReady.UnitTest.Features.Event
         }
 
         [Fact]
-        public void FiltersEventsCorrectly()
+        public async Task FiltersEventsCorrectly()
         {
             var may = new DateTimeOffset(2016, 5, 1, 0, 0, 0, new TimeSpan());
             var june = new DateTimeOffset(2016, 6, 1, 0, 0, 0, new TimeSpan());
@@ -34,7 +35,8 @@ namespace AllReady.UnitTest.Features.Event
             Context.SaveChanges();
 
             var sut = new EventByDateRangeQueryHandler(Context);
-            var result = sut.Handle(new EventByDateRangeQuery { StartDate = may, EndDate = june }).ToArray();
+            var eventViewModel = await sut.Handle(new EventByDateRangeQuery { StartDate = may, EndDate = june });
+            var result = eventViewModel.ToArray();
 
             Context.Events.RemoveRange(events);
             Context.SaveChanges();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Event/EventsWithUnlockedCampaignsQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Event/EventsWithUnlockedCampaignsQueryHandlerShould.cs
@@ -13,28 +13,20 @@ namespace AllReady.UnitTest.Features.Event
         [Fact]
         public async Task HandleReturnsEventsWitUnlockedCampaigns()
         {
-            var options = CreateNewContextOptions();
-
             const int unlockedEventId = 1;
 
-            using (var context = new AllReadyContext(options))
+            var campaignEvents = new List<Event>
             {
-                var campaignEvents = new List<Event>
-                {
-                    new Event {Id = unlockedEventId, Campaign = new Campaign {Locked = false, ManagingOrganization = new Organization()}},
-                    new Event {Id = 2, Campaign = new Campaign {Locked = true, ManagingOrganization = new Organization()}}
-                };
-                context.Events.AddRange(campaignEvents);
-                await context.SaveChangesAsync();
-            }
+                new Event {Id = unlockedEventId, Campaign = new Campaign {Locked = false, ManagingOrganization = new Organization()}},
+                new Event {Id = 2, Campaign = new Campaign {Locked = true, ManagingOrganization = new Organization()}}
+            };
+            Context.Events.AddRange(campaignEvents);
+            Context.SaveChanges();
 
-            using (var context = new AllReadyContext(options))
-            {
-                var sut = new EventsWithUnlockedCampaignsQueryHandler(context);
-                var results = sut.Handle(new EventsWithUnlockedCampaignsQuery());
+            var sut = new EventsWithUnlockedCampaignsQueryHandler(Context);
+            var results = await sut.Handle(new EventsWithUnlockedCampaignsQuery());
 
-                Assert.Equal(results[0].Id, unlockedEventId);
-            }
+            Assert.Equal(results[0].Id, unlockedEventId);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/NotifyAdminForUserUnenrollsHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Notifications/NotifyAdminForUserUnenrollsHandlerShould.cs
@@ -29,10 +29,6 @@ namespace AllReady.UnitTest.Features.Notifications
                 .Setup(x => x.SendAsync(It.IsAny<TaskDetailForNotificationQuery>()))
                 .ReturnsAsync(GetTaskDetailForNotificationModel(taskId, eventId));
 
-            // Setup action call
-            mediator.Setup(x => x.SendAsync(It.IsAny<NotifyVolunteersCommand>()))
-                .ReturnsAsync(new Unit());
-
             var logger = Mock.Of<ILogger<NotifyAdminForUserUnenrollsHandler>>();
             var options = GetSettings();
             var notification = GetUserUnenrolls(taskId);
@@ -64,10 +60,6 @@ namespace AllReady.UnitTest.Features.Notifications
                 .Setup(x => x.SendAsync(It.IsAny<TaskDetailForNotificationQuery>()))
                 .ReturnsAsync(GetTaskDetailForNotificationModel(taskId, eventId));
 
-            // Setup action call
-            mediator.Setup(x => x.SendAsync(It.Is<NotifyVolunteersCommand>(n => !string.IsNullOrWhiteSpace(n.ViewModel.Subject))))
-                .ReturnsAsync(new Unit());
-
             var logger = Mock.Of<ILogger<NotifyAdminForUserUnenrollsHandler>>();
             var options = GetSettings();
             var notification = GetUserUnenrolls(taskId);
@@ -97,10 +89,6 @@ namespace AllReady.UnitTest.Features.Notifications
             mediator
                 .Setup(x => x.SendAsync(It.IsAny<TaskDetailForNotificationQuery>()))
                 .ReturnsAsync(taskDetail);
-
-            // Setup action call
-            mediator.Setup(x => x.SendAsync(It.Is<NotifyVolunteersCommand>(n => n.ViewModel.EmailRecipients.Contains(expectedEmail))))
-                .ReturnsAsync(new Unit());
 
             var logger = Mock.Of<ILogger<NotifyAdminForUserUnenrollsHandler>>();
             var options = GetSettings();

--- a/AllReadyApp/Web-App/AllReady/Controllers/CampaignController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/CampaignController.cs
@@ -21,9 +21,9 @@ namespace AllReady.Controllers
 
         [HttpGet]
         [Route("~/[controller]")]
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
-            var unlockedCampaigns = GetUnlockedCampaigns();
+            var unlockedCampaigns = await GetUnlockedCampaigns();
             return View(unlockedCampaigns);
         }
 
@@ -57,9 +57,9 @@ namespace AllReady.Controllers
 
         // GET: api/values
         [HttpGet]
-        public IEnumerable<CampaignViewModel> Get()
+        public async Task<IEnumerable<CampaignViewModel>> Get()
         {
-            return GetUnlockedCampaigns();
+            return await GetUnlockedCampaigns();
         }
 
         // GET api/values/5
@@ -75,9 +75,9 @@ namespace AllReady.Controllers
             return Json(campaign.ToViewModel());
         }
 
-        private List<CampaignViewModel> GetUnlockedCampaigns()
+        private async Task<List<CampaignViewModel>> GetUnlockedCampaigns()
         {
-            return _mediator.Send(new UnlockedCampaignsQuery());
+            return await _mediator.SendAsync(new UnlockedCampaignsQuery());
         }
 
         private async Task<Campaign> GetCampaign(int campaignId)

--- a/AllReadyApp/Web-App/AllReady/Controllers/EventApiController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/EventApiController.cs
@@ -22,9 +22,9 @@ namespace AllReady.Controllers
 
         // GET: api/values
         [HttpGet]
-        public IEnumerable<EventViewModel> Get()
+        public async Task<IEnumerable<EventViewModel>> Get()
         {
-            return _mediator.Send(new EventsWithUnlockedCampaignsQuery());
+            return await _mediator.SendAsync(new EventsWithUnlockedCampaignsQuery());
         }
 
         //orginial code
@@ -46,9 +46,9 @@ namespace AllReady.Controllers
         //orginial code
         [HttpGet("{start}/{end}")]
         [Produces("application/json", Type = typeof(EventViewModel))]
-        public ActionResult GetEventsByDateRange(DateTimeOffset start, DateTimeOffset end)
+        public async Task<IActionResult> GetEventsByDateRange(DateTimeOffset start, DateTimeOffset end)
         {
-            var events = _mediator.Send(new EventByDateRangeQuery { EndDate = end, StartDate = start });
+            var events = await _mediator.SendAsync(new EventByDateRangeQuery { EndDate = end, StartDate = start });
             if (events == null)
             {
                 return NoContent();

--- a/AllReadyApp/Web-App/AllReady/Features/Campaigns/UnlockedCampaignsQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Campaigns/UnlockedCampaignsQuery.cs
@@ -4,7 +4,7 @@ using MediatR;
 
 namespace AllReady.Features.Campaigns
 {
-    public class UnlockedCampaignsQuery : IRequest<List<CampaignViewModel>>
+    public class UnlockedCampaignsQuery : IAsyncRequest<List<CampaignViewModel>>
     {
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Features/Campaigns/UnlockedCampaignsQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Campaigns/UnlockedCampaignsQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Models;
 using AllReady.ViewModels.Campaign;
 using MediatR;
@@ -7,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AllReady.Features.Campaigns
 {
-    public class UnlockedCampaignsQueryHandler : IRequestHandler<UnlockedCampaignsQuery, List<CampaignViewModel>>
+    public class UnlockedCampaignsQueryHandler : IAsyncRequestHandler<UnlockedCampaignsQuery, List<CampaignViewModel>>
     {
         private readonly AllReadyContext _context;
 
@@ -16,15 +17,14 @@ namespace AllReady.Features.Campaigns
             _context = context;
         }
 
-        public List<CampaignViewModel> Handle(UnlockedCampaignsQuery message)
+        public async Task<List<CampaignViewModel>> Handle(UnlockedCampaignsQuery message)
         {
-            return _context.Campaigns
-                   .Include(x => x.ManagingOrganization)
-                   .Include(x => x.Events)
-                   .Include(x => x.ParticipatingOrganizations)
-                   .Where(c => !c.Locked && c.Published)
-                   .ToViewModel()
-                   .ToList();
+            return await _context.Campaigns
+                .Include(x => x.ManagingOrganization)
+                .Include(x => x.Events)
+                .Include(x => x.ParticipatingOrganizations)
+                .Where(c => !c.Locked && c.Published)
+                .Select(campaign => campaign.ToViewModel()).ToListAsync();
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Features/Events/EventByDateRangeQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Events/EventByDateRangeQuery.cs
@@ -5,7 +5,7 @@ using MediatR;
 
 namespace AllReady.Features.Events
 {
-    public class EventByDateRangeQuery : IRequest<IEnumerable<EventViewModel>>
+    public class EventByDateRangeQuery : IAsyncRequest<IEnumerable<EventViewModel>>
     {
         public DateTimeOffset EndDate { get; set; }
         public DateTimeOffset StartDate { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Features/Events/EventByDateRangeQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Events/EventByDateRangeQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Models;
 using AllReady.ViewModels.Event;
 using MediatR;
@@ -7,7 +8,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace AllReady.Features.Events
 {
-    public class EventByDateRangeQueryHandler : IRequestHandler<EventByDateRangeQuery, IEnumerable<EventViewModel>>
+    public class EventByDateRangeQueryHandler : IAsyncRequestHandler<EventByDateRangeQuery, IEnumerable<EventViewModel>>
     {
         private AllReadyContext _context;
 
@@ -16,14 +17,15 @@ namespace AllReady.Features.Events
             _context = context;
         }
 
-        public IEnumerable<EventViewModel> Handle(EventByDateRangeQuery message)
+        public async Task<IEnumerable<EventViewModel>> Handle(EventByDateRangeQuery message)
         {
             var start = message.StartDate;
             var end = message.EndDate;
 
-            return _context.Events.AsNoTracking()
+            return await _context.Events.AsNoTracking()
                 .Where(e => e.StartDateTime <= end && e.EndDateTime >= start)
-                .Select(e => new EventViewModel(e));
+                .Select(e => new EventViewModel(e))
+                .ToListAsync();
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Features/Events/EventsWithUnlockedCampaignsQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Events/EventsWithUnlockedCampaignsQuery.cs
@@ -4,7 +4,7 @@ using MediatR;
 
 namespace AllReady.Features.Events
 {
-    public class EventsWithUnlockedCampaignsQuery : IRequest<List<EventViewModel>>
+    public class EventsWithUnlockedCampaignsQuery : IAsyncRequest<List<EventViewModel>>
     {
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Features/Events/EventsWithUnlockedCampaignsQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Events/EventsWithUnlockedCampaignsQueryHandler.cs
@@ -1,12 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using AllReady.Models;
 using AllReady.ViewModels.Event;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace AllReady.Features.Events
 {
-    public class EventsWithUnlockedCampaignsQueryHandler : IRequestHandler<EventsWithUnlockedCampaignsQuery, List<EventViewModel>>
+    public class EventsWithUnlockedCampaignsQueryHandler : IAsyncRequestHandler<EventsWithUnlockedCampaignsQuery, List<EventViewModel>>
     {
         private readonly AllReadyContext dataContext;
 
@@ -15,12 +17,10 @@ namespace AllReady.Features.Events
             this.dataContext = dataContext;
         }
 
-        public List<EventViewModel> Handle(EventsWithUnlockedCampaignsQuery message)
+        public async Task<List<EventViewModel>> Handle(EventsWithUnlockedCampaignsQuery message)
         {
-            return dataContext.Events.Where(c => !c.Campaign.Locked)
-                .ToList() // get from SQL to C#
-                .Select(a => new EventViewModel(a))
-                .ToList();
+            var @events = await dataContext.Events.Where(c => !c.Campaign.Locked).ToListAsync();
+            return @events.Select(@event => new EventViewModel(@event)).ToList();
         }
     }
 }


### PR DESCRIPTION
- Update CampaignController/UnlockedCampaignsQuery/Handler and unit tests to use async
- update EventApiController and associated files to async
- Removing/re-writing unit tests that use "new Unit()" when mocking MediatR. Version 3.0 will not support being tested like this