### PR TITLE
Fixing campaign progress bar

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/_CampaignGoal.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/_CampaignGoal.cshtml
@@ -12,22 +12,15 @@
     <div class="panel-body">
         @if (Model.GoalType == GoalType.Numeric)
             {
-            <div class="progress">
-                <div class="progress-bar" role="progressbar"
-                     aria-valuenow="@Model.PercentComplete"
-                     aria-valuemin="@Model.CurrentGoalLevel"
-                     aria-valuemax="@Model.NumericGoal"
-                     style="width: @Model.PercentComplete%;">
-                    @if (Model.PercentComplete > 30)
-                    {
-                        <text>@Model.CurrentGoalLevel / @Model.NumericGoal</text>
-                    }
-                    else
-                    {
-                        <text>@Model.PercentComplete</text>
-                    }
+                <div class="progress">
+                    <div class="progress-bar" role="progressbar"
+                         aria-valuenow="@Model.PercentComplete"
+                         aria-valuemin="@Model.CurrentGoalLevel"
+                         aria-valuemax="@Model.NumericGoal"
+                         style="width: @Model.PercentComplete%;">
+                    </div>
                 </div>
-            </div>
-        }
+                <text>@Model.CurrentGoalLevel / @Model.NumericGoal</text>
+            }
     </div>
 </div>


### PR DESCRIPTION
Fixes #1883

Original code displayed percentage complete if it was under 30% and then CurrentGoalLevel / NumericGoal for anything over so figures were confusing.

Changed to only show CurrentGoalLevel / NumericGoal and moved this text below the progress bar as text won't always fit in the progress bar