### PR TITLE
Display Friendly Error Pages

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ErrorControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ErrorControllerTests.cs
@@ -1,0 +1,25 @@
+﻿using AllReady.Controllers;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace AllReady.UnitTest.Controllers
+{
+    public class ErrorControllerTests
+    {
+        [Fact]
+        public void ErrorReturnsTheCorrectView_WhenStatusCodeIsNull()
+        {
+            var controller = new ErrorController();
+            var result = (ViewResult) controller.Error(null);
+            Assert.Equal("~/Views/Shared/Error.cshtml", result.ViewName);
+        }
+
+        [Fact]
+        public void ErrorReturnsTheCorrectView_WhenStatusCodeIs404()
+        {
+            var controller = new ErrorController();
+            var result = (ViewResult) controller.Error(404);
+            Assert.Equal("404", result.ViewName);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/HomeControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/HomeControllerTests.cs
@@ -76,14 +76,6 @@ namespace AllReady.UnitTest.Controllers
         //}
 
         [Fact]
-        public void ErrorReturnsTheCorrectView()
-        {
-            var controller = new HomeController(null);
-            var result = (ViewResult)controller.Error();
-            Assert.Equal("~/Views/Shared/Error.cshtml", result.ViewName);
-        }
-
-        [Fact]
         public void AccessDeniedReturnsTheCorrectView()
         {
             var controller = new HomeController(null);

--- a/AllReadyApp/Web-App/AllReady/Controllers/ErrorController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ErrorController.cs
@@ -1,12 +1,35 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System;
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
 
 namespace AllReady.Controllers
 {
     public class ErrorController : Controller
     {
-        public IActionResult Error404()
+        [Route("/Error/{statusCode?}")]
+        public IActionResult Error(int? statusCode)
         {
-            return View("404");
+            if (statusCode == (int) HttpStatusCode.NotFound)
+            {
+                return View("404");
+            }
+
+            return View("~/Views/Shared/Error.cshtml");
         }
+
+#if DEBUG
+        // Test actions
+        [Route("/Error/Generate/{statusCode}")]
+        public IActionResult Generate(int? statusCode)
+        {
+            return StatusCode(statusCode ?? 500);
+        }
+
+        [Route("/Error/Generate/Exception")]
+        public IActionResult Exception()
+        {
+            throw new Exception("This exception has been thrown purposefully to test error handling.");
+        }
+#endif
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Security/UserAuthorizationService.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/UserAuthorizationService.cs
@@ -31,6 +31,13 @@ namespace AllReady.Security
         {
             if (HasAssociatedUser)
             {
+                if (_user.Email == claimsPrincipal.Identity.Name)
+                {
+                    // This is probably a "re-executed" request that has already been
+                    // through the pipeline once.
+                    return;
+                }
+
                 throw new InvalidOperationException("AssociateUser cannot be called when a user has been previously associated");
             }
 
@@ -131,7 +138,7 @@ namespace AllReady.Security
 
                 int organizationId;
                 if (int.TryParse(organizationIdClaim.Value, out organizationId))
-                { 
+                {
                     result = organizationId;
                 }
 

--- a/AllReadyApp/Web-App/AllReady/Startup.cs
+++ b/AllReadyApp/Web-App/AllReady/Startup.cs
@@ -138,7 +138,7 @@ namespace AllReady
         // Configure is called after ConfigureServices is called.
         public async void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory, SampleDataGenerator sampleData, AllReadyContext context, IConfiguration configuration)
         {
-            // Put first to avoid issues with OPTIONS when calling from Angular/Browser.  
+            // Put first to avoid issues with OPTIONS when calling from Angular/Browser.
             app.UseCors("allReady");
 
             // todo: in RC update we can read from a logging.json config file
@@ -182,8 +182,10 @@ namespace AllReady
             {
                 // Add Error handling middleware which catches all application specific errors and
                 // sends the request to the following path or controller action.
-                app.UseExceptionHandler("/Home/Error");
+                app.UseExceptionHandler("/Error/500");
             }
+
+            app.UseStatusCodePagesWithReExecute("/Error/{0}");
 
             // Add static files to the request pipeline.
             app.UseStaticFiles();
@@ -191,6 +193,7 @@ namespace AllReady
             app.UseRequestLocalization();
 
             Authentication.ConfigureAuthentication(app, Configuration);
+
 
             //call Migrate here to force the creation of the AllReady database so Hangfire can create its schema under it
             if (!env.IsProduction())


### PR DESCRIPTION
I noticed as I was working on other issues that the 404 handler was not working.  I remembered seeing an issue closed  a couple weeks ago (#1905) dealing with this, so I'm not sure why its still not working.

As part of this PR I validated that the correct pages are displayed for 404 and other errors as well.  I also centralized all of the error page handling to the ErrorController.

@stevejgordon please take a look, as I had to make an adjustment to the UserAuthorizationService in order to handle rendering the error pages via a "re-executed" request.