### PR TITLE
Local filesystem IImageService implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -238,3 +238,4 @@ bower_components
 /smoke-alarm-requests-sample-data-INVALID.csv
 /smoke-alarm-requests-sample-data-EMPTY.csv
 /smoke-alarm-requests-sample-data-DUPLICATE.csv
+upload/

--- a/.gitignore
+++ b/.gitignore
@@ -238,4 +238,4 @@ bower_components
 /smoke-alarm-requests-sample-data-INVALID.csv
 /smoke-alarm-requests-sample-data-EMPTY.csv
 /smoke-alarm-requests-sample-data-DUPLICATE.csv
-upload/
+/AllReadyApp/Web-App/AllReady/wwwroot/upload

--- a/AllReadyApp/Web-App/AllReady/Configuration/Services.cs
+++ b/AllReadyApp/Web-App/AllReady/Configuration/Services.cs
@@ -43,11 +43,9 @@ namespace AllReady.Configuration
             services.AddTransient<IItineraryEditModelValidator, ItineraryEditModelValidator>();
             services.AddTransient<IOrganizationEditModelValidator, OrganizationEditModelValidator>();
             services.AddTransient<IRedirectAccountControllerRequests, RedirectAccountControllerRequests>();
-            services.AddSingleton<IImageService, ImageService>();
             services.AddSingleton<ICsvFactory, CsvFactory>();
             services.AddTransient<SampleDataGenerator>();
             services.AddSingleton<IHttpClient, StaticHttpClient>();
-           
 
             if (configuration["Mapping:EnableGoogleGeocodingService"] == "true")
             {
@@ -58,9 +56,18 @@ namespace AllReady.Configuration
                 services.AddSingleton<IGeocodeService, FakeGeocodeService>();
             }
 
+            if (configuration["Data:Storage:EnableAzureBlobImageService"] == "true")
+            {
+                services.AddSingleton<IImageService, ImageService>();
+            }
+            else
+            {
+                services.AddSingleton<IImageService, FileImageService>();
+            }
+
             if (configuration["Data:Storage:EnableAzureQueueService"] == "true")
             {
-                // This setting is false by default. To enable queue processing you will 
+                // This setting is false by default. To enable queue processing you will
                 // need to override the setting in your user secrets or env vars.
                 services.AddTransient<IQueueStorageService, QueueStorageService>();
             }

--- a/AllReadyApp/Web-App/AllReady/Configuration/Settings.cs
+++ b/AllReadyApp/Web-App/AllReady/Configuration/Settings.cs
@@ -6,6 +6,7 @@ namespace AllReady.Configuration
     {
         public string AzureStorage { get; set; }
         public bool EnableAzureQueueService { get; set; }
+        public bool EnableAzureBlobImageService { get; set; }
     }
 
     public class GeneralSettings

--- a/AllReadyApp/Web-App/AllReady/Services/FileImageService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/FileImageService.cs
@@ -24,26 +24,27 @@ namespace AllReady.Services
 
         public Task<string> UploadEventImageAsync(int organizationId, int eventId, IFormFile image)
         {
-            return UploadFile($"EI{organizationId:D6}_{eventId:D6}", image);
+            return UploadFile(image);
         }
 
         public Task<string> UploadCampaignImageAsync(int organizationId, int campaignId, IFormFile image)
         {
-            return UploadFile($"CI{organizationId:D6}_{campaignId:D6}", image);
+            return UploadFile(image);
         }
 
         public Task<string> UploadImageAsync(IFormFile image)
         {
-            return UploadFile(Guid.NewGuid().ToString().ToLower(), image);
+            return UploadFile(image);
         }
 
         public Task<string> UploadOrganizationImageAsync(int organizationId, IFormFile image)
         {
-            return UploadFile($"OI{organizationId:D6}", image);
+            return UploadFile(image);
         }
 
-        private async Task<string> UploadFile(string filename, IFormFile image)
+        private async Task<string> UploadFile(IFormFile image)
         {
+            string filename = Guid.NewGuid().ToString().ToLower();
             string filenameWithExt = filename + Path.GetExtension(image.FileName);
             string fullPath = Path.Combine(_uploadPath, filenameWithExt);
             using (FileStream fs = File.OpenWrite(fullPath))
@@ -58,7 +59,11 @@ namespace AllReady.Services
         {
             string filename = Path.GetFileName(imageUrl);
             string fileFullPath = Path.Combine(_uploadPath, filename);
-            File.Delete(fileFullPath);
+            if(File.Exists(fileFullPath))
+            {
+                File.Delete(fileFullPath);
+            }
+
             return Task.CompletedTask;
         }
     }

--- a/AllReadyApp/Web-App/AllReady/Services/FileImageService.cs
+++ b/AllReadyApp/Web-App/AllReady/Services/FileImageService.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using System.IO;
+
+namespace AllReady.Services
+{
+    public class FileImageService : IImageService
+    {
+        private const string UploadFolder = "upload";
+        private const string WebPath = "/" + UploadFolder + "/";
+        private readonly string _uploadPath;
+
+        public FileImageService(IHostingEnvironment environment)
+        {
+            _uploadPath = Path.Combine(environment.WebRootPath, UploadFolder);
+            var uploadDir = new DirectoryInfo(_uploadPath);
+            if (!uploadDir.Exists)
+            {
+                uploadDir.Create();
+            }
+        }
+
+        public Task<string> UploadEventImageAsync(int organizationId, int eventId, IFormFile image)
+        {
+            return UploadFile($"EI{organizationId:D6}_{eventId:D6}", image);
+        }
+
+        public Task<string> UploadCampaignImageAsync(int organizationId, int campaignId, IFormFile image)
+        {
+            return UploadFile($"CI{organizationId:D6}_{campaignId:D6}", image);
+        }
+
+        public Task<string> UploadImageAsync(IFormFile image)
+        {
+            return UploadFile(Guid.NewGuid().ToString().ToLower(), image);
+        }
+
+        public Task<string> UploadOrganizationImageAsync(int organizationId, IFormFile image)
+        {
+            return UploadFile($"OI{organizationId:D6}", image);
+        }
+
+        private async Task<string> UploadFile(string filename, IFormFile image)
+        {
+            string filenameWithExt = filename + Path.GetExtension(image.FileName);
+            string fullPath = Path.Combine(_uploadPath, filenameWithExt);
+            using (FileStream fs = File.OpenWrite(fullPath))
+            {
+                await image.CopyToAsync(fs);
+            }
+
+            return WebPath + filenameWithExt;
+        }
+
+        public Task DeleteImageAsync(string imageUrl)
+        {
+            string filename = Path.GetFileName(imageUrl);
+            string fileFullPath = Path.Combine(_uploadPath, filename);
+            File.Delete(fileFullPath);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/config.json
+++ b/AllReadyApp/Web-App/AllReady/config.json
@@ -39,7 +39,8 @@
     },
     "Storage": {
       "AzureStorage": "[storagekey]",
-      "EnableAzureQueueService": "false"
+        "EnableAzureQueueService": "false",
+        "EnableAzureBlobImageService":  "false"
     }
   },
   "Email": {
@@ -73,7 +74,7 @@
       "Token": "[twiliotoken]",
       "PhoneNo": "[twilionumber]"
     }
-  },  
+  },
     "ApprovedRegions": {
       "Enabled": true,
       "Regions": ["IDMT",
@@ -86,5 +87,5 @@
         "WISC",
         "CHNI",
         "CSIL"]
-  } 
+  }
 }


### PR DESCRIPTION
This PR is just a quick-and-dirty implementation of the `IImageService` so that you don't have to have an Azure account setup to upload images during development.  I have found it very useful in testing the homepage, and have found some bugs because I've been able to actually render images.  The image service stores the images in an "upload" folder in `wwwroot`, so this is definitely not something that should be used in production.  I have added appropriate flags to toggle this vs the Azure Blob Storage implementation, but I believe there would need to be a config change in the Azure deployment to make sure the right service is used.

Hopefully this is something useful, if not feel free to close the PR.  Thoughts?