### PR TITLE
Make typescript compile again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.min.js
 *.min.css
 
+#ignore map files
+*.js.map
+*.css.map
+
 #Ignore any leftover PrepOpsApp files
 PrepOpsApp
 

--- a/AllReadyApp/Web-App/AllReady/gulpfile.js
+++ b/AllReadyApp/Web-App/AllReady/gulpfile.js
@@ -3,59 +3,44 @@ var gulp = require("gulp"),
     rimraf = require("rimraf"),
     concat = require("gulp-concat"),
     cssmin = require("gulp-cssmin"),
-    uglify = require("gulp-uglify"),
     ts = require('gulp-typescript'),
     project = require("./project.json");
+
+// https://www.npmjs.com/package/gulp-typescript
+// http://weblogs.asp.net/dwahlin/creating-a-typescript-workflow-with-gulp
+var tsProject = ts.createProject('tsconfig.json');
 
 var paths = {
     webroot: "./" + project.webroot + "/"
 };
 
-paths.js = paths.webroot + "js/**/*.js";
-paths.minJs = paths.webroot + "js/**/*.min.js";
+paths.ts = paths.webroot + "{ts,js}/**/*.ts";
 paths.css = paths.webroot + "css/**/*.css";
 paths.minCss = paths.webroot + "css/**/*.min.css";
-paths.concatJsDest = paths.webroot + "js/site.min.js";
 paths.concatCssDest = paths.webroot + "css/site.min.css";
 
-gulp.task("clean:js", function (cb) {
-    rimraf(paths.concatJsDest, cb);
-});
 
-gulp.task("clean:css", function (cb) {
+gulp.task("clean", function (cb) {
     rimraf(paths.concatCssDest, cb);
 });
 
-gulp.task("clean", ["clean:js", "clean:css"]);
-
-gulp.task("min:js", function () {
-    return gulp.src([paths.js, "!" + paths.minJs], { base: "." })
-        .pipe(concat(paths.concatJsDest))
-        .pipe(uglify())
-        .pipe(gulp.dest("."));
+gulp.task('build:ts', function () {
+    var tsResult = tsProject.src()
+        .pipe(tsProject())
+        .js.pipe(gulp.dest(paths.webroot));
 });
 
-gulp.task("min:css", function () {
+gulp.task("build:css", function () {
     return gulp.src([paths.css, "!" + paths.minCss])
         .pipe(concat(paths.concatCssDest))
         .pipe(cssmin())
         .pipe(gulp.dest("."));
 });
 
-gulp.task("min", ["min:js", "min:css"]);
+gulp.task("build", ["build:ts", "build:css"]);
+gulp.task("min", ["build"]);
 
 gulp.task("watch", function () {
-    gulp.watch(paths.css, ["min"]);
-})
-
-
-//https://www.npmjs.com/package/gulp-typescript
-//http://weblogs.asp.net/dwahlin/creating-a-typescript-workflow-with-gulp
-var tsProject = ts.createProject('tsconfig.json');
-
-gulp.task('typescript:Build', function () {
-    var tsResult = tsProject.src() // instead of gulp.src(...) 
-        .pipe(ts(tsProject));
-    return tsResult.js.pipe(gulp.dest('wwwroot/release'));
+    gulp.watch([paths.css, paths.ts], ["build"]);
 });
 

--- a/AllReadyApp/Web-App/AllReady/package.json
+++ b/AllReadyApp/Web-App/AllReady/package.json
@@ -5,13 +5,15 @@
   "license": "MIT",
   "repository": "HTBox/allReady",
   "devDependencies": {
+    "@types/jquery": "2.0.40",
+    "bingmaps": "1.0.13",
+    "bower": "1.6.5",
     "gulp": "3.8.11",
     "gulp-concat": "2.5.2",
     "gulp-cssmin": "0.1.7",
-    "gulp-uglify": "1.2.0",
-    "bower": "1.6.5",
+    "gulp-sourcemaps": "1.6.0",
+    "gulp-typescript": "3.1.5",
     "rimraf": "2.2.8",
-    "gulp-typescript": "2.9.2",
-    "gulp-sourcemaps": "1.6.0"
+    "typescript": "2.2.1"
   }
 }

--- a/AllReadyApp/Web-App/AllReady/tsconfig.json
+++ b/AllReadyApp/Web-App/AllReady/tsconfig.json
@@ -1,15 +1,19 @@
 {
-    "compilerOptions": {
-        "noImplicitAny": false,
-        "noEmitOnError": true,
-        "removeComments": false,
-        "sourceMap": true,
-        "module": "system",
-        "target": "es5"
-    },
+  "compileOnSave": true,
+  "compilerOptions": {
+    "module": "system",
+    "noEmitOnError": true,
+    "noImplicitAny": false,
+    "removeComments": false,
+    "sourceMap": true,
+    "target": "es5"
+  },
+  "include": [
+    "wwwroot/js/**/*.ts",
+    "wwwroot/ts/**/*.ts"
+  ],
   "exclude": [
     "node_modules",
-    "wwwroot",
     "bin/output"
   ]
 }

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/site.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/site.js
@@ -1,48 +1,43 @@
-﻿var geoHelper = function (positionReceivedCallback) {
-    console.log('geoHelper created');
-
+///<reference path="../../node_modules/bingmaps/scripts/MicrosoftMaps/Microsoft.Maps.d.ts" />
+var geoHelper = function (positionReceivedCallback) {
+    console.log("geoHelper created");
     this.getMyLocation = function () {
         navigator.geolocation.getCurrentPosition(positionReceivedCallback);
-    }
-}
-
+    };
+};
 var BingMapKey = "ArclGe51CDYUCjW2tcjeuCSxXDg0z4_NFRCmVMpnpMY0qGUvPBazQIp9AjDgm2kv";
-
 var renderBingMap = function (divIdForMap, positionCoordsList) {
     if (positionCoordsList) {
         var bingMap = createBingMap(divIdForMap);
         var microsoftMapsLocations = createMapLocationsAndAddPushPinsToMap(bingMap, positionCoordsList);
-        setMapCenterAndZoom(bingMap, microsoftMapsLocations);
+        setMapCenterAndZoom(bingMap, microsoftMapsLocations, 10);
     }
-}
-
-var renderRequestsMap = function(divIdForMap, requestData) {
+};
+var renderRequestsMap = function (divIdForMap, requestData) {
     if (requestData) {
         var bingMap = createBingMap(divIdForMap);
         addRequestPins(bingMap, requestData);
     }
-}
-
+};
 var getGeoCoordinates = function (address1, address2, city, state, postalCode, country, callbackFunction) {
     var lookupAddress = "";
-    lookupAddress = lookupAddress + (address1 != undefined || address1 != null ? " " + address1 : "");
-    lookupAddress = lookupAddress + (address2 != undefined || address2 != null ? " " + address2 : "");
-    lookupAddress = lookupAddress + (city != undefined || city != null ? ", " + city : "");
-    lookupAddress = lookupAddress + (state != undefined || state != null ? " " + state : "");
-    lookupAddress = lookupAddress + (postalCode != undefined || postalCode != null ? " " + postalCode : "");
-    lookupAddress = lookupAddress + (country != undefined || country != null ? " " + country : "");
-    if (lookupAddress.trim() == "") {
+    lookupAddress = lookupAddress + (address1 !== undefined || address1 !== null ? " " + address1 : "");
+    lookupAddress = lookupAddress + (address2 !== undefined || address2 !== null ? " " + address2 : "");
+    lookupAddress = lookupAddress + (city !== undefined || city !== null ? ", " + city : "");
+    lookupAddress = lookupAddress + (state !== undefined || state !== null ? " " + state : "");
+    lookupAddress = lookupAddress + (postalCode !== undefined || postalCode !== null ? " " + postalCode : "");
+    lookupAddress = lookupAddress + (country !== undefined || country !== null ? " " + country : "");
+    if (lookupAddress.trim() === "") {
         return;
     }
     var geocodeRequest = "http://dev.virtualearth.net/REST/v1/Locations?query=" +
         encodeURIComponent(lookupAddress) +
         "&key=" + BingMapKey;
-
     $.ajax({
         url: geocodeRequest,
         dataType: "jsonp",
         jsonp: "jsonp",
-        success: function(result) {
+        success: function (result) {
             var geoCoordinates = { latitude: 0, longitude: 0 };
             if (result.resourceSets[0].estimatedTotal > 0) {
                 geoCoordinates = {
@@ -52,52 +47,54 @@ var getGeoCoordinates = function (address1, address2, city, state, postalCode, c
             }
             callbackFunction(geoCoordinates);
         },
-        error: function(e) {
+        error: function (e) {
             alert(e.statusText);
         }
     });
-}
-
+};
 function createBingMap(divIdForMap) {
-    return new Microsoft.Maps.Map(
-        document.getElementById(divIdForMap), {
+    "use strict";
+    return new Microsoft.Maps.Map(document.getElementById(divIdForMap), {
         credentials: BingMapKey
     });
 }
-
 function createMapLocationsAndAddPushPinsToMap(bingMap, positionCoordsList) {
+    "use strict";
     var microsoftMapsLocations = [];
     $.each(positionCoordsList, function (index, LocationData) {
         var microsoftMapsLocation = new Microsoft.Maps.Location(LocationData.latitude, LocationData.longitude);
         microsoftMapsLocations.push(microsoftMapsLocation);
-        var pushpin = new Microsoft.Maps.Pushpin();
-        pushpin.setLocation(microsoftMapsLocation);
+        var pushpin = new Microsoft.Maps.Pushpin(microsoftMapsLocation);
         bingMap.entities.push(pushpin);
     });
     return microsoftMapsLocations;
 }
-
 function addRequestPins(bingMap, requestData) {
+    "use strict";
     var locations = [];
     $.each(requestData, function (index, data) {
         var location = new Microsoft.Maps.Location(data.lat, data.long);
         locations.push(location);
         var order = index + 1;
-        var pin = new Microsoft.Maps.Pushpin(location, { title: data.name, color: data.color, text: order.toString() });
+        var pin = new Microsoft.Maps.Pushpin(location, {
+            title: data.name, color: data.color, text: order.toString()
+        });
         bingMap.entities.push(pin);
     });
     var rect = Microsoft.Maps.LocationRect.fromLocations(locations);
     bingMap.setView({ bounds: rect, padding: 80 });
 }
-
 function setMapCenterAndZoom(bingMap, microsoftMapsLocations, zoom) {
+    "use strict";
     var options = bingMap.getOptions();
     options.zoom = zoom || 10;
     if (microsoftMapsLocations.length === 1) {
         options.center = microsoftMapsLocations[0];
-    } else if(microsoftMapsLocations.length > 1) {
+    }
+    else if (microsoftMapsLocations.length > 1) {
         options.bounds = Microsoft.Maps.LocationRect.fromLocations(microsoftMapsLocations);
         options.padding = 50;
     }
     bingMap.setView(options);
 }
+//# sourceMappingURL=site.js.map

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/site.ts
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/site.ts
@@ -1,0 +1,114 @@
+﻿///<reference path="../../node_modules/bingmaps/scripts/MicrosoftMaps/Microsoft.Maps.d.ts" />
+
+var geoHelper: Function = function (positionReceivedCallback: PositionCallback): void {
+    console.log("geoHelper created");
+
+    this.getMyLocation = function (): void {
+        navigator.geolocation.getCurrentPosition(positionReceivedCallback);
+    };
+};
+
+var BingMapKey: string = "ArclGe51CDYUCjW2tcjeuCSxXDg0z4_NFRCmVMpnpMY0qGUvPBazQIp9AjDgm2kv";
+
+var renderBingMap: Function = function (divIdForMap: string, positionCoordsList: any): void {
+    if (positionCoordsList) {
+        var bingMap: Microsoft.Maps.Map = createBingMap(divIdForMap);
+        var microsoftMapsLocations: Microsoft.Maps.Location[] = createMapLocationsAndAddPushPinsToMap(bingMap, positionCoordsList);
+        setMapCenterAndZoom(bingMap, microsoftMapsLocations, 10);
+    }
+};
+
+var renderRequestsMap: Function = function (divIdForMap: string, requestData: any[]): void {
+    if (requestData) {
+        var bingMap: Microsoft.Maps.Map = createBingMap(divIdForMap);
+        addRequestPins(bingMap, requestData);
+    }
+};
+
+var getGeoCoordinates: Function = function (address1: string, address2: string, city: string, state: string, postalCode:string, country: string, callbackFunction: Function): void {
+    var lookupAddress: string = "";
+    lookupAddress = lookupAddress + (address1 !== undefined || address1 !== null ? " " + address1 : "");
+    lookupAddress = lookupAddress + (address2 !== undefined || address2 !== null ? " " + address2 : "");
+    lookupAddress = lookupAddress + (city !== undefined || city !== null ? ", " + city : "");
+    lookupAddress = lookupAddress + (state !== undefined || state !== null ? " " + state : "");
+    lookupAddress = lookupAddress + (postalCode !== undefined || postalCode !== null ? " " + postalCode : "");
+    lookupAddress = lookupAddress + (country !== undefined || country !== null ? " " + country : "");
+    if (lookupAddress.trim() === "") {
+        return;
+    }
+    var geocodeRequest: string = "http://dev.virtualearth.net/REST/v1/Locations?query=" +
+        encodeURIComponent(lookupAddress) +
+        "&key=" + BingMapKey;
+
+    $.ajax({
+        url: geocodeRequest,
+        dataType: "jsonp",
+        jsonp: "jsonp",
+        success: function (result: any): void {
+            var geoCoordinates: any = { latitude: 0, longitude: 0 };
+            if (result.resourceSets[0].estimatedTotal > 0) {
+                geoCoordinates = {
+                    latitude: result.resourceSets[0].resources[0].geocodePoints[0].coordinates[0],
+                    longitude: result.resourceSets[0].resources[0].geocodePoints[0].coordinates[1]
+                };
+            }
+            callbackFunction(geoCoordinates);
+        },
+        error: function (e: JQueryXHR): void {
+            alert(e.statusText);
+        }
+    });
+};
+
+function createBingMap(divIdForMap: string): Microsoft.Maps.Map {
+    "use strict";
+
+    return new Microsoft.Maps.Map(
+        document.getElementById(divIdForMap), {
+        credentials: BingMapKey
+    });
+}
+
+function createMapLocationsAndAddPushPinsToMap(bingMap: Microsoft.Maps.Map, positionCoordsList: any[]): Microsoft.Maps.Location[] {
+    "use strict";
+
+    var microsoftMapsLocations: Microsoft.Maps.Location[] = [];
+    $.each(positionCoordsList, function (index: number, LocationData: any): void {
+        var microsoftMapsLocation: Microsoft.Maps.Location = new Microsoft.Maps.Location(LocationData.latitude, LocationData.longitude);
+        microsoftMapsLocations.push(microsoftMapsLocation);
+        var pushpin: Microsoft.Maps.Pushpin = new Microsoft.Maps.Pushpin(microsoftMapsLocation);
+        bingMap.entities.push(pushpin);
+    });
+    return microsoftMapsLocations;
+}
+
+function addRequestPins(bingMap: Microsoft.Maps.Map, requestData: any[]): void {
+    "use strict";
+
+    var locations: Microsoft.Maps.Location[] = [];
+    $.each(requestData, function (index: number, data: any): void {
+        var location: Microsoft.Maps.Location = new Microsoft.Maps.Location(data.lat, data.long);
+        locations.push(location);
+        var order: number = index + 1;
+        var pin: Microsoft.Maps.Pushpin = new Microsoft.Maps.Pushpin(location, {
+            title: data.name, color: data.color, text: order.toString()
+        });
+        bingMap.entities.push(pin);
+    });
+    var rect: Microsoft.Maps.LocationRect = Microsoft.Maps.LocationRect.fromLocations(locations);
+    bingMap.setView({ bounds: rect, padding:80 });
+}
+
+function setMapCenterAndZoom(bingMap: Microsoft.Maps.Map, microsoftMapsLocations: Microsoft.Maps.Location[], zoom: number): void {
+    "use strict";
+
+    var options: any = bingMap.getOptions();
+    options.zoom = zoom || 10;
+    if (microsoftMapsLocations.length === 1) {
+        options.center = microsoftMapsLocations[0];
+    } else if(microsoftMapsLocations.length > 1) {
+        options.bounds = Microsoft.Maps.LocationRect.fromLocations(microsoftMapsLocations);
+        options.padding = 50;
+    }
+    bingMap.setView(options);
+}

--- a/AllReadyApp/Web-App/AllReady/wwwroot/ts/mappingTools.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/ts/mappingTools.js
@@ -1,0 +1,83 @@
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var HTBox;
+    return {
+        setters: [],
+        execute: function () {
+            (function (HTBox) {
+                var maps;
+                (function (maps) {
+                    var geoMaps = Microsoft.Maps;
+                    var BingMapKey = "ArclGe51CDYUCjW2tcjeuCSxXDg0z4_NFRCmVMpnpMY0qGUvPBazQIp9AjDgm2kv";
+                    var Location = (function () {
+                        function Location(config) {
+                            for (var p in config) {
+                                if (config.hasOwnProperty(p)) {
+                                    this[p] = config[p];
+                                }
+                            }
+                        }
+                        return Location;
+                    }());
+                    maps.Location = Location;
+                    var MapRender = (function () {
+                        function MapRender(divIdForMap) {
+                            this.bingMap = new geoMaps.Map(document.getElementById(divIdForMap), {
+                                credentials: BingMapKey
+                            });
+                        }
+                        ;
+                        MapRender.prototype.getMyLocation = function (callback) {
+                            navigator.geolocation.getCurrentPosition(callback);
+                        };
+                        MapRender.prototype.drawLocations = function (locations) {
+                            var bingMap = this.bingMap;
+                            var center = bingMap.getCenter();
+                            var pushpin = new geoMaps.Pushpin(center, null);
+                            locations.forEach(function (loc) {
+                                pushpin.setLocation(new geoMaps.Location(loc.latitude, loc.longitude));
+                            });
+                            bingMap.entities.push(pushpin);
+                            bingMap.setView({
+                                zoom: 10,
+                                center: center
+                            });
+                        };
+                        MapRender.prototype.getGeoCoordinates = function (address1, address2, city, state, postalCode, country, callbackFunction) {
+                            var lookupAddress = "";
+                            lookupAddress = lookupAddress + (address1 != undefined || address1 != null ? " " + address1 : null);
+                            lookupAddress = lookupAddress + (address2 != undefined || address2 != null ? " " + address2 : null);
+                            lookupAddress = lookupAddress + (city != undefined || city != null ? " " + city : null);
+                            lookupAddress = lookupAddress + (state != undefined || state != null ? " " + state : null);
+                            lookupAddress = lookupAddress + (postalCode != undefined || postalCode != null ? " " + postalCode : null);
+                            lookupAddress = lookupAddress + (country != undefined || country != null ? " " + country : null);
+                            var geocodeRequest = "http://dev.virtualearth.net/REST/v1/Locations?query=" +
+                                encodeURIComponent(lookupAddress) +
+                                "&key=" + BingMapKey;
+                            $.ajax({
+                                url: geocodeRequest,
+                                dataType: "jsonp",
+                                jsonp: "jsonp",
+                                success: function (result) {
+                                    var geoCoordinates = {
+                                        latitude: result.resourceSets[0].resources[0].geocodePoints[0].coordinates[0],
+                                        longitude: result.resourceSets[0].resources[0].geocodePoints[0].coordinates[1]
+                                    };
+                                    callbackFunction(geoCoordinates);
+                                },
+                                error: function (e) {
+                                    alert(e.statusText);
+                                }
+                            });
+                        };
+                        return MapRender;
+                    }());
+                    maps.MapRender = MapRender;
+                })(maps = HTBox.maps || (HTBox.maps = {}));
+            })(HTBox || (HTBox = {}));
+            exports_1("HTBox", HTBox);
+        }
+    };
+});
+//# sourceMappingURL=mappingTools.js.map

--- a/AllReadyApp/Web-App/AllReady/wwwroot/ts/shapelist.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/ts/shapelist.js
@@ -1,0 +1,31 @@
+System.register(["./shapes"], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var sss, ShapeUser, rect;
+    return {
+        setters: [
+            function (sss_1) {
+                sss = sss_1;
+            }
+        ],
+        execute: function () {
+            // This works!
+            (function (ShapeUser) {
+                var User = (function () {
+                    function User() {
+                        this.rects = new sss.Shapes.Rectangle(10, 4);
+                    }
+                    User.prototype.greet = function () {
+                        var x = new sss.Shapes.Rectangle(10, 4);
+                        return this.rects;
+                    };
+                    return User;
+                }());
+                ShapeUser.User = User;
+            })(ShapeUser || (ShapeUser = {}));
+            exports_1("ShapeUser", ShapeUser);
+            rect = new sss.Shapes.Rectangle(10, 4);
+        }
+    };
+});
+//# sourceMappingURL=shapelist.js.map

--- a/AllReadyApp/Web-App/AllReady/wwwroot/ts/shapes.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/ts/shapes.js
@@ -1,0 +1,26 @@
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var Shapes;
+    return {
+        setters: [],
+        execute: function () {
+            (function (Shapes) {
+                var Rectangle = (function () {
+                    function Rectangle(height, width) {
+                        this.height = height;
+                        this.width = width;
+                        this.area = width * height;
+                    }
+                    Rectangle.prototype.getArea = function () {
+                        return this.area;
+                    };
+                    return Rectangle;
+                }());
+                Shapes.Rectangle = Rectangle;
+            })(Shapes || (Shapes = {}));
+            exports_1("Shapes", Shapes);
+        }
+    };
+});
+//# sourceMappingURL=shapes.js.map


### PR DESCRIPTION
After reading #284 I decided to take a stab at seeing if I can get Typescript to work (again).

Although this PR is mergable, I consider it a bit of a Work in Progress. But I think the discussion about maybe switching to Typescript works better if you have some actual code to point at. :)

Things I did:
- Removed building of the `site.min.js` from the gulpfile. It isn't used anywhere in the site and it was confusing that you have a `site.js` (which is used) that doesn't correspond with `site.min.js`, but is actually just a small part of that file's contents.
- Fixed `tsconfig.json` so it doesn't give an error anymore and actually compiles/transpiles stuff.
- Added compiled/transpiled versions of the files in `wwwroot/ts`.
- Renamed `wwwroot/js/site.js` to `wwwroot/js/site.ts` as a sample. You can see that the now generated `site.js` closely matches the previous version.
- Tweaked `wwwroot/js/site.ts` a bit to sprinkle some Typescript goodness on it. (And to get rid of the many warnings it was giving.)
- Added Typings for `jquery` and `bingmaps`. Had to reference the latter one manually from `site.ts` as it delivers it `.d.ts` in a non-standard way.
- Put the `devDependencies` in `packages.json` in alphabetical order, updated `gulp-typescript`, added the `typescript` dependency and dropped the now unused `gulp-minify` dependency.
- Made a new `gulp build` task that transpiles the `.ts` files (and incorporates the old task that minifies the `site.css` file), so people who don't use Visual Studio can use it as well.
- Aliased the old `gulp min` task to `gulp build` for backwards compatibility in case people depend on the old name.

Questions I have:
- Are the files in `webroot/ts` used? I can't find any reference to them and they were missing their `.js` counterparts
- Do we want bundling and minification for the resulting `.js` files?
- What settings do we want to use in `tsconfig.json`?
- Do we want the generated `.js` files in sourcecontrol?