### PR TITLE
Issue-1908 Fixed the graphic issue on safari by updating CSS

### DIFF
--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -20,13 +20,14 @@ body {
 
 .logo-background {
     background-color: #d58033;
-    position: relative;
     width: 100vw;
     left: -25px;
     color: #fff;
     padding-bottom: 20px;
     margin-top: -20px;
     margin-bottom: 20px;
+    margin-right: -50px;
+    margin-left: -50px;
 }
 
 /* Set widths on the form inputs since otherwise they're 100% wide */


### PR DESCRIPTION
Fixed #1908 by adding a left and right margin to -50 px and removing position attribute from logo-background in site.css for a home page. Checked on safari browser 5.1.7, chrome, firefox, and IE