### PR TITLE
Fixes #1973 Missing AuthorizationTask

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableTask.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/FakeAuthorizableTask.cs
@@ -1,0 +1,48 @@
+﻿using AllReady.Security;
+using System.Threading.Tasks;
+
+namespace AllReady.UnitTest.Areas.Admin.Controllers
+{
+    public class FakeAuthorizableTask : IAuthorizableTask
+    {
+        private readonly bool _canView;
+        private readonly bool _canEdit;
+        private readonly bool _canDelete;
+        private readonly bool _canManageChildren;
+
+        public int TaskId { get; }
+        public int EventId { get; }
+        public int CampaignId { get; }
+        public int OrganizationId { get; }
+
+        public FakeAuthorizableTask(bool canView, bool canEdit, bool canDelete, bool canManageChildren, int campaignId = 0)
+        {
+            _canView = canView;
+            _canEdit = canEdit;
+            _canDelete = canDelete;
+            _canManageChildren = canManageChildren;
+
+            CampaignId = campaignId;
+        }
+
+        public Task<bool> UserCanView()
+        {
+            return Task.FromResult(_canView);
+        }
+
+        public Task<bool> UserCanEdit()
+        {
+            return Task.FromResult(_canEdit);
+        }
+
+        public Task<bool> UserCanDelete()
+        {
+            return Task.FromResult(_canDelete);
+        }
+
+        public Task<bool> UserCanManageChildObjects()
+        {
+            return Task.FromResult(_canManageChildren);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Security/AuthorizableTaskBuilderTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Security/AuthorizableTaskBuilderTests.cs
@@ -1,0 +1,142 @@
+﻿using AllReady.Models;
+using AllReady.Security;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+using Shouldly;
+using System;
+
+namespace AllReady.UnitTest.Security
+{
+    public class AuthorizableTaskBuilderTests : InMemoryContextTest
+    {
+        public static int TaskId = 123;
+        public static int TaskIdForTaskWithoutLinks = 764;
+        public static int TaskIdForTaskWithPartialLinks = 343;
+
+        [Fact]
+        public async Task Build_WithAllFivesIds_ReturnsTheAuthorizableTask()
+        {
+            var sut = new AuthorizableTaskBuilder(Context, new MemoryCache(new MemoryCacheOptions()), Mock.Of<IUserAuthorizationService>());
+
+            var result = await sut.Build(TaskId, 3, 4, 5);
+
+            result.TaskId.ShouldBe(TaskId);
+            result.EventId.ShouldBe(3);
+            result.CampaignId.ShouldBe(4);
+            result.OrganizationId.ShouldBe(5);
+        }
+
+        [Fact]
+        public async Task Build_WithJustTaskId_ReturnsFromTheCacheWhenAvailable()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions());
+            cache.Set("AuthorizableTask_" + TaskId, new FakeAuthorizableTaskIdContainer(), TimeSpan.FromMinutes(5));
+
+            var sut = new AuthorizableTaskBuilder(Context, cache, Mock.Of<IUserAuthorizationService>());
+
+            var result = await sut.Build(TaskId);
+
+            result.TaskId.ShouldBe(TaskId);
+            result.EventId.ShouldBe(200);
+            result.CampaignId.ShouldBe(300);
+            result.OrganizationId.ShouldBe(400);
+        }
+
+        [Fact]
+        public async Task Build_WithJustTaskId_ReturnsTheAuthorizableTaskFromTheDatabase()
+        {
+            var sut = new AuthorizableTaskBuilder(Context, new MemoryCache(new MemoryCacheOptions()), Mock.Of<IUserAuthorizationService>());
+
+            var result = await sut.Build(TaskId);
+
+            result.TaskId.ShouldBe(TaskId);
+            result.EventId.ShouldBe(10);
+            result.CampaignId.ShouldBe(20);
+            result.OrganizationId.ShouldBe(30);
+        }
+
+        [Fact]
+        public async Task Build_WithJustTaskId_ReturnsTheAuthorizableTaskFromTheDatabase_WithExpectedIds_WhenNoLinkedElements()
+        {
+            var sut = new AuthorizableTaskBuilder(Context, new MemoryCache(new MemoryCacheOptions()), Mock.Of<IUserAuthorizationService>());
+
+            var result = await sut.Build(TaskIdForTaskWithoutLinks);
+
+            result.TaskId.ShouldBe(TaskIdForTaskWithoutLinks);
+            result.EventId.ShouldBe(-1);
+            result.CampaignId.ShouldBe(-1);
+            result.OrganizationId.ShouldBe(-1);
+        }
+
+        [Fact]
+        public async Task Build_WithJustTaskId_ReturnsTheAuthorizableTaskFromTheDatabase_WithExpectedIds_WhenPartialLinkedElements()
+        {
+            var sut = new AuthorizableTaskBuilder(Context, new MemoryCache(new MemoryCacheOptions()), Mock.Of<IUserAuthorizationService>());
+
+            var result = await sut.Build(TaskIdForTaskWithPartialLinks);
+
+            result.TaskId.ShouldBe(TaskIdForTaskWithPartialLinks);
+            result.EventId.ShouldBe(-1);
+            result.CampaignId.ShouldBe(-1);
+            result.OrganizationId.ShouldBe(30);
+        }
+
+        [Fact]
+        public async Task Build_SetsCaches_WithTheAuthorizableTask()
+        {
+            var cache = new MemoryCache(new MemoryCacheOptions());
+
+            var sut = new AuthorizableTaskBuilder(Context, cache, Mock.Of<IUserAuthorizationService>());
+
+            var result = await sut.Build(TaskId);
+
+            var foundInCache = cache.TryGetValue("AuthorizableTask_" + TaskId, out IAuthorizableTaskIdContainer AuthorizableTask);
+
+            foundInCache.ShouldBeTrue();
+            AuthorizableTask.TaskId.ShouldBe(TaskId);
+            AuthorizableTask.EventId.ShouldBe(10);
+            AuthorizableTask.CampaignId.ShouldBe(20);
+            AuthorizableTask.OrganizationId.ShouldBe(30);
+        }
+
+        private class FakeAuthorizableTaskIdContainer : IAuthorizableTaskIdContainer
+        {
+            public int TaskId => AuthorizableTaskBuilderTests.TaskId;
+
+            public int ItineraryId => 100;
+
+            public int EventId => 200;
+
+            public int CampaignId => 300;
+
+            public int OrganizationId => 400;
+        }
+
+        protected override void LoadTestData()
+        {
+            var org = new Organization { Id = 30 };
+
+            Context.Organizations.Add(org);
+
+            var campaign = new Campaign { Id = 20, ManagingOrganization = org };
+
+            Context.Campaigns.Add(campaign);
+
+            var @event = new Event { Id = 10, Campaign = campaign };
+
+            Context.Events.Add(@event);
+
+            var task = new VolunteerTask { Id = TaskId, EventId = 10, Organization = org };
+            var taskWithoutLinks = new VolunteerTask { Id = TaskIdForTaskWithoutLinks };
+            var TaskWithPartialLinks = new VolunteerTask { Id = TaskIdForTaskWithPartialLinks, Organization = org };
+
+            Context.VolunteerTasks.Add(task);
+            Context.VolunteerTasks.Add(taskWithoutLinks);
+            Context.VolunteerTasks.Add(TaskWithPartialLinks);
+
+            Context.SaveChanges();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Security/AuthorizableTaskTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Security/AuthorizableTaskTests.cs
@@ -1,0 +1,292 @@
+﻿using AllReady.Security;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AllReady.UnitTest.Security
+{
+    public class AuthorizableTaskTests
+    {
+        #region NoAssociatedUser
+
+        private static async Task<IAuthorizableTask> AuthorizableTaskWhenNoAssociatedUser()
+        {
+            var userAuthService = new Mock<IUserAuthorizationService>();
+            userAuthService.Setup(x => x.HasAssociatedUser).Returns(false);
+
+            var authEventBuilder = new AuthorizableTaskBuilder(null, new MemoryCache(new MemoryCacheOptions()), userAuthService.Object);
+
+            return await authEventBuilder.Build(1001, 3, 4, 5);
+        }
+
+        [Fact]
+        public async Task UserCanView_ReturnsFalse_WhenUserAuthorizationService_HasNoAssociatedUser()
+        {
+            var sut = await AuthorizableTaskWhenNoAssociatedUser();
+
+            var isAuthorized = await sut.UserCanView();
+
+            isAuthorized.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task UserCanDelete_ReturnsFalse_WhenUserAuthorizationService_HasNoAssociatedUser()
+        {
+            var sut = await AuthorizableTaskWhenNoAssociatedUser();
+
+            var isAuthorized = await sut.UserCanDelete();
+
+            isAuthorized.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task UserCanEdit_ReturnsFalse_WhenUserAuthorizationService_HasNoAssociatedUser()
+        {
+            var sut = await AuthorizableTaskWhenNoAssociatedUser();
+
+            var isAuthorized = await sut.UserCanEdit();
+
+            isAuthorized.ShouldBeFalse();
+        }      
+
+        #endregion
+
+        #region SiteAdminUser
+
+        private static async Task<IAuthorizableTask> AuthorizableTaskWhenSiteAdminUser()
+        {
+            var userAuthService = new Mock<IUserAuthorizationService>();
+            userAuthService.Setup(x => x.HasAssociatedUser).Returns(true);
+            userAuthService.Setup(x => x.IsSiteAdmin).Returns(true);
+
+            var authEventBuilder = new AuthorizableTaskBuilder(null, new MemoryCache(new MemoryCacheOptions()), userAuthService.Object);
+
+            return await authEventBuilder.Build(1001, 3, 4, 5);
+        }
+
+        [Fact]
+        public async Task UserCanView_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsSiteAdmin()
+        {
+            var sut = await AuthorizableTaskWhenSiteAdminUser();
+
+            var isAuthorized = await sut.UserCanView();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UserCanDelete_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsSiteAdmin()
+        {
+            var sut = await AuthorizableTaskWhenSiteAdminUser();
+
+            var isAuthorized = await sut.UserCanDelete();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UserCanEdit_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsSiteAdmin()
+        {
+            var sut = await AuthorizableTaskWhenSiteAdminUser();
+
+            var isAuthorized = await sut.UserCanEdit();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        #endregion
+
+        #region OrgAdminUser
+
+        private static async Task<IAuthorizableTask> AuthorizableTaskWhenOrgAdminUser()
+        {
+            var userAuthService = new Mock<IUserAuthorizationService>();
+            userAuthService.Setup(x => x.HasAssociatedUser).Returns(true);
+            userAuthService.Setup(x => x.IsOrganizationAdmin(It.IsAny<int>())).Returns(true);
+
+            var authEventBuilder = new AuthorizableTaskBuilder(null, new MemoryCache(new MemoryCacheOptions()), userAuthService.Object);
+
+            return await authEventBuilder.Build(1001, 3, 4, 5);
+        }
+
+        [Fact]
+        public async Task UserCanView_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsOrganizationAdmin_ReturnsTrue()
+        {
+            var sut = await AuthorizableTaskWhenOrgAdminUser();
+
+            var isAuthorized = await sut.UserCanView();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UserCanDelete_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsOrgAdmin()
+        {
+            var sut = await AuthorizableTaskWhenOrgAdminUser();
+
+            var isAuthorized = await sut.UserCanDelete();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UserCanEdit_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsOrgAdmin()
+        {
+            var sut = await AuthorizableTaskWhenOrgAdminUser();
+
+            var isAuthorized = await sut.UserCanEdit();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        #endregion
+
+        #region EventManagerUser
+
+        private static async Task<IAuthorizableTask> AuthorizableTaskWhenEventManagerUser()
+        {
+            var userAuthService = new Mock<IUserAuthorizationService>();
+            userAuthService.Setup(x => x.HasAssociatedUser).Returns(true);
+            userAuthService.Setup(x => x.IsSiteAdmin).Returns(false);
+            userAuthService.Setup(x => x.IsOrganizationAdmin(It.IsAny<int>())).Returns(false);
+            userAuthService.Setup(x => x.GetManagedEventIds()).ReturnsAsync(new List<int> { 3 });
+
+            var authEventBuilder = new AuthorizableTaskBuilder(null, new MemoryCache(new MemoryCacheOptions()), userAuthService.Object);
+
+            return await authEventBuilder.Build(1001, 3, 4, 5);
+        }
+        
+        [Fact]
+        public async Task UserCanView_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsEventManager()
+        {
+            var sut = await AuthorizableTaskWhenEventManagerUser();
+
+            var isAuthorized = await sut.UserCanView();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UserCanDelete_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsEventManager()
+        {
+            var sut = await AuthorizableTaskWhenEventManagerUser();
+
+            var isAuthorized = await sut.UserCanDelete();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UserCanEdit_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsEventManager()
+        {
+            var sut = await AuthorizableTaskWhenEventManagerUser();
+
+            var isAuthorized = await sut.UserCanEdit();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        #endregion
+
+        #region CampaignManagerUser
+
+        private static async Task<IAuthorizableTask> AuthorizableTaskWhenCampaignManagerUser()
+        {
+            var userAuthService = new Mock<IUserAuthorizationService>();
+            userAuthService.Setup(x => x.HasAssociatedUser).Returns(true);
+            userAuthService.Setup(x => x.IsSiteAdmin).Returns(false);
+            userAuthService.Setup(x => x.IsOrganizationAdmin(It.IsAny<int>())).Returns(false);
+            userAuthService.Setup(x => x.GetManagedEventIds()).ReturnsAsync(new List<int>());
+            userAuthService.Setup(x => x.GetManagedCampaignIds()).ReturnsAsync(new List<int> { 4 });
+
+            var authEventBuilder = new AuthorizableTaskBuilder(null, new MemoryCache(new MemoryCacheOptions()), userAuthService.Object);
+
+            return await authEventBuilder.Build(1001, 3, 4, 5);
+        }
+        
+        [Fact]
+        public async Task UserCanView_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsCampaignManager()
+        {
+            var sut = await AuthorizableTaskWhenCampaignManagerUser();
+
+            var isAuthorized = await sut.UserCanView();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UserCanDelete_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsCampaignManager()
+        {
+            var sut = await AuthorizableTaskWhenCampaignManagerUser();
+
+            var isAuthorized = await sut.UserCanDelete();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task UserCanEdit_ReturnsTrue_WhenUserAuthorizationService_HasAssociatedUser_AndIsCampaignManager()
+        {
+            var sut = await AuthorizableTaskWhenCampaignManagerUser();
+
+            var isAuthorized = await sut.UserCanEdit();
+
+            isAuthorized.ShouldBeTrue();
+        }
+
+        #endregion
+
+        #region NotAuthorizedUser
+
+        private static async Task<IAuthorizableTask> AuthorizableTaskWhenUserAssociatedIsNotAdminOrManager()
+        {
+            var userAuthService = new Mock<IUserAuthorizationService>();
+            userAuthService.Setup(x => x.HasAssociatedUser).Returns(true);
+            userAuthService.Setup(x => x.IsSiteAdmin).Returns(false);
+            userAuthService.Setup(x => x.IsOrganizationAdmin(It.IsAny<int>())).Returns(false);
+            userAuthService.Setup(x => x.GetManagedEventIds()).ReturnsAsync(new List<int>());
+            userAuthService.Setup(x => x.GetManagedCampaignIds()).ReturnsAsync(new List<int>());
+            userAuthService.Setup(x => x.GetLedItineraryIds()).ReturnsAsync(new List<int>());
+
+            var authEventBuilder = new AuthorizableTaskBuilder(null, new MemoryCache(new MemoryCacheOptions()), userAuthService.Object);
+
+            return await authEventBuilder.Build(1001, 3, 4, 5);
+        }
+
+        [Fact]
+        public async Task UserCanView_ReturnsFalse_WhenUserAuthorizationService_HasAssociatedUser_AndAllOtherChecksAreNotMatched()
+        {
+            var sut = await AuthorizableTaskWhenUserAssociatedIsNotAdminOrManager();
+
+            var isAuthorized = await sut.UserCanView();
+
+            isAuthorized.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task UserCanDelete_ReturnsFalse_WhenUserAuthorizationService_HasAssociatedUser_AndAllOtherChecksAreNotMatched()
+        {
+            var sut = await AuthorizableTaskWhenUserAssociatedIsNotAdminOrManager();
+
+            var isAuthorized = await sut.UserCanDelete();
+
+            isAuthorized.ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task UserCanEdit_ReturnsFalse_WhenUserAuthorizationService_HasAssociatedUser_AndAllOtherChecksAreNotMatched()
+        {
+            var sut = await AuthorizableTaskWhenUserAssociatedIsNotAdminOrManager();
+
+            var isAuthorized = await sut.UserCanEdit();
+
+            isAuthorized.ShouldBeFalse();
+        }
+
+        #endregion
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/AuthorizableTaskQuery.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/Tasks/AuthorizableTaskQuery.cs
@@ -1,0 +1,65 @@
+﻿using AllReady.Security;
+using MediatR;
+using System.Threading.Tasks;
+
+namespace AllReady.Areas.Admin.Features.Tasks
+{
+    /// <summary>
+    /// Uses an <see cref="IAuthorizableTaskBuilder"/> to build a <see cref="IAuthorizableTask"/>
+    /// </summary>
+    public class AuthorizableTaskQuery : IAsyncRequest<IAuthorizableTask>
+    {
+        /// <summary>
+        /// Initializes a new instance of an <see cref="AuthorizableTaskQuery"/>.
+        /// Uses an <see cref="IAuthorizableTaskBuilder"/> to build a <see cref="IAuthorizableTask"/>
+        /// </summary>
+        public AuthorizableTaskQuery(int taskId, int? eventId = null, int? campaignId = null, int? orgId = null)
+        {
+            TaskId = taskId;
+            EventId = eventId;
+            CampaignId = campaignId;
+            OrganizationId = orgId;
+        }
+
+        /// <summary>
+        /// The task ID
+        /// </summary>
+        public int TaskId { get; }
+
+        /// <summary>
+        /// The event ID for the task, if known
+        /// </summary>
+        public int? EventId { get; }
+
+        /// <summary>
+        /// The organization ID for the task, if known
+        /// </summary>
+        public int? OrganizationId { get; }
+
+        /// <summary>
+        /// The campaign ID for the task, if known
+        /// </summary>
+        public int? CampaignId { get; }
+    }
+
+    /// <summary>
+    /// Handles an <see cref="AuthorizableTaskQuery"/>
+    /// </summary>
+    public class AuthorizableTaskQueryHandler : IAsyncRequestHandler<AuthorizableTaskQuery, IAuthorizableTask>
+    {
+        private readonly IAuthorizableTaskBuilder _authorizableTaskBuilder;
+
+        public AuthorizableTaskQueryHandler(IAuthorizableTaskBuilder authorizableTaskBuilder)
+        {
+            _authorizableTaskBuilder = authorizableTaskBuilder;
+        }
+
+        /// <summary>
+        /// Handles an <see cref="AuthorizableTaskQuery"/>
+        /// </summary>
+        public async Task<IAuthorizableTask> Handle(AuthorizableTaskQuery message)
+        {
+            return await _authorizableTaskBuilder.Build(message.TaskId, message.EventId, message.CampaignId, message.OrganizationId);
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Security/AuthorizableTaskBuilder.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/AuthorizableTaskBuilder.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Threading.Tasks;
+using AllReady.Models;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace AllReady.Security
+{
+    public class AuthorizableTaskBuilder : IAuthorizableTaskBuilder
+    {
+        private readonly AllReadyContext _context;
+        private readonly IMemoryCache _cache;
+        private readonly IUserAuthorizationService _userAuthorizationService;
+
+        private const string CachePrefix = "AuthorizableTask_";
+
+        public AuthorizableTaskBuilder(AllReadyContext context, IMemoryCache cache, IUserAuthorizationService userAuthorizationService)
+        {
+            _context = context;
+            _cache = cache;
+            _userAuthorizationService = userAuthorizationService;
+        }
+
+        /// <inheritdoc />
+        public async Task<IAuthorizableTask> Build(int taskId, int? eventId = null, int? campaignId = null, int? orgId = null)
+        {
+            IAuthorizableTaskIdContainer cacheAuthorizableTaskIdContainer;
+
+            if (taskId == 0)
+            {
+                return new NotFoundAuthorizableTask();
+            }
+
+            if (_cache.TryGetValue(GetCacheKey(taskId), out cacheAuthorizableTaskIdContainer))
+            {
+                return new AuthorizableTask(cacheAuthorizableTaskIdContainer, _userAuthorizationService);
+            }
+
+            int finalEventId;
+            int finalCampaignId;
+            int finalOrgId;
+
+            if (!HasValidIds(eventId, campaignId, orgId))
+            {
+                var loadedIds = await
+                    _context.VolunteerTasks.AsNoTracking()
+                        .Where(x => x.Id == taskId)
+                        .Include(x => x.Event).ThenInclude(x => x.Campaign)
+                        .Include(x => x.Organization)
+                        .FirstOrDefaultAsync();
+
+                if (loadedIds == null)
+                {
+                    return new NotFoundAuthorizableTask();
+                }
+
+                finalEventId = loadedIds.Event == null ? -1 : loadedIds.EventId;
+                finalCampaignId = loadedIds.Event == null ? -1 : loadedIds.Event.CampaignId;
+                finalOrgId = loadedIds.Organization == null ? -1 : loadedIds.Organization.Id;
+            }
+            else
+            {
+                finalEventId = eventId.Value;
+                finalCampaignId = campaignId.Value;
+                finalOrgId = orgId.Value;
+            }
+
+            var authorizedEventIdContainer = new AuthorizableTaskIdContainer(taskId, finalEventId, finalCampaignId, finalOrgId);
+
+            _cache.Set(GetCacheKey(taskId), authorizedEventIdContainer, TimeSpan.FromHours(1)); // cached for 1 hour
+
+            return new AuthorizableTask(authorizedEventIdContainer, _userAuthorizationService);
+        }
+
+        private class AuthorizableTaskIdContainer : IAuthorizableTaskIdContainer
+        {
+            public AuthorizableTaskIdContainer(int taskId, int eventId, int campaignId, int orgId)
+            {
+                TaskId = taskId;
+                EventId = eventId;
+                CampaignId = campaignId;
+                OrganizationId = orgId;
+            }
+
+            public int TaskId { get; }
+            public int EventId { get; }
+            public int OrganizationId { get; }
+            public int CampaignId { get; }
+        }
+
+        private static bool HasValidIds(int? eventId, int? campaignId, int? orgId)
+        {
+            if (!eventId.HasValue || !campaignId.HasValue || !orgId.HasValue)
+            {
+                return false;
+            }
+
+            return eventId.Value != 0 && campaignId.Value != 0 && orgId.Value != 0;
+        }
+
+        private static string GetCacheKey(int taskId)
+        {
+            return string.Concat(CachePrefix, taskId.ToString());
+        }
+
+        private class NotFoundAuthorizableTask : IAuthorizableTask
+        {
+            public int TaskId => 0;
+            public int CampaignId => 0;
+            public int EventId => 0;
+            public int OrganizationId => 0;
+
+            public Task<bool> UserCanView()
+            {
+                return Task.FromResult(false);
+            }
+
+            public Task<bool> UserCanEdit()
+            {
+                return Task.FromResult(false);
+            }
+
+            public Task<bool> UserCanDelete()
+            {
+                return Task.FromResult(false);
+            }
+        }
+
+        /// <inheritdoc />
+        private class AuthorizableTask : IAuthorizableTask
+        {
+            private readonly IUserAuthorizationService _userAuthorizationService;
+
+            public AuthorizableTask(IAuthorizableTaskIdContainer AuthorizableTaskIds, IUserAuthorizationService userAuthorizationService)
+            {
+                _userAuthorizationService = userAuthorizationService;
+                TaskId = AuthorizableTaskIds.TaskId;
+                EventId = AuthorizableTaskIds.EventId;
+                CampaignId = AuthorizableTaskIds.CampaignId;
+                OrganizationId = AuthorizableTaskIds.OrganizationId;
+            }
+
+            /// <inheritdoc />
+            public int TaskId { get; }
+
+            /// <inheritdoc />
+            public int EventId { get; }
+
+            /// <inheritdoc />
+            public int CampaignId { get; }
+
+            /// <inheritdoc />
+            public int OrganizationId { get; }
+
+            private async Task<ItineraryAccessType> UserAccessType()
+            {
+                if (!_userAuthorizationService.HasAssociatedUser)
+                {
+                    return ItineraryAccessType.Unauthorized;
+                }
+
+                if (_userAuthorizationService.IsSiteAdmin)
+                {
+                    return ItineraryAccessType.SiteAdmin;
+                }
+
+                if (_userAuthorizationService.IsOrganizationAdmin(OrganizationId))
+                {
+                    return ItineraryAccessType.OrganizationAdmin;
+                }
+
+                var managedEventIds = await _userAuthorizationService.GetManagedEventIds();
+
+                if (managedEventIds.Contains(EventId))
+                {
+                    return ItineraryAccessType.EventAdmin;
+                }
+
+                var managedCampaignIds = await _userAuthorizationService.GetManagedCampaignIds();
+
+                if (managedCampaignIds.Contains(CampaignId))
+                {
+                    return ItineraryAccessType.CampaignAdmin;
+                }
+
+                return ItineraryAccessType.Unknown;
+            }
+
+            /// <inheritdoc />
+            public Task<bool> UserCanDelete()
+            {
+                return UserCanManage();
+            }
+
+            /// <inheritdoc />
+            public Task<bool> UserCanView()
+            {
+                return UserCanManage();
+            }
+
+            /// <inheritdoc />
+            public Task<bool> UserCanEdit()
+            {
+                return UserCanManage();
+            }
+
+            private async Task<bool> UserCanManage()
+            {
+                var userAccessType = await UserAccessType();
+
+                return userAccessType == ItineraryAccessType.SiteAdmin
+                       || userAccessType == ItineraryAccessType.OrganizationAdmin
+                       || userAccessType == ItineraryAccessType.CampaignAdmin
+                       || userAccessType == ItineraryAccessType.EventAdmin;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Defines the possible access types that can potentially manage an <see cref="IAuthorizableTask"/>
+    /// </summary>
+    public enum TaskAccessType
+    {
+        Unknown = 0,
+        Unauthorized = 1,
+        SiteAdmin = 2,
+        OrganizationAdmin = 3,
+        CampaignAdmin = 4,
+        EventAdmin = 5,
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Security/IAuthorizableTask.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/IAuthorizableTask.cs
@@ -1,0 +1,25 @@
+﻿namespace AllReady.Security
+{
+    public interface IAuthorizableTask : IAuthorizable
+    {
+        /// <summary>
+        /// The ID of the task
+        /// </summary>
+        int TaskId { get; }
+
+        /// <summary>
+        /// The ID of the event that the task belongs to
+        /// </summary>
+        int EventId { get; }
+
+        /// <summary>
+        /// The ID of the campaign that the task belongs to
+        /// </summary>
+        int CampaignId { get; }
+
+        /// <summary>
+        /// The ID of the organization that the task belongs to
+        /// </summary>
+        int OrganizationId { get; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Security/IAuthorizableTaskBuilder.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/IAuthorizableTaskBuilder.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+
+namespace AllReady.Security
+{
+    /// <summary>
+    /// Builder for <see cref="IAuthorizableTask"/>s
+    /// </summary>
+    public interface IAuthorizableTaskBuilder
+    {
+        /// <summary>
+        /// Builds an instance of an <see cref="IAuthorizableTask"/>
+        /// </summary>
+        Task<IAuthorizableTask> Build(int taskId, int? eventId = null, int? campaignId = null, int? orgId = null);
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Security/IAuthorizableTaskIdContainer.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/IAuthorizableTaskIdContainer.cs
@@ -1,0 +1,14 @@
+﻿namespace AllReady.Security
+{
+    /// <summary>
+    /// Contains the IDs that form full knowledge of components required to establish authorization on an <see cref="IAuthorizableTask"/>
+    /// </summary>
+    /// <remarks>This is used for caching of the results of an <see cref="IAuthorizableTask"/></remarks>
+    public interface IAuthorizableTaskIdContainer
+    {
+        int TaskId { get; }
+        int EventId { get; }
+        int CampaignId { get; }
+        int OrganizationId { get; }
+    }
+}


### PR DESCRIPTION
Missing AuthorizationTask #1973

Adds IAuthorizableTask and related classes

@stevejgordon - I followed the pattern you used for the domain entity model.  I used the implementation you created for Request as a template.
- removed Itinerary related code like testing for TeamLead since they don't apply to Task
- believe I've got the Build method correct in AuthorizableTaskBuilder - definitely need you to take a look

