### PR TITLE
Fix admin menu in integrations test

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_AdminNavigationPartial.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_AdminNavigationPartial.cshtml
@@ -6,7 +6,7 @@
     var areaName = descriptor.RouteValues["area"]; // there must be a better way to get the area name!
     var controllerName = descriptor.ControllerName;
     var isAdmin = areaName == "Admin";
-    <li class="dropdown @(isAdmin? "active":"")">
+    <li class="dropdown dropdown-admin @(isAdmin? "active":"")">
         <a class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-haspopup="true" aria-expanded="false">
             Admin <span class="caret"></span>
         </a>


### PR DESCRIPTION
Fixes #1976

This is a pretty minor change, just adding a class back that was mistakenly removed.  The class is only used in the integration test to locate the Admin menu.