### PR TITLE
Sync script/css versions

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
@@ -17,10 +17,10 @@
         <link rel="stylesheet" href="~/lib/fullcalendar/dist/fullcalendar.css" />
     </environment>
     <environment names="Staging,Production">
-        <link rel="stylesheet" href="//ajax.aspnetcdn.com/ajax/bootstrap/3.0.0/css/bootstrap.min.css"
+        <link rel="stylesheet" href="//ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/css/bootstrap.min.css"
               asp-fallback-href="~/lib/bootstrap/css/bootstrap.min.css" />
         <link rel="stylesheet" href="~/lib/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css" />
-        <link rel="stylesheet" href="//gitcdn.github.io/bootstrap-toggle/2.2.0/css/bootstrap-toggle.min.css"
+        <link rel="stylesheet" href="//gitcdn.github.io/bootstrap-toggle/2.2.2/css/bootstrap-toggle.min.css"
               asp-fallback-href="~/lib/bootstrap-toggle/css/bootstrap-toggle.css" />
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/fullcalendar/2.9.1/fullcalendar.min.css"
               asp-fallback-href="~/lib/fullcalendar/dist/fullcalendar.css" />
@@ -29,7 +29,7 @@
     </environment>
 
     @Html.Raw(JavaScriptSnippet.FullScript)
-   
+
     @RenderSection("styles", required: false)
 
     <script type="text/javascript">
@@ -95,11 +95,11 @@
                 asp-fallback-test="window.jQuery">
         </script>
         <script src="//ajax.aspnetcdn.com/ajax/knockout/knockout-3.3.0.js"></script>
-        <script src="//ajax.aspnetcdn.com/ajax/bootstrap/3.0.0/bootstrap.min.js"
+        <script src="//ajax.aspnetcdn.com/ajax/bootstrap/3.3.7/bootstrap.min.js"
                 asp-fallback-src="~/lib/bootstrap/dist/js/bootstrap.min.js"
                 asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.modal">
         </script>
-        <script src="//gitcdn.github.io/bootstrap-toggle/2.2.0/js/bootstrap-toggle.min.js"
+        <script src="//gitcdn.github.io/bootstrap-toggle/2.2.2/js/bootstrap-toggle.min.js"
                 asp-fallback-src="~/lib/bootstrap-toggle/js/bootstrap-toggle.js"
                 asp-fallback-test="window.jQuery && window.jQuery.fn && window.jQuery.fn.bootstrapToggle">
         </script>

--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_ValidationScriptsPartial.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_ValidationScriptsPartial.cshtml
@@ -7,7 +7,7 @@
             asp-fallback-src="~/lib/jquery-validation/jquery.validate.js"
             asp-fallback-test="window.jquery && window.jquery.validator">
     </script>
-    <script src="//ajax.aspnetcdn.com/ajax/mvc/5.2.3/jquery.validate.unobtrusive.min.js"
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-validation-unobtrusive/3.2.2/jquery.validate.unobtrusive.min.js"
             asp-fallback-src="~/lib/jquery-validation-unobtrusive/jquery.validate.unobtrusive.min.js"
             asp-fallback-test="window.jquery && window.jquery.validator && window.jquery.validator.unobtrusive">
     </script>

--- a/AllReadyApp/Web-App/AllReady/bower.json
+++ b/AllReadyApp/Web-App/AllReady/bower.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "description": "AllReady",
   "dependencies": {
-    "bootstrap": "~3.3.5",
-    "bootstrap-toggle": "2.2.1",
+    "bootstrap": "3.3.7",
+    "bootstrap-toggle": "2.2.2",
     "eonasdan-bootstrap-datetimepicker": "4.17.42",
     "bootstrap-touch-carousel": "0.8.0",
     "hammer.js": "2.0.4",
@@ -18,9 +18,9 @@
     "knockout-mapping" : "2.4.1",
     "moment": "2.10.6",
     "tota11y": "0.1.2",
-    "tinymce": "4.2.6",
+    "tinymce": "^4.5.4",
     "bootstrap-tagsinput": "0.6.1",
-    "d3": "3.5.9",
+    "d3": "^3.5.17",
     "jquery.maskedinput": "1.4.1",
     "system.js": "0.19.26",
     "fullcalendar": "2.9.1"


### PR DESCRIPTION
While setting up my dev environment I noticed that some script and style sheets included in `_Layout.cshtml` differ in version depending on whether it's Staging/Production or Development.

This PR brings them back in line.

**bootstrap**; Local (Bower) was giving `3.3.7`, while the CDN was pointing at `3.0.0`. Set them both at `3.3.7` and made the Bower version fixed.

**bootstrap-toggle**; local (Bower) was set to `2.2.1`, while the CDN was pointing at `2.2.0`. Updated them both to `2.2.2` as `2.2.1` isn't on the CDN for some reason.

**tinymce**; local (Bower) was set to `4.2.6`, while the CDN gives `4.5.4`. I set Bower to `4.5.4` as well, but added a caret, as the CDN one doesn't contain a version number and will always give the latest in the `4.x` range.

**d3**; local (Bower) was set to `3.5.9`, while the CDN gives `3.5.17`. I set Bower to `3.5.17` as well, but added a caret, as the CDN one doesn't contain an explicit version number and will always give the latest in the `3.x` range.

**jquery-validation-unobtrusive**;  local (Bower) is set to `3.2.2`, while the CDN was giving a different version, for which I was unable to determine the actual version. I switched to `3.3.2` on a different CDN.