### PR TITLE
Remove Campaign Goals from campaign edit page in Admin

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CampaignSummaryQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/CampaignSummaryQueryHandler.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using AllReady.Areas.Admin.Extensions;
 using AllReady.Areas.Admin.ViewModels.Campaign;
@@ -50,7 +49,6 @@ namespace AllReady.Areas.Admin.Features.Campaigns
                     StartDate = campaign.StartDateTime,
                     EndDate = campaign.EndDateTime,
                     Location = campaign.Location.ToEditModel(),
-                    CampaignGoals = campaign.CampaignGoals ?? new List<CampaignGoal>(),
                     Headline = campaign.Headline
                 };
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/EditCampaignCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/EditCampaignCommandHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using AllReady.Areas.Admin.Models;
 using AllReady.Areas.Admin.ViewModels.Organization;
 using AllReady.Extensions;
 using AllReady.Models;
@@ -41,7 +40,6 @@ namespace AllReady.Areas.Admin.Features.Campaigns
             campaign.ImageUrl = message.Campaign.ImageUrl;
 
             CreateUpdateOrDeleteCampaignPrimaryContact(campaign, message.Campaign);
-            CreateUpdateOrDeleteCampaignGoals(campaign, message.Campaign.CampaignGoals);
             campaign.Location = campaign.Location.UpdateModel(message.Campaign.Location);
 
             campaign.Featured = message.Campaign.Featured;
@@ -53,24 +51,6 @@ namespace AllReady.Areas.Admin.Features.Campaigns
             await _context.SaveChangesAsync();
 
             return campaign.Id;
-        }
-
-        private void CreateUpdateOrDeleteCampaignGoals(Campaign campaign, IList<CampaignGoal> editModelCampaignGoals)
-        {
-            var originalCampaignGoals = campaign.CampaignGoals ?? (campaign.CampaignGoals = new List<CampaignGoal>());
-            originalCampaignGoals.RemoveAll(original => !editModelCampaignGoals.Select(c => c.Id).Contains(original.Id));
-
-            foreach (var editModel in editModelCampaignGoals)
-            {
-                var originalGoal = (editModel.Id == 0 ? null : originalCampaignGoals.FirstOrDefault(i => i.Id == editModel.Id)) ?? new CampaignGoal();
-                if (originalGoal.Id == 0)
-                {
-                    originalCampaignGoals.Add(originalGoal);
-                    originalGoal.Campaign = campaign;
-                    originalGoal.CampaignId = campaign.Id;
-                }
-                originalGoal.UpdateModel(editModel);
-            }
         }
 
         private void CreateUpdateOrDeleteCampaignPrimaryContact(Campaign campaign, IPrimaryContactViewModel contactModel)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Campaign/CampaignSummaryViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Campaign/CampaignSummaryViewModel.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using AllReady.Areas.Admin.ViewModels.Organization;
 using AllReady.Areas.Admin.ViewModels.Shared;
-using AllReady.Models;
 using AllReady.ModelBinding;
 
 namespace AllReady.Areas.Admin.ViewModels.Campaign
@@ -52,8 +50,6 @@ namespace AllReady.Areas.Admin.ViewModels.Campaign
         [DisplayFormat(ApplyFormatInEditMode = true, DataFormatString = "{0:d}")]
         [AdjustToTimezone(TimeZoneIdPropertyName = nameof(TimeZoneId))]
         public DateTimeOffset EndDate { get; set; }
-
-        public List<CampaignGoal> CampaignGoals { get; set; } = new List<CampaignGoal>();
 
         [UIHint("Location")]
         public LocationEditViewModel Location { get; set; }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
@@ -244,27 +244,6 @@
                         <span asp-validation-for="PrimaryContactEmail" class="text-danger"></span>
                     </div>
                 </div>
-
-                @if (isEdit)
-                {
-                    <h3>Campaign Goals</h3>
-                    <div class="row">
-                        <div class="col-md-5">
-                            <div class="alert alert-warning">
-                                <p>
-                                    <strong>Define your campaign's goals in a way that will inspire people to help you reach those goals.</strong>
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                    
-                    foreach (var campaignGoal in Model.CampaignGoals)
-                    {
-                        <div class="col-md-4">
-                            @Html.Partial("_CampaignGoal", campaignGoal)
-                        </div>
-                    }
-                }
             </div>
             <div class="row">
                 <div class="col-md-12">


### PR DESCRIPTION
Fixes #1902 

Removed Campaign Goals from the admin campaign Edit.cshtml.  Also removed CampaignGoals property from the CampaignSummaryViewModel.  Updated CampaignSummaryQueryHandler and EditCampaignCommandHandler to remove references to the CampaignGoals property in the view model.