### PR TITLE
#1870 - Account page - rename external links to social media logins

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -151,7 +151,7 @@
             else
             {
                 <div class="form-group">
-                    <label class="control-label col-md-2">External logins</label>
+                    <label class="control-label col-md-2">Social media logins</label>
                     <div class="col-md-10">
                         <p class="form-control-static">
                             @Model.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/ManageLogins.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/ManageLogins.cshtml
@@ -3,7 +3,7 @@
 @using AllReady.ViewModels.Manage
 
 @{
-    ViewData["Title"] = "Manage your external logins";
+    ViewData["Title"] = "Manage your social media logins";
 }
 
 <h2>@ViewData["Title"].</h2>


### PR DESCRIPTION
Fixes #1870

I've updated the account management page like so:
![image](https://cloud.githubusercontent.com/assets/24384148/24072968/508b712c-0be7-11e7-8668-e0f5bf18618e.png)

I've also update the page you get when you click on the manage link:
![image](https://cloud.githubusercontent.com/assets/24384148/24072974/73722b5e-0be7-11e7-9ca6-fa3dd728759a.png)
