### PR TITLE
Fix Aesop layout

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Home/Aesop.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Home/Aesop.cshtml
@@ -5,7 +5,7 @@
     <div class="col-md-3"></div>
     <div class="col-md-6">
        <h1>A Story by Aesop</h1>
-        <div class="logo-background">
+        <div style="background-color: #d58033;">
             <img src="~/images/Web-Logo.png" alt="Logo image for the project" class="img-responsive center-block" />
         </div>
        <h2>The Ant and the Grasshopper</h2>


### PR DESCRIPTION
The styles on the `logo-background` class are mangling the page layout.

As we only need to set a `background-color` after dropping that class I decided to use an inline style, but am happy to move it to `site.css` if that's preferred.