### PR TITLE
Fix unwanted escaping in preq_install_guide

### DIFF
--- a/docs/prerequisite_install_guide/prerequisite_install_guide.md
+++ b/docs/prerequisite_install_guide/prerequisite_install_guide.md
@@ -161,7 +161,7 @@ http.proxy=[Your Proxy Server and Port]
 ```
 
 Behind the scenes these will commands created entries in the .gitconfig file that is located in
-your user profile directory.  On Windows this would be c:\users\[your idsid]. 
+your user profile directory.  On Windows this would be c:\users\\[your idsid]. 
 
  The file will look similar to:
 


### PR DESCRIPTION
The backslash isn't being shown.

The backslash in front of the square bracket is considered an escape character, so we need to escape the escape character.