### PR TITLE
Show fail reason when volunteering fails

### DIFF
--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/event.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/event.js
@@ -159,7 +159,7 @@
                     self.changeTaskStatus("CanNotComplete", viewModel.NotCompleteReason, taskSave);
                 });
         };
-        
+
         self.confirmGoToLogin = function () {
             hideAlert();
             var title = "Confirm";
@@ -245,6 +245,7 @@
                 }
             }).fail(function(fail) {
                 self.isSubmitting(false);
+                self.validationErrors([fail.statusText]);
                 console.log(fail);
             });
         }
@@ -264,7 +265,7 @@
             clearTimeout(alertVm.timer);
         }
     }
- 
+
    CannotCompleteViewModel = function (task) {
         var self = this;
         self.Name = task.Name;


### PR DESCRIPTION
When volunteering for an event and the request to the server fails for whatever reason there is no visual indication that something went wrong at all.

This PR adds the `statusText` from the failed request to the `validationErrors` to at least show that something went wrong. 

