### PR TITLE
Fixes #1803 Event Managers Enabled Only

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/EventAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/EventAdminControllerTests.cs
@@ -650,7 +650,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task DeleteEventImageReturnsJsonObjectWithStatusOfNotFound()
+        public async Task DeleteEventImage_ReturnsJsonObjectWithStatusOfNotFound()
         {
             var mediatorMock = new Mock<IMediator>();
             mediatorMock.Setup(m => m.SendAsync(It.IsAny<EventEditQuery>())).ReturnsAsync(null);
@@ -672,10 +672,12 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
 
         [Fact]
-        public async Task DeleteEventImageReturnsJsonObjectWithStatusOfUnauthorizedIfUserIsNotOrganizationAdmin()
+        public async Task DeleteEventImage_ReturnsJsonObjectWithStatusOfUnauthorizedIfUserIsNotAuthorized()
         {
             var mediatorMock = new Mock<IMediator>();
             mediatorMock.Setup(m => m.SendAsync(It.IsAny<EventEditQuery>())).ReturnsAsync(new EventEditViewModel());
+            mediatorMock.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, false));
+
             var imageServiceMock = new Mock<IImageService>();
             var eventEditViewModelValidatorMock = new Mock<IValidateEventEditViewModels>();
             var sut = new EventController(imageServiceMock.Object, mediatorMock.Object, eventEditViewModelValidatorMock.Object);
@@ -709,17 +711,17 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
 
         [Fact]
-        public async Task DeleteEventImageCallsDeleteImageAsyncWithCorrectData()
+        public async Task DeleteEventImage_CallsDeleteImageAsyncWithCorrectData()
         {
-            var mediatorMock = new Mock<IMediator>();
-
             var eventEditViewModel = new EventEditViewModel
             {
                 OrganizationId = 1,
                 ImageUrl = "URL!"
             };
 
+            var mediatorMock = new Mock<IMediator>();
             mediatorMock.Setup(m => m.SendAsync(It.IsAny<EventEditQuery>())).ReturnsAsync(eventEditViewModel);
+            mediatorMock.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, true, false, false));
 
             var imageServiceMock = new Mock<IImageService>();
             var eventEditViewModelValidatorMock = new Mock<IValidateEventEditViewModels>();
@@ -733,17 +735,17 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
 
         [Fact]
-        public async Task DeleteEventImageCallsEditEventCommandWithCorrectData()
+        public async Task DeleteEventImage_CallsEditEventCommandWithCorrectData()
         {
-            var mediatorMock = new Mock<IMediator>();
-
             var eventEditViewModel = new EventEditViewModel
             {
                 OrganizationId = 1,
                 ImageUrl = "URL!"
             };
 
+            var mediatorMock = new Mock<IMediator>();
             mediatorMock.Setup(m => m.SendAsync(It.IsAny<EventEditQuery>())).ReturnsAsync(eventEditViewModel);
+            mediatorMock.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, true, false, false));
 
             var imageServiceMock = new Mock<IImageService>();
             var eventEditViewModelValidatorMock = new Mock<IValidateEventEditViewModels>();
@@ -757,17 +759,17 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
 
         [Fact]
-        public async Task DeleteEventImageReturnsJsonObjectWithStatusOfSuccessIfImageDeletedSuccessfully()
+        public async Task DeleteEventImage_ReturnsJsonObjectWithStatusOfSuccessIfImageDeletedSuccessfully()
         {
-            var mediatorMock = new Mock<IMediator>();
-
             var eventEditViewModel = new EventEditViewModel
             {
                 OrganizationId = 1,
                 ImageUrl = "URL!"
             };
 
+            var mediatorMock = new Mock<IMediator>();
             mediatorMock.Setup(m => m.SendAsync(It.IsAny<EventEditQuery>())).ReturnsAsync(eventEditViewModel);
+            mediatorMock.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, true, false, false));
 
             var imageServiceMock = new Mock<IImageService>();
             var eventEditViewModelValidatorMock = new Mock<IValidateEventEditViewModels>();
@@ -785,16 +787,16 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
 
         [Fact]
-        public async Task DeleteEventImageReturnsJsonObjectWithStatusOfNothingToDeleteIfThereWasNoExistingImage()
+        public async Task DeleteEventImage_ReturnsJsonObjectWithStatusOfNothingToDeleteIfThereWasNoExistingImage()
         {
-            var mediatorMock = new Mock<IMediator>();
-
             var eventEditViewModel = new EventEditViewModel
             {
                 OrganizationId = 1
             };
 
+            var mediatorMock = new Mock<IMediator>();
             mediatorMock.Setup(m => m.SendAsync(It.IsAny<EventEditQuery>())).ReturnsAsync(eventEditViewModel);
+            mediatorMock.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, true, false, false));
 
             var imageServiceMock = new Mock<IImageService>();
             var eventEditViewModelValidatorMock = new Mock<IValidateEventEditViewModels>();
@@ -924,7 +926,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public void RequestsHasHttpGetAttribute()
+        public void Requests_HasHttpGetAttribute()
         {
             var sut = EventControllerWithNoInjectedDependencies();
             var attribute = sut.GetAttributesOn(x => x.Requests(It.IsAny<int>(), null)).OfType<HttpGetAttribute>().SingleOrDefault();
@@ -932,7 +934,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public void RequestsHasRouteAttributeWithCorrectRoute()
+        public void Requests_HasRouteAttributeWithCorrectRoute()
         {
             var sut = EventControllerWithNoInjectedDependencies();
             var routeAttribute = sut.GetAttributesOn(x => x.Requests(It.IsAny<int>(), null)).OfType<RouteAttribute>().SingleOrDefault();
@@ -941,59 +943,53 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task RequestsSendsOrganizationIdByEventIdQueryWithTheCorrectEventId()
+        public async Task Requests_SendsEventRequestsQueryWithTheCorrectEventId()
         {
             const int eventId = 1;
-            const int organizationId = 1;
 
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationIdByEventIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(true, false, false, false));
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventRequestsQuery>())).ReturnsAsync(new EventRequestsViewModel());
 
             var sut = new EventController(null, mockMediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
             await sut.Requests(eventId, null);
 
-            mockMediator.Verify(x => x.SendAsync(It.Is<OrganizationIdByEventIdQuery>(y => y.EventId == eventId)), Times.Once);
+            mockMediator.Verify(x => x.SendAsync(It.Is<EventRequestsQuery>(y => y.EventId == eventId)), Times.Once);
         }
 
         [Fact]
-        public async Task RequestsReturnsHttpUnauthorizedResult_WhenUserIsNotOrgAdmin()
+        public async Task Requests_ReturnsHttpForbidResult_WhenUserIsNotAuthorized()
         {
             var mockMediator = new Mock<IMediator>();
             mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationIdByEventIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, false));
 
             var sut = new EventController(null, mockMediator.Object, null);
-            sut.MakeUserNotAnOrgAdmin();
 
-            Assert.IsType<UnauthorizedResult>(await sut.Requests(It.IsAny<int>(), null));
+            Assert.IsType<ForbidResult>(await sut.Requests(It.IsAny<int>(), null));
         }
 
         [Fact]
-        public async Task RequestsReturnsRedirect_WhenStatusDoesNotMatchEnumOptions()
+        public async Task Requests_ReturnsRedirect_WhenStatusDoesNotMatchEnumOptions()
         {
-            const int orgId = 1;
-
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationIdByEventIdQuery>())).ReturnsAsync(orgId);
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(true, false, false, false));
 
             var sut = new EventController(null, mockMediator.Object, null);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             Assert.IsType<RedirectToActionResult>(await sut.Requests(It.IsAny<int>(), "MadeUp"));
         }
 
         [Fact]
-        public async Task RequestsSendsEventRequestsQueryWithCorrectEventId_WhenNoStatusRouteParamPassed_AndUserIsOrgAdmin()
+        public async Task Requests_SendsEventRequestsQueryWithCorrectEventId_WhenNoStatusRouteParamPassed_AndUserIsOrgAdmin()
         {
-            const int orgId = 1;
             const int eventId = 1;
 
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationIdByEventIdQuery>())).ReturnsAsync(orgId);
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(true, false, false, false));
             mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventRequestsQuery>())).ReturnsAsync(new EventRequestsViewModel());
 
             var sut = new EventController(null, mockMediator.Object, null);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             await sut.Requests(eventId, null);
 
@@ -1001,17 +997,15 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task RequestsSendsRequestListItemsQueryWithCorrectCriteria_WhenNoStatusRouteParamPassed_AndUserIsOrgAdmin()
+        public async Task Requests_SendsRequestListItemsQueryWithCorrectCriteria_WhenNoStatusRouteParamPassed_AndUserAuthorized()
         {
-            const int orgId = 1;
             const int eventId = 1;
 
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationIdByEventIdQuery>())).ReturnsAsync(orgId);
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(true, false, false, false));
             mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventRequestsQuery>())).ReturnsAsync(new EventRequestsViewModel());
 
             var sut = new EventController(null, mockMediator.Object, null);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             await sut.Requests(eventId, null);
 
@@ -1019,16 +1013,13 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task RequestsSetsCorrectPageTitleOnModel_WhenStatusParamIsNotSet()
+        public async Task Requests_SetsCorrectPageTitleOnModel_WhenStatusParamIsNotSet()
         {
-            const int orgId = 1;
-
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationIdByEventIdQuery>())).ReturnsAsync(orgId);
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(true, false, false, false));
             mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventRequestsQuery>())).ReturnsAsync(new EventRequestsViewModel());
 
             var sut = new EventController(null, mockMediator.Object, null);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             var result = await sut.Requests(1, null) as ViewResult;
             result.ShouldNotBeNull();
@@ -1040,16 +1031,13 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task RequestsSetsCorrectPageTitleOnModel_WhenStatusParamIsSet()
+        public async Task Requests_SetsCorrectPageTitleOnModel_WhenStatusParamIsSet()
         {
-            const int orgId = 1;
-
             var mockMediator = new Mock<IMediator>();
-            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<OrganizationIdByEventIdQuery>())).ReturnsAsync(orgId);
+            mockMediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(true, false, false, false));
             mockMediator.Setup(mock => mock.SendAsync(It.IsAny<EventRequestsQuery>())).ReturnsAsync(new EventRequestsViewModel());
 
             var sut = new EventController(null, mockMediator.Object, null);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             var result = await sut.Requests(1, "Assigned") as ViewResult;
             result.ShouldNotBeNull();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableCampaign.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableCampaign.cs
@@ -1,0 +1,46 @@
+﻿using AllReady.Security;
+using System.Threading.Tasks;
+
+namespace AllReady.UnitTest.Areas.Admin.Controllers
+{
+    public class FakeAuthorizableCampaign : IAuthorizableCampaign
+    {
+        private readonly bool _canView;
+        private readonly bool _canEdit;
+        private readonly bool _canDelete;
+        private readonly bool _canManageChildren;
+
+        public int CampaignId { get; }
+        public int OrganizationId { get; }
+
+        public FakeAuthorizableCampaign(bool canView, bool canEdit, bool canDelete, bool canManageChildren, int campaignId = 0)
+        {
+            _canView = canView;
+            _canEdit = canEdit;
+            _canDelete = canDelete;
+            _canManageChildren = canManageChildren;
+
+            CampaignId = campaignId;
+        }
+
+        public Task<bool> UserCanView()
+        {
+            return Task.FromResult(_canView);
+        }
+
+        public Task<bool> UserCanEdit()
+        {
+            return Task.FromResult(_canEdit);
+        }
+
+        public Task<bool> UserCanDelete()
+        {
+            return Task.FromResult(_canDelete);
+        }
+
+        public Task<bool> UserCanManageChildObjects()
+        {
+            return Task.FromResult(_canManageChildren);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableEvent.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableEvent.cs
@@ -1,0 +1,47 @@
+﻿using AllReady.Security;
+using System.Threading.Tasks;
+
+namespace AllReady.UnitTest.Areas.Admin.Controllers
+{
+    public class FakeAuthorizableEvent : IAuthorizableEvent
+    {
+        private readonly bool _canView;
+        private readonly bool _canEdit;
+        private readonly bool _canDelete;
+        private readonly bool _canManageChildren;
+
+        public int EventId { get; }
+        public int CampaignId { get; }
+        public int OrganizationId { get; }
+
+        public FakeAuthorizableEvent(bool canView, bool canEdit, bool canDelete, bool canManageChildren, int campaignId = 0)
+        {
+            _canView = canView;
+            _canEdit = canEdit;
+            _canDelete = canDelete;
+            _canManageChildren = canManageChildren;
+
+            CampaignId = campaignId;
+        }
+
+        public Task<bool> UserCanView()
+        {
+            return Task.FromResult(_canView);
+        }
+
+        public Task<bool> UserCanEdit()
+        {
+            return Task.FromResult(_canEdit);
+        }
+
+        public Task<bool> UserCanDelete()
+        {
+            return Task.FromResult(_canDelete);
+        }
+
+        public Task<bool> UserCanManageChildObjects()
+        {
+            return Task.FromResult(_canManageChildren);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableItinerary.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableItinerary.cs
@@ -1,0 +1,62 @@
+﻿using AllReady.Security;
+using System.Threading.Tasks;
+
+namespace AllReady.UnitTest.Areas.Admin.Controllers
+{
+    public class FakeAuthorizableItinerary : IAuthorizableItinerary
+    {
+        private readonly bool _canView;
+        private readonly bool _canEdit;
+        private readonly bool _canDelete;
+        private readonly bool _canManageChildren;
+        private readonly bool _canManageRequests;
+        private readonly bool _canManageTeamMembers;
+
+        public int ItineraryId { get; }
+        public int EventId { get; }
+        public int CampaignId { get; }
+        public int OrganizationId { get; }
+
+        public FakeAuthorizableItinerary(bool canView, bool canEdit, bool canDelete, bool canManageChildren, bool canManageRequests, bool canManageTeamMembers, int campaignId = 0)
+        {
+            _canView = canView;
+            _canEdit = canEdit;
+            _canDelete = canDelete;
+            _canManageChildren = canManageChildren;
+            _canManageRequests = canManageRequests;
+            _canManageTeamMembers = canManageTeamMembers;
+
+            CampaignId = campaignId;
+        }
+
+        public Task<bool> UserCanView()
+        {
+            return Task.FromResult(_canView);
+        }
+
+        public Task<bool> UserCanEdit()
+        {
+            return Task.FromResult(_canEdit);
+        }
+
+        public Task<bool> UserCanDelete()
+        {
+            return Task.FromResult(_canDelete);
+        }
+
+        public Task<bool> UserCanManageChildObjects()
+        {
+            return Task.FromResult(_canManageChildren);
+        }
+
+        public Task<bool> UserCanManageRequests()
+        {
+            return Task.FromResult(_canManageRequests);
+        }
+
+        public Task<bool> UserCanManageTeamMembers()
+        {
+            return Task.FromResult(_canManageTeamMembers);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableRequest.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableRequest.cs
@@ -1,0 +1,50 @@
+﻿using AllReady.Security;
+using System;
+using System.Threading.Tasks;
+
+namespace AllReady.UnitTest.Areas.Admin.Controllers
+{
+    public class FakeAuthorizableRequest : IAuthorizableRequest
+    {
+        private readonly bool _canView;
+        private readonly bool _canEdit;
+        private readonly bool _canDelete;
+        private readonly bool _canManageChildren;
+
+        public Guid RequestId { get; }
+        public int ItineraryId { get; }
+        public int EventId { get; }
+        public int CampaignId { get; }
+        public int OrganizationId { get; }
+
+        public FakeAuthorizableRequest(bool canView, bool canEdit, bool canDelete, bool canManageChildren, int campaignId = 0)
+        {
+            _canView = canView;
+            _canEdit = canEdit;
+            _canDelete = canDelete;
+            _canManageChildren = canManageChildren;
+
+            CampaignId = campaignId;
+        }
+
+        public Task<bool> UserCanView()
+        {
+            return Task.FromResult(_canView);
+        }
+
+        public Task<bool> UserCanEdit()
+        {
+            return Task.FromResult(_canEdit);
+        }
+
+        public Task<bool> UserCanDelete()
+        {
+            return Task.FromResult(_canDelete);
+        }
+
+        public Task<bool> UserCanManageChildObjects()
+        {
+            return Task.FromResult(_canManageChildren);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/RequestControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/RequestControllerTests.cs
@@ -193,6 +193,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, false));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, false, false, false));
 
             var sut = new RequestController(mediator.Object);
@@ -212,6 +213,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel { Id = eventId, OrganizationId = orgId });
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true, PhoneNumberE164 = model.Phone });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
@@ -231,6 +233,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel { Id = eventId, OrganizationId = orgId });
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = false });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
@@ -251,6 +254,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel { Id = eventId, OrganizationId = orgId });
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = false });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
@@ -270,6 +274,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(viewModel);
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
@@ -291,6 +296,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(viewModel);
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/RequestControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/RequestControllerTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using AllReady.Areas.Admin.Controllers;
+﻿using AllReady.Areas.Admin.Controllers;
 using AllReady.Areas.Admin.Features.Events;
 using AllReady.Areas.Admin.Features.Requests;
 using AllReady.Areas.Admin.ViewModels.Request;
@@ -14,6 +11,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Moq;
 using Shouldly;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace AllReady.UnitTest.Areas.Admin.Controllers
@@ -35,7 +35,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var sut = new RequestController(null);
             var attribute = sut.GetAttributes().OfType<AuthorizeAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
-            Assert.Equal(attribute.Policy, "OrgAdmin");
+            Assert.Equal(attribute.Policy, null);
         }
 
         [Fact]
@@ -91,21 +91,21 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task Create_ReturnsHttpUnauthorizedResult_WhenUserIsNotOrgAdmin()
+        public async Task Create_ReturnsForbidResult_WhenUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserNotAnOrgAdmin();
 
             var result = await sut.Create(1);
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
-        public async Task Create_ReturnsCorrectViewAndViewModel_WhenEventIsNotNullAndUserIsOrgAdmin()
+        public async Task Create_ReturnsCorrectViewAndViewModel_WhenEventIsNotNullAndUserIsAuthorized()
         {
             const int eventId = 1;
             const int orgId = 1;
@@ -113,9 +113,9 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(viewModel);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableEventQuery>())).ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             var result = await sut.Create(It.IsAny<int>()) as ViewResult;
             result.ViewName.ShouldBe("Edit");
@@ -189,21 +189,21 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task EditPost_ReturnsHttpUnauthorizedResult_WhenUserIsNotOrgAdmin()
+        public async Task EditPost_ReturnsForbidResult_WhenUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, false, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserNotAnOrgAdmin();
 
             var result = await sut.Edit(new EditRequestViewModel { EventId = 1 });
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
-        public async Task EditPost_SendsValidatePhoneNumberRequestWithCorrectData_WhenModelStateIsValid_AndEventIsNotNull_AndUserIsOrgAdmin()
+        public async Task EditPost_SendsValidatePhoneNumberRequestWithCorrectData_WhenModelStateIsValid_AndEventIsNotNull_AndUserIsAuthorized()
         {
             const int eventId = 1;
             const int orgId = 1;
@@ -212,9 +212,9 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel { Id = eventId, OrganizationId = orgId });
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true, PhoneNumberE164 = model.Phone });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             await sut.Edit(model);
 
@@ -231,9 +231,9 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel { Id = eventId, OrganizationId = orgId });
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = false });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             var result = await sut.Edit(model) as ViewResult;
             Assert.Equal(result.ViewData.ModelState.ErrorCount, 1);
@@ -251,9 +251,9 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(new EventSummaryViewModel { Id = eventId, OrganizationId = orgId });
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = false });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             var result = await sut.Edit(model) as ViewResult;
             Assert.Equal(result.ViewName, "Edit");
@@ -261,7 +261,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task EditPost_SendsEditRequestCommandWithCorrrectModel_WhenModelStateIsValid_AndEventIsNotNull_AndUserIsOrgAdmin_AndPhoneNumberIsValid()
+        public async Task EditPost_SendsEditRequestCommandWithCorrrectModel_WhenModelStateIsValid_AndEventIsNotNull_AndUserIsAuthorized_AndPhoneNumberIsValid()
         {
             const int eventId = 1;
             const int orgId = 1;
@@ -270,9 +270,9 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(viewModel);
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             var model = new EditRequestViewModel { EventId = eventId };
 
@@ -282,7 +282,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task EditPost_ReturnsRedirectToActionWithTheCorrectAcitonAndControllerName_WhenModelStateIsValid_AndEventIsNotNull_AndUserIsOrgAdmin_AndPhoneNumberIsValid()
+        public async Task EditPost_ReturnsRedirectToActionWithTheCorrectAcitonAndControllerName_WhenModelStateIsValid_AndEventIsNotNull_AndUserIsAuthorized_AndPhoneNumberIsValid()
         {
             const int eventId = 1;
             const int orgId = 1;
@@ -291,9 +291,9 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var mediator = new Mock<IMediator>();
             mediator.Setup(mock => mock.SendAsync(It.IsAny<EventSummaryQuery>())).ReturnsAsync(viewModel);
             mediator.Setup(mock => mock.SendAsync(It.IsAny<ValidatePhoneNumberRequestCommand>())).ReturnsAsync(new ValidatePhoneNumberResult { IsValid = true });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, true, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             var result = await sut.Edit(new EditRequestViewModel { EventId = eventId }) as RedirectToActionResult;
 
@@ -344,29 +344,27 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task EditGet_ReturnsHttpUnauthorizedResult_WhenUserIsNotOrgAdmin()
+        public async Task EditGet_ReturnsForbidResult_WhenUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditRequestQuery>())).ReturnsAsync(new EditRequestViewModel());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(false, false, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserNotAnOrgAdmin();
 
             var result = await sut.Edit(Guid.NewGuid());
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
-        public async Task EditGet_ReturnsViewResult_WhenRequestIsFoundAndUserIsOrgAdmin()
+        public async Task EditGet_ReturnsViewResult_WhenRequestIsFoundAndUserIsAuthorized()
         {
-            const int orgId = 1;
-
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<EditRequestQuery>())).ReturnsAsync(new EditRequestViewModel { OrganizationId = orgId, Name = "test" });
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditRequestQuery>())).ReturnsAsync(new EditRequestViewModel { Name = "test" });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableRequestQuery>())).ReturnsAsync(new FakeAuthorizableRequest(true, false, false, false));
 
             var sut = new RequestController(mediator.Object);
-            sut.MakeUserAnOrgAdmin(orgId.ToString());
 
             var result = await sut.Edit(Guid.NewGuid()) as ViewResult;
 

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/TaskControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/TaskControllerTests.cs
@@ -349,6 +349,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         public async Task EditPostReturnsForbidResultWhenModelStateIsValidAndUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, false));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, false, false, false));
 
             var validator = new Mock<IValidateVolunteerTaskEditViewModelValidator>();
@@ -363,12 +365,14 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task EditPostSendsEditTaskCommandWithCorrectModel_WhenModelStateIsValidAndUserIsOrganizationAdmin()
+        public async Task EditPostSendsEditTaskCommandWithCorrectModel_WhenModelStateIsValidAndUserIsAuthorized()
         {
             var model = new EditViewModel { };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskCommand>())).ReturnsAsync(1);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var validator = new Mock<IValidateVolunteerTaskEditViewModelValidator>();
@@ -388,6 +392,8 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskCommand>())).ReturnsAsync(1);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
             mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var validator = new Mock<IValidateVolunteerTaskEditViewModelValidator>();

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/TaskControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/TaskControllerTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using AllReady.Areas.Admin.Controllers;
+﻿using AllReady.Areas.Admin.Controllers;
 using AllReady.Areas.Admin.Features.Tasks;
 using AllReady.Areas.Admin.ViewModels.Task;
 using AllReady.Areas.Admin.ViewModels.Validators.Task;
@@ -13,6 +9,10 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Routing;
 using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace AllReady.UnitTest.Areas.Admin.Controllers
@@ -23,33 +23,35 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         public async Task CreateGetSendsCreateTaskQueryWithTheCorrectEventId()
         {
             const int eventId = 1;
-            const int organizationId = 1;
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(new EditViewModel { OrganizationId = organizationId });
+            mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(new EditViewModel { });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             await sut.Create(eventId);
             mediator.Verify(x => x.SendAsync(It.Is<CreateVolunteerTaskQuery>(y => y.EventId == eventId)), Times.Once);
         }
 
         [Fact]
-        public async Task CreateGetReturnsUnauthorizedResultWhenUserIsNotOrganizationAdmin()
+        public async Task CreateGetReturnsForbidResultWhenUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(new EditViewModel());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, false));
 
             var sut = new TaskController(mediator.Object, null);
             sut.SetDefaultHttpContext();
 
             var result = await sut.Create(It.IsAny<int>());
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
@@ -59,12 +61,13 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(model);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(model.OrganizationId.ToString());
 
             await sut.Create(It.IsAny<int>());
 
@@ -83,12 +86,13 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(model);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(cancelUrl);
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(model.OrganizationId.ToString());
 
             var result = await sut.Create(It.IsAny<int>()) as ViewResult;
             var modelResult = result.Model as EditViewModel;
@@ -99,16 +103,17 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task CreateGetSetCorrectToTitleOnViewBag()
         {
-            var model = new EditViewModel { EventId = 1, OrganizationId = 1 };
+            var model = new EditViewModel { EventId = 1 };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(model);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(model.OrganizationId.ToString());
 
             await sut.Create(It.IsAny<int>());
 
@@ -118,17 +123,17 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task CreateGetReturnsCorrectViewModel()
         {
-            const int organizationId = 1;
-            var model = new EditViewModel { OrganizationId = organizationId };
+            var model = new EditViewModel { };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(model);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             var result = await sut.Create(It.IsAny<int>()) as ViewResult;
             var modelResult = result.ViewData.Model as EditViewModel;
@@ -139,16 +144,15 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task CreateGetReturnsCorrectView()
         {
-            const int organizationId = 1;
-
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(new EditViewModel { OrganizationId = organizationId });
+            mediator.Setup(x => x.SendAsync(It.IsAny<CreateVolunteerTaskQuery>())).ReturnsAsync(new EditViewModel { });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AllReady.Areas.Admin.Features.Events.AuthorizableEventQuery>()))
+                .ReturnsAsync(new FakeAuthorizableEvent(false, false, false, true));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             var result = await sut.Create(It.IsAny<int>()) as ViewResult;
 
@@ -176,48 +180,48 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         public async Task EditGetSendsEditTaskQueryWithCorrectTaskId()
         {
             const int volunteerTaskId = 1;
-            const int organizationId = 1;
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskQuery>())).ReturnsAsync(new EditViewModel { OrganizationId = organizationId });
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskQuery>())).ReturnsAsync(new EditViewModel { });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(true, false, false, false));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
             await sut.Edit(volunteerTaskId);
 
             mediator.Verify(x => x.SendAsync(It.Is<EditVolunteerTaskQuery>(y => y.VolunteerTaskId == volunteerTaskId)), Times.Once);
         }
 
         [Fact]
-        public async Task EditGetReturnsUnauthorizedResultWhenUserIsNotOrgAdmin()
+        public async Task EditGetReturnsForbidResultWhenUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskQuery>())).ReturnsAsync(new EditViewModel());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, false, false, false));
 
             var sut = new TaskController(mediator.Object, null);
             sut.SetDefaultHttpContext();
             var result = await sut.Edit(It.IsAny<int>());
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
         public async Task EditGetAssignsCancelUrlToModel()
         {
             const string cancelUrl = "url";
-            var model = new EditViewModel { EventId = 1, OrganizationId = 1 };
+            var model = new EditViewModel { EventId = 1 };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskQuery>())).ReturnsAsync(model);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(true, false, false, false));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(cancelUrl);
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(model.OrganizationId.ToString());
 
             var result = await sut.Edit(It.IsAny<int>()) as ViewResult;
             var modelResult = result.Model as EditViewModel;
@@ -228,16 +232,16 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task EditGetPopulatesCorrectTitleOnViewBag()
         {
-            var model = new EditViewModel { EventId = 1, OrganizationId = 1 };
+            var model = new EditViewModel { EventId = 1 };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskQuery>())).ReturnsAsync(model);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(true, false, false, false));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(model.OrganizationId.ToString());
 
             await sut.Edit(It.IsAny<int>());
 
@@ -247,17 +251,16 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task EditGetReturnsCorrectViewModelAndView()
         {
-            const int organizationId = 1;
-            var editViewModel = new EditViewModel { OrganizationId = organizationId };
+            var editViewModel = new EditViewModel { };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskQuery>())).ReturnsAsync(editViewModel);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(true, false, false, false));
 
             var urlHelper = new Mock<IUrlHelper>();
             urlHelper.Setup(x => x.Action(It.IsAny<UrlActionContext>())).Returns(It.IsAny<string>());
 
             var sut = new TaskController(mediator.Object, null) { Url = urlHelper.Object };
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             var result = await sut.Edit(It.IsAny<int>()) as ViewResult;
             var modelResult = result.ViewData.Model as EditViewModel;
@@ -343,34 +346,35 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task EditPostReturnsUnauthorizedResultWhenModelStateIsValidAndUserIsNotAnOrganizationAdminUser()
+        public async Task EditPostReturnsForbidResultWhenModelStateIsValidAndUserIsNotAuthorized()
         {
-            var validator = new Mock<IValidateVolunteerTaskEditViewModelValidator>();
-            validator.Setup(x => x.Validate(It.IsAny<EditViewModel>())).ReturnsAsync(new List<KeyValuePair<string, string>>());
-
-            var sut = new TaskController(Mock.Of<IMediator>(), validator.Object);
-            sut.SetDefaultHttpContext();
-
-            var result = await sut.Edit(new EditViewModel());
-
-            Assert.IsType<UnauthorizedResult>(result);
-        }
-
-        [Fact]
-        public async Task EditPostSendsEditTaskCommandWithCorrectModel_WhenModelStateIsValidAndUserIsOrganizationAdmin()
-        {
-            const int organizationId = 1;
-
-            var model = new EditViewModel { OrganizationId = organizationId };
-
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskCommand>())).ReturnsAsync(1);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, false, false, false));
 
             var validator = new Mock<IValidateVolunteerTaskEditViewModelValidator>();
             validator.Setup(x => x.Validate(It.IsAny<EditViewModel>())).ReturnsAsync(new List<KeyValuePair<string, string>>());
 
             var sut = new TaskController(mediator.Object, validator.Object);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
+            sut.SetDefaultHttpContext();
+
+            var result = await sut.Edit(new EditViewModel());
+
+            Assert.IsType<ForbidResult>(result);
+        }
+
+        [Fact]
+        public async Task EditPostSendsEditTaskCommandWithCorrectModel_WhenModelStateIsValidAndUserIsOrganizationAdmin()
+        {
+            var model = new EditViewModel { };
+
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskCommand>())).ReturnsAsync(1);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
+
+            var validator = new Mock<IValidateVolunteerTaskEditViewModelValidator>();
+            validator.Setup(x => x.Validate(It.IsAny<EditViewModel>())).ReturnsAsync(new List<KeyValuePair<string, string>>());
+
+            var sut = new TaskController(mediator.Object, validator.Object);
 
             await sut.Edit(model);
 
@@ -380,18 +384,16 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task EditPostRedirectsToCorrectAction_WhenCreatingTask()
         {
-            const int organizationId = 1;
-
-            var model = new EditViewModel { Id = 0, OrganizationId = organizationId, EventId = 1 };
+            var model = new EditViewModel { Id = 0, EventId = 1 };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskCommand>())).ReturnsAsync(1);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var validator = new Mock<IValidateVolunteerTaskEditViewModelValidator>();
             validator.Setup(x => x.Validate(It.IsAny<EditViewModel>())).ReturnsAsync(new List<KeyValuePair<string, string>>());
 
             var sut = new TaskController(mediator.Object, validator.Object);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             var result = await sut.Edit(model) as RedirectToActionResult;
 
@@ -405,18 +407,16 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task EditPostRedirectsToCorrectAction_WhenUpdatingTask()
         {
-            const int organizationId = 1;
-
-            var model = new EditViewModel { Id = 1, OrganizationId = organizationId };
+            var model = new EditViewModel { Id = 1 };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<EditVolunteerTaskCommand>())).ReturnsAsync(1);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var validator = new Mock<IValidateVolunteerTaskEditViewModelValidator>();
             validator.Setup(x => x.Validate(It.IsAny<EditViewModel>())).ReturnsAsync(new List<KeyValuePair<string, string>>());
 
             var sut = new TaskController(mediator.Object, validator.Object);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             var result = await sut.Edit(model) as RedirectToActionResult;
 
@@ -447,42 +447,41 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         public async Task DeleteSendsDeleteQueryWithCorrectTaskId()
         {
             const int volunteerTaskId = 1;
-            const int organizationId = 1;
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<DeleteQuery>())).ReturnsAsync(new DeleteViewModel { OrganizationId = organizationId });
+            mediator.Setup(x => x.SendAsync(It.IsAny<DeleteQuery>())).ReturnsAsync(new DeleteViewModel { });
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
             await sut.Delete(volunteerTaskId);
 
             mediator.Verify(x => x.SendAsync(It.Is<DeleteQuery>(y => y.VolunteerTaskId == volunteerTaskId)), Times.Once);
         }
 
         [Fact]
-        public async Task DeleteReturnsHttpUnauthorizedResultWhenUserIsNotOrgAdmin()
+        public async Task DeleteReturnsForbidResultWhenUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<DeleteQuery>())).ReturnsAsync(new DeleteViewModel());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, false, false, false));
 
             var sut = new TaskController(mediator.Object, null);
             sut.SetDefaultHttpContext();
             var result = await sut.Delete(It.IsAny<int>());
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
         public async Task DeleteReturnsCorrectViewModelAndView()
         {
-            const int organizationId = 1;
-            var deleteViewModel = new DeleteViewModel { OrganizationId = organizationId };
+            var deleteViewModel = new DeleteViewModel { };
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<DeleteQuery>())).ReturnsAsync(deleteViewModel);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             var result = await sut.Delete(It.IsAny<int>()) as ViewResult;
             var modelResult = result.ViewData.Model as DeleteViewModel;
@@ -518,6 +517,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<DetailsQuery>())).ReturnsAsync(detailsViewModel);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(true, false, false, false));
 
             var sut = new TaskController(mediator.Object, null);
             var result = await sut.Details(It.IsAny<int>()) as ViewResult;
@@ -546,7 +546,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task DeleteConfirmedReturnsUnauthorizedResultWhenUserIsNotOrgAdmin()
+        public async Task DeleteConfirmedReturnsForbidResultWhenUserIsNotAuthorized()
         {
             var model = new DeleteViewModel { UserIsOrgAdmin = false };
 
@@ -555,7 +555,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             var result = await sut.DeleteConfirmed(model);
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
@@ -574,14 +574,12 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task DeleteConfirmedRedirectsToCorrectAction()
         {
-            const int organizationId = 1;
-
-            var deleteViewModel = new DeleteViewModel { OrganizationId = organizationId, EventId = 1, UserIsOrgAdmin = true };
+            var deleteViewModel = new DeleteViewModel { EventId = 1, UserIsOrgAdmin = true };
 
             var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             var result = await sut.DeleteConfirmed(deleteViewModel) as RedirectToActionResult;
 
@@ -623,6 +621,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
             sut.SetDefaultHttpContext();
@@ -632,30 +631,30 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
-        public async Task AssignReturnsUnauthorizedResultWhenUserIsNotOrgAdmin()
+        public async Task AssignReturnsForbidResultWhenUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, false, false, false));
 
             var sut = new TaskController(mediator.Object, null);
             sut.SetDefaultHttpContext();
             var result = await sut.Assign(1, null);
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
         public async Task AssignSendsAssignTaskCommand()
         {
-            const int organizationId = 1;
             const int volunteerTaskId = 1;
             var userIds = new List<string> { "1", "2" };
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(organizationId);
+            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
             await sut.Assign(volunteerTaskId, userIds);
 
             mediator.Verify(x => x.SendAsync(It.Is<AssignVolunteerTaskCommand>(y => y.VolunteerTaskId == volunteerTaskId && y.UserIds == userIds)), Times.Once);
@@ -664,14 +663,13 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task AssignRedirectsToCorrectRoute()
         {
-            const int organizationId = 1;
             const int volunteerTaskId = 1;
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(organizationId);
+            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
 
             var result = await sut.Assign(volunteerTaskId, null) as RedirectToRouteResult;
 
@@ -709,43 +707,42 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task MessageAllVounteersSendsOrganizationIdByTaskIdQueryWithCorrectTaskId()
         {
-            const int organizationId = 1;
             var model = new MessageTaskVolunteersViewModel { VolunteerTaskId = 1 };
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(organizationId);
+            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
             await sut.MessageAllVolunteers(model);
 
             mediator.Verify(x => x.SendAsync(It.Is<OrganizationIdByVolunteerTaskIdQuery>(y => y.VolunteerTaskId == model.VolunteerTaskId)), Times.Once);
         }
 
         [Fact]
-        public async Task MessageAllVolunteersReturnsUnauthorizedResultWhenUserIsNotOrgAdmin()
+        public async Task MessageAllVolunteersReturnsForbidResultWhenUserIsNotAuthorized()
         {
             var mediator = new Mock<IMediator>();
             mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, false, false, false));
 
             var sut = new TaskController(mediator.Object, null);
             sut.SetDefaultHttpContext();
             var result = await sut.MessageAllVolunteers(new MessageTaskVolunteersViewModel());
 
-            Assert.IsType<UnauthorizedResult>(result);
+            Assert.IsType<ForbidResult>(result);
         }
 
         [Fact]
         public async Task MessageAllVolunteersSendsMessageTaskVolunteersCommandWithCorrectData()
         {
-            const int organizationId = 1;
             var model = new MessageTaskVolunteersViewModel();
 
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(organizationId);
+            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
             await sut.MessageAllVolunteers(model);
 
             mediator.Verify(x => x.SendAsync(It.Is<MessageTaskVolunteersCommand>(y => y.Model == model)), Times.Once);
@@ -754,13 +751,11 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         [Fact]
         public async Task MessageAllVolunteersReturnsHttpOkResult()
         {
-            const int organizationId = 1;
-
             var mediator = new Mock<IMediator>();
-            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(organizationId);
+            mediator.Setup(x => x.SendAsync(It.IsAny<OrganizationIdByVolunteerTaskIdQuery>())).ReturnsAsync(It.IsAny<int>());
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableTaskQuery>())).ReturnsAsync(new FakeAuthorizableTask(false, true, false, false));
 
             var sut = new TaskController(mediator.Object, null);
-            sut.MakeUserAnOrgAdmin(organizationId.ToString());
             var result = await sut.MessageAllVolunteers(new MessageTaskVolunteersViewModel());
 
             Assert.IsType<OkResult>(result);
@@ -798,7 +793,7 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
             var sut = new TaskController(null, null);
             var attribute = sut.GetAttributes().OfType<AuthorizeAttribute>().SingleOrDefault();
             Assert.NotNull(attribute);
-            Assert.Equal(attribute.Policy, "OrgAdmin");
+            Assert.Equal(attribute.Policy, null);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
@@ -75,7 +75,7 @@ namespace AllReady.Areas.Admin.Controllers
             var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
 
             var authorizableCampaign = await _mediator.SendAsync(new AuthorizableCampaignQuery(campaign.Id, campaign.OrganizationId));
-            if (authorizableCampaign == null || !await authorizableCampaign.UserCanManageChildObjects())
+            if (!await authorizableCampaign.UserCanManageChildObjects())
             {
                 return new ForbidResult();
             }
@@ -102,7 +102,7 @@ namespace AllReady.Areas.Admin.Controllers
             var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
 
             var authorizableCampaign = await _mediator.SendAsync(new AuthorizableCampaignQuery(campaign.Id, campaign.OrganizationId));
-            if (authorizableCampaign == null || !await authorizableCampaign.UserCanManageChildObjects())
+            if (!await authorizableCampaign.UserCanManageChildObjects())
             {
                 return new ForbidResult();
             }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
@@ -73,9 +73,11 @@ namespace AllReady.Areas.Admin.Controllers
         public async Task<IActionResult> Create(int campaignId)
         {
             var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
-            if (campaign == null || !User.IsOrganizationAdmin(campaign.OrganizationId))
+
+            var authorizableCampaign = await _mediator.SendAsync(new AuthorizableCampaignQuery(campaign.Id, campaign.OrganizationId));
+            if (authorizableCampaign == null || !await authorizableCampaign.UserCanManageChildObjects())
             {
-                return Unauthorized();
+                return new ForbidResult();
             }
 
             var viewModel = new EventEditViewModel
@@ -98,9 +100,11 @@ namespace AllReady.Areas.Admin.Controllers
         public async Task<IActionResult> Create(int campaignId, EventEditViewModel eventEditViewModel, IFormFile fileUpload)
         {
             var campaign = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = campaignId });
-            if (campaign == null || !User.IsOrganizationAdmin(campaign.OrganizationId))
+
+            var authorizableCampaign = await _mediator.SendAsync(new AuthorizableCampaignQuery(campaign.Id, campaign.OrganizationId));
+            if (authorizableCampaign == null || !await authorizableCampaign.UserCanManageChildObjects())
             {
-                return Unauthorized();
+                return new ForbidResult();
             }
 
             var errors = _eventEditViewModelValidator.Validate(eventEditViewModel, campaign);

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
@@ -1,18 +1,17 @@
-﻿using System;
-using System.Threading.Tasks;
-using AllReady.Areas.Admin.Features.Events;
+﻿using AllReady.Areas.Admin.Features.Events;
 using AllReady.Areas.Admin.Features.Requests;
-using AllReady.Security;
+using AllReady.Areas.Admin.ViewModels.Request;
+using AllReady.Features.Sms;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using AllReady.Areas.Admin.ViewModels.Request;
-using AllReady.Features.Sms;
+using System;
+using System.Threading.Tasks;
 
 namespace AllReady.Areas.Admin.Controllers
 {
     [Area("Admin")]
-    [Authorize("OrgAdmin")]
+    [Authorize]
     [Route("Admin/Requests")]
     public class RequestController : Controller
     {
@@ -46,9 +45,10 @@ namespace AllReady.Areas.Admin.Controllers
                 return BadRequest("Invalid event id");
             }
 
-            if (!User.IsOrganizationAdmin(campaignEvent.OrganizationId))
+            var authorizableEvent = await _mediator.SendAsync(new AuthorizableEventQuery(campaignEvent.Id));
+            if (!await authorizableEvent.UserCanManageChildObjects())
             {
-                return Unauthorized();
+                return new ForbidResult();
             }
 
             var model = new EditRequestViewModel
@@ -80,9 +80,10 @@ namespace AllReady.Areas.Admin.Controllers
                 return NotFound();
             }
 
-            if (!User.IsOrganizationAdmin(model.OrganizationId))
+            var authorizableRequest = await _mediator.SendAsync(new AuthorizableRequestQuery(model.Id));
+            if (!await authorizableRequest.UserCanView())
             {
-                return Unauthorized();
+                return new ForbidResult();
             }
 
             ViewData["Title"] = "Edit " + model.Name;
@@ -111,9 +112,10 @@ namespace AllReady.Areas.Admin.Controllers
                 return BadRequest("Invalid event id");
             }
 
-            if (!User.IsOrganizationAdmin(@event.OrganizationId))
+            var authorizableRequest = await _mediator.SendAsync(new AuthorizableRequestQuery(model.Id));
+            if (!await authorizableRequest.UserCanEdit())
             {
-                return Unauthorized();
+                return new ForbidResult();
             }
 
             var validatePhoneNumberResult = await _mediator.SendAsync(new ValidatePhoneNumberRequestCommand { PhoneNumber = model.Phone, ValidateType = true });

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/RequestController.cs
@@ -112,10 +112,21 @@ namespace AllReady.Areas.Admin.Controllers
                 return BadRequest("Invalid event id");
             }
 
-            var authorizableRequest = await _mediator.SendAsync(new AuthorizableRequestQuery(model.Id));
-            if (!await authorizableRequest.UserCanEdit())
+            if (model.Id == Guid.Empty)
             {
-                return new ForbidResult();
+                var authorizableEvent = await _mediator.SendAsync(new AuthorizableEventQuery(model.EventId));
+                if (!await authorizableEvent.UserCanManageChildObjects())
+                {
+                    return new ForbidResult();
+                }
+            }
+            else
+            {
+                var authorizableRequest = await _mediator.SendAsync(new AuthorizableRequestQuery(model.Id));
+                if (!await authorizableRequest.UserCanEdit())
+                {
+                    return new ForbidResult();
+                }
             }
 
             var validatePhoneNumberResult = await _mediator.SendAsync(new ValidatePhoneNumberRequestCommand { PhoneNumber = model.Phone, ValidateType = true });

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/TaskController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/TaskController.cs
@@ -88,10 +88,21 @@ namespace AllReady.Areas.Admin.Controllers
 
             if (ModelState.IsValid)
             {
-                var authorizableTask = await _mediator.SendAsync(new AuthorizableTaskQuery(viewModel.Id));
-                if (!await authorizableTask.UserCanEdit())
+                if (viewModel.Id == 0)
                 {
-                    return new ForbidResult();
+                    var authorizableEvent = await _mediator.SendAsync(new Features.Events.AuthorizableEventQuery(viewModel.EventId));
+                    if (!await authorizableEvent.UserCanManageChildObjects())
+                    {
+                        return new ForbidResult();
+                    }
+                }
+                else
+                {
+                    var authorizableTask = await _mediator.SendAsync(new AuthorizableTaskQuery(viewModel.Id));
+                    if (!await authorizableTask.UserCanEdit())
+                    {
+                        return new ForbidResult();
+                    }
                 }
 
                 var volunteerTaskId = await _mediator.SendAsync(new EditVolunteerTaskCommand { VolunteerTask = viewModel });

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/AuthorizableCampaignQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Campaigns/AuthorizableCampaignQuery.cs
@@ -1,0 +1,53 @@
+﻿using AllReady.Security;
+using MediatR;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Campaigns
+{
+    /// <summary>
+    /// Uses an <see cref="IAuthorizableCampaignBuilder"/> to build a <see cref="IAuthorizableCampaign"/>
+    /// </summary>
+    public class AuthorizableCampaignQuery : IAsyncRequest<IAuthorizableCampaign>
+    {
+        /// <summary>
+        /// Initializes a new instance of an <see cref="AuthorizableCampaignQuery"/>.
+        /// Uses an <see cref="IAuthorizableCampaignBuilder"/> to build a <see cref="IAuthorizableCampaign"/>
+        /// </summary>
+        public AuthorizableCampaignQuery(int campaignId, int? orgId = null)
+        {
+            CampaignId = campaignId;
+            OrganizationId = orgId;
+        }
+
+        /// <summary>
+        /// The campaign ID
+        /// </summary>
+        public int CampaignId { get; }
+
+        /// <summary>
+        /// The organization ID for the campaign, if known
+        /// </summary>
+        public int? OrganizationId { get; }
+    }
+
+    /// <summary>
+    /// Handles an <see cref="AuthorizableCampaignQuery"/>
+    /// </summary>
+    public class AuthorizableCampaignQueryHandler : IAsyncRequestHandler<AuthorizableCampaignQuery, IAuthorizableCampaign>
+    {
+        private readonly IAuthorizableCampaignBuilder _authorizableCampaignBuilder;
+
+        public AuthorizableCampaignQueryHandler(IAuthorizableCampaignBuilder authorizableCampaignBuilder)
+        {
+            _authorizableCampaignBuilder = authorizableCampaignBuilder;
+        }
+
+        /// <summary>
+        /// Handles an <see cref="AuthorizableCampaignQuery"/>
+        /// </summary>
+        public async Task<IAuthorizableCampaign> Handle(AuthorizableCampaignQuery message)
+        {
+            return await _authorizableCampaignBuilder.Build(message.CampaignId, message.OrganizationId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AuthorizableItineraryQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Itineraries/AuthorizableItineraryQuery.cs
@@ -1,0 +1,65 @@
+﻿using AllReady.Security;
+using MediatR;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Itineraries
+{
+    /// <summary>
+    /// Uses an <see cref="IAuthorizableItineraryBuilder"/> to build a <see cref="IAuthorizableItinerary"/>
+    /// </summary>
+    public class AuthorizableItineraryQuery : IAsyncRequest<IAuthorizableItinerary>
+    {
+        /// <summary>
+        /// Initializes a new instance of an <see cref="AuthorizableItineraryQuery"/>.
+        /// Uses an <see cref="IAuthorizableItineraryBuilder"/> to build a <see cref="IAuthorizableItinerary"/>
+        /// </summary>
+        public AuthorizableItineraryQuery(int itineraryId, int? eventId = null, int? campaignId = null, int? orgId = null)
+        {
+            ItineraryId = itineraryId;
+            EventId = eventId;
+            CampaignId = campaignId;
+            OrganizationId = orgId;
+        }
+
+        /// <summary>
+        /// The itinerary ID
+        /// </summary>
+        public int ItineraryId { get; }
+
+        /// <summary>
+        /// The event ID for the itinerary, if known
+        /// </summary>
+        public int? EventId { get; }
+
+        /// <summary>
+        /// The organization ID for the itinerary, if known
+        /// </summary>
+        public int? OrganizationId { get; }
+
+        /// <summary>
+        /// The campaign ID for the itinerary, if known
+        /// </summary>
+        public int? CampaignId { get; }
+    }
+
+    /// <summary>
+    /// Handles an <see cref="AuthorizableItineraryQuery"/>
+    /// </summary>
+    public class AuthorizableItineraryQueryHandler : IAsyncRequestHandler<AuthorizableItineraryQuery, IAuthorizableItinerary>
+    {
+        private readonly IAuthorizableItineraryBuilder _authorizableItineraryBuilder;
+
+        public AuthorizableItineraryQueryHandler(IAuthorizableItineraryBuilder authorizableItineraryBuilder)
+        {
+            _authorizableItineraryBuilder = authorizableItineraryBuilder;
+        }
+
+        /// <summary>
+        /// Handles an <see cref="AuthorizableItineraryQuery"/>
+        /// </summary>
+        public async Task<IAuthorizableItinerary> Handle(AuthorizableItineraryQuery message)
+        {
+            return await _authorizableItineraryBuilder.Build(message.ItineraryId, message.EventId, message.CampaignId, message.OrganizationId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/AuthorizableRequestQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Requests/AuthorizableRequestQuery.cs
@@ -1,0 +1,66 @@
+﻿using AllReady.Security;
+using MediatR;
+using System;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Requests
+{
+    /// <summary>
+    /// Uses an <see cref="IAuthorizableRequestBuilder"/> to build a <see cref="IAuthorizableRequest"/>
+    /// </summary>
+    public class AuthorizableRequestQuery : IAsyncRequest<IAuthorizableRequest>
+    {
+        /// <summary>
+        /// Initializes a new instance of an <see cref="AuthorizableRequestQuery"/>.
+        /// Uses an <see cref="IAuthorizableRequestBuilder"/> to build a <see cref="IAuthorizableRequest"/>
+        /// </summary>
+        public AuthorizableRequestQuery(Guid requestId, int? eventId = null, int? campaignId = null, int? orgId = null)
+        {
+            RequestId = requestId;
+            EventId = eventId;
+            CampaignId = campaignId;
+            OrganizationId = orgId;
+        }
+
+        /// <summary>
+        /// The request ID
+        /// </summary>
+        public Guid RequestId { get; }
+
+        /// <summary>
+        /// The event ID for the request, if known
+        /// </summary>
+        public int? EventId { get; }
+
+        /// <summary>
+        /// The organization ID for the request, if known
+        /// </summary>
+        public int? OrganizationId { get; }
+
+        /// <summary>
+        /// The campaign ID for the request, if known
+        /// </summary>
+        public int? CampaignId { get; }
+    }
+
+    /// <summary>
+    /// Handles an <see cref="AuthorizableRequestQuery"/>
+    /// </summary>
+    public class AuthorizableRequestQueryHandler : IAsyncRequestHandler<AuthorizableRequestQuery, IAuthorizableRequest>
+    {
+        private readonly IAuthorizableRequestBuilder _authorizableRequestBuilder;
+
+        public AuthorizableRequestQueryHandler(IAuthorizableRequestBuilder authorizableRequestBuilder)
+        {
+            _authorizableRequestBuilder = authorizableRequestBuilder;
+        }
+
+        /// <summary>
+        /// Handles an <see cref="AuthorizableRequestQuery"/>
+        /// </summary>
+        public async Task<IAuthorizableRequest> Handle(AuthorizableRequestQuery message)
+        {
+            return await _authorizableRequestBuilder.Build(message.RequestId, message.EventId, message.CampaignId, message.OrganizationId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -1,4 +1,4 @@
-@using System.Threading.Tasks
+﻿@using System.Threading.Tasks
 @using AllReady.Security
 @model AllReady.Areas.Admin.ViewModels.Event.EventDetailViewModel
 
@@ -28,9 +28,9 @@
         <h2>
             <span data-event-title>@Model.Name</span>
             <a asp-area="Admin" asp-controller="Event" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
-            <a asp-area="Admin" asp-controller="Event" asp-action="Duplicate" asp-route-id="@Model.Id" class="btn btn-default">Duplicate</a>
             @if (Model.ShowDeleteButton)
             {
+                <a asp-area="Admin" asp-controller="Event" asp-action="Duplicate" asp-route-id="@Model.Id" class="btn btn-default">Duplicate</a>
                 <a asp-area="Admin" asp-controller="Event" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>
             }
         </h2>


### PR DESCRIPTION
More bits for Event Managers (EPIC) #1803 

@stevejgordon Can you please review?  I did not make any changes to the `EventController `methods that would result in the creation of a new event.  I assumed that in the future that there will be an implementation of `AuthorizableCampaign` in the future.

Specific items to look at
- `DeleteImage` method - I assumed that the correct method to check is `UserCanEdit()` not `UserCanManageChildObjects()`.
- `Requests`method - I assumed `UserCanView()` was sufficient.
