### PR TITLE
remove new(er) sdk so we can continue to build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ cache:
 install:
  - cmd: nuget sources add -Name api.nuget.org -Source https://api.nuget.org/v3/index.json
  - choco install firefox
+ - rd /s /q "C:\Program Files\dotnet\sdk\1.0.1"
  
 before_build:
  - cmd: dotnet restore AllReadyApp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+#remove the noted line below when upgrading to vs2017
 version: 1.0.0.{build}.{branch}
 
 nuget:
@@ -17,6 +18,7 @@ install:
  - cmd: nuget sources add -Name api.nuget.org -Source https://api.nuget.org/v3/index.json
  - choco install firefox
  - rd /s /q "C:\Program Files\dotnet\sdk\1.0.1"
+ # remove the above line on upgrade to vs2017
  
 before_build:
  - cmd: dotnet restore AllReadyApp


### PR DESCRIPTION
per this document https://github.com/appveyor/ci/issues/1377#issuecomment-287644271 using the total hack of removing the new sdk before we build.  This will buy us time before we move to vs2017 which is on the horizon for the next 30 days or so