### PR TITLE
Fixes  #1961 Replacing Image Deletes Updated Image

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using AllReady.Areas.Admin.Features.Campaigns;
 using AllReady.Extensions;
@@ -121,7 +121,7 @@ namespace AllReady.Areas.Admin.Controllers
                         if (!string.IsNullOrEmpty(newImageUrl))
                         {
                             campaign.ImageUrl = newImageUrl;
-                            if (existingImageUrl != null)
+                            if (existingImageUrl != null && existingImageUrl != newImageUrl)
                             {
                                 await _imageService.DeleteImageAsync(existingImageUrl);
                             }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/EventAdminController.cs
@@ -189,11 +189,11 @@ namespace AllReady.Areas.Admin.Controllers
                     if (fileUpload.IsAcceptableImageContentType())
                     {
                         var existingImageUrl = eventEditViewModel.ImageUrl;
-                        var newImageUrl = await _imageService.UploadEventImageAsync(campaign.OrganizationId, campaign.Id, fileUpload);
+                        var newImageUrl = await _imageService.UploadEventImageAsync(campaign.OrganizationId, eventEditViewModel.Id, fileUpload);
                         if (!string.IsNullOrEmpty(newImageUrl))
                         {
                             eventEditViewModel.ImageUrl = newImageUrl;
-                            if (existingImageUrl != null)
+                            if (existingImageUrl != null && existingImageUrl != newImageUrl)
                             {
                                 await _imageService.DeleteImageAsync(existingImageUrl);
                             }


### PR DESCRIPTION
Fixes #1961 Replacing Image Deletes Updated Image

- Fixes  image deleted when image is updated for CampaignController
- Fixes image deleted when image is updated for EventController
- Fixes wrong parameters sent to UploadEventImageAsync method