### PR TITLE
Fixes #249 Add button to populate contact info from organization on Campaign Edit page

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
@@ -61,18 +61,6 @@
 
         <form asp-controller="Campaign" asp-area="Admin" asp-action="Edit" id="campaign-form" method="post" enctype="multipart/form-data">
 
-            @if (User.IsUserType(UserType.OrgAdmin))
-            {
-                <button type="button"
-                        id="btnGetContactInfo"
-                        class="btn btn-info"
-                        data-toggle="modal"
-                        data-target="#confirmContactModal"
-                        title="Copy Contact Information from Organization">
-                    Copy Contact Info
-                </button>
-            }
-
             <div class="form-horizontal">
 
                 <div asp-validation-summary="All" class="text-danger"></div>
@@ -213,6 +201,15 @@
                         </div>
                     </div>
                 </div>
+                <hr />
+                <button type="button"
+                        id="btnGetContactInfo"
+                        class="btn btn-info"
+                        data-toggle="modal"
+                        data-target="#confirmContactModal"
+                        title="Information copied from selected organisation.">
+                    Copy Location and Primary Contact
+                </button>
                 <h3>Location</h3>
                 @Html.EditorFor(m => m.Location)
                 <h3>Primary Contact</h3>


### PR DESCRIPTION
Fixes #249 

Most of the work had already been done.  
- **Copy** button only appeared if the logged in user was an **OrgAdmin**.  It did not appear for the **SiteAdmin**.  
- Moved the button further down the page closer to _Location_ and _Primary Contact_.
- Changed text on button and tool tip.