### PR TITLE
Fixes #1976 broken integration test

### DIFF
--- a/AllReadyApp/AllReady.IntegrationTest/Pages.fs
+++ b/AllReadyApp/AllReady.IntegrationTest/Pages.fs
@@ -3,7 +3,7 @@ open canopy
 
 module TopMenu =
     let private Campaigns = "Campaigns"
-    let private Admin = "li.dropdown-admin a"
+    let private Admin = "li.dropdown a"
     let private AdminCampaigns = "a[href='/Admin/Campaign']"
     let private AdminOrganizations = "a[href='/Admin/Organization']"
 


### PR DESCRIPTION
Fixes #1976 

The fix for #1877 changed a tag in `_AdminNavigationPartial.cshtml` on which the integration tests requires.