### PR TITLE
#1882 - FIx issue with campaign preview page not loading

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/_CampaignPreview.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/_CampaignPreview.cshtml
@@ -149,36 +149,5 @@
             <td><label asp-for="PrimaryContactEmail" class="col-md-4 control-label"></label></td>
             <td>@Model.PrimaryContactEmail</td>
         </tr>
-        @if (isEdit)
-        {
-            <tr>
-                <td><label class="col-md-4 control-label">Display Goal</label></td>
-                <td>@(Model.CampaignGoal.Display == true ? "Yes" : "No")</td>
-            </tr>
-
-            <tr>
-                <td><label class="col-md-4 control-label">Campaign Goal</label></td>
-                <td>@Model.CampaignGoal.TextualGoal</td>
-            </tr>
-
-            <tr>
-                <td><label class="col-md-4 control-label">Goal Type</label></td>
-                <td>@Model.CampaignGoal.GoalType</td>
-            </tr>
-                    @if (Model.CampaignGoal.GoalType == GoalType.Numeric)
-                    {
-                        <tr>
-                            <td><label class="col-md-4 control-label">Current Goal Level</label></td>
-                            <td>@Model.CampaignGoal.CurrentGoalLevel</td>
-                        </tr>
-
-                        <tr>
-                            <td><label class="col-md-4 control-label">Numeric Goal Goal</label></td>
-                            <td>@Model.CampaignGoal.NumericGoal</td>
-                        </tr>
-                    }
-        }
-
     </tbody>
-
 </table>


### PR DESCRIPTION
Fixes #1882
The preview page was failing to load because the template was making reference to a model property (CampaignGoals) that didn't exist.  

I've fixed the issue by removing the reference to CampaignGoals from the template. Whilst this is not ideal, I've had to do this because the current design of the 'preview' UI is not appropriate for displaying multiple campaign goals. I'm not 100% sure what the purpose of the 'preview' screen is in it's current form....it doesn't really seem to add any valuable functionality for the user. Perhaps it would be better if we actually rendered the campaign as it will be displayed on the site?

Also - it would be nice if template issues like this caused a build error. From what I understand, pre compiled templates have been added back into core 1.1.0. Could be a nice to have?

