### PR TITLE
Added unit test to cover the SendInProgressStatusToGetASmokeAlarmHandler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,8 @@ _TeamCity*
 # NCrunch
 _NCrunch_*
 .*crunch*.local.xml
+*.ncrunchproject
+*.ncrunchsolution
 
 # MightyMoose
 *.mm.*

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Notifications/SendInProgressStatusToGetASmokeAlarmHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Notifications/SendInProgressStatusToGetASmokeAlarmHandlerShould.cs
@@ -1,11 +1,54 @@
-﻿using System;
+﻿using AllReady.Areas.Admin.Features.Notifications;
+using AllReady.Hangfire.Jobs;
+using AllReady.Models;
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.States;
+using Moq;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace AllReady.UnitTest.Areas.Admin.Features.Notifications
 {
-    public class SendInProgressStatusToGetASmokeAlarmHandlerShould
+
+
+    public class SendInProgressStatusToGetASmokeAlarmHandlerShould : InMemoryContextTest
     {
+        private const string firstProviderrequestid = "providerRequestId1";
+        private const string secondProviderrequestid = "providerRequestId2";
+        private readonly Guid firstRequestId = Guid.NewGuid();
+        private readonly Guid secondRequestId = Guid.NewGuid();
+        private readonly Mock<IBackgroundJobClient> backgroundJobClient;
+
+        public SendInProgressStatusToGetASmokeAlarmHandlerShould()
+        {
+            backgroundJobClient = new Mock<IBackgroundJobClient>();
+            Context.Requests.Add(new Request { RequestId = firstRequestId, ProviderRequestId = firstProviderrequestid, Source = RequestSource.Api });
+            Context.Requests.Add(new Request { RequestId = secondRequestId, ProviderRequestId = secondProviderrequestid, Source = RequestSource.Api });
+            Context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task EnqueueARequestToGasaWithAStatusOfInProgressAndAcceptanceOfTrueForEveryRequestIdOnTheNotification()
+        {
+            const bool expectedAcceptance = true;
+            var notification = new RequestsAssignedToItinerary
+            {
+                ItineraryId = 1,
+                RequestIds = new List<Guid>
+                {
+                    firstRequestId,
+                    secondRequestId
+                }
+            };
+
+            var sut = new SendInProgressStatusToGetASmokeAlarmHandler(Context, backgroundJobClient.Object);
+            await sut.Handle(notification);
+
+            backgroundJobClient.Verify(s => s.Create(It.Is<Job>(job => (string)job.Args[0] == firstProviderrequestid && (string)job.Args[1] == GasaStatus.InProgress && (bool)job.Args[2] == expectedAcceptance), It.IsAny<EnqueuedState>()), Times.Once);
+            backgroundJobClient.Verify(s => s.Create(It.Is<Job>(job => (string)job.Args[0] == secondProviderrequestid && (string)job.Args[1] == GasaStatus.InProgress && (bool)job.Args[2] == expectedAcceptance), It.IsAny<EnqueuedState>()), Times.Once);
+        }
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Notifications/SendInProgressStatusToGetASmokeAlarmHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/Notifications/SendInProgressStatusToGetASmokeAlarmHandlerShould.cs
@@ -12,8 +12,6 @@ using Xunit;
 
 namespace AllReady.UnitTest.Areas.Admin.Features.Notifications
 {
-
-
     public class SendInProgressStatusToGetASmokeAlarmHandlerShould : InMemoryContextTest
     {
         private const string firstProviderrequestid = "providerRequestId1";
@@ -47,8 +45,8 @@ namespace AllReady.UnitTest.Areas.Admin.Features.Notifications
             var sut = new SendInProgressStatusToGetASmokeAlarmHandler(Context, backgroundJobClient.Object);
             await sut.Handle(notification);
 
-            backgroundJobClient.Verify(s => s.Create(It.Is<Job>(job => (string)job.Args[0] == firstProviderrequestid && (string)job.Args[1] == GasaStatus.InProgress && (bool)job.Args[2] == expectedAcceptance), It.IsAny<EnqueuedState>()), Times.Once);
-            backgroundJobClient.Verify(s => s.Create(It.Is<Job>(job => (string)job.Args[0] == secondProviderrequestid && (string)job.Args[1] == GasaStatus.InProgress && (bool)job.Args[2] == expectedAcceptance), It.IsAny<EnqueuedState>()), Times.Once);
+            backgroundJobClient.Verify(s => s.Create(It.Is<Job>(job => job.Method.Name == nameof(SendRequestStatusToGetASmokeAlarm.Send) && (string)job.Args[0] == firstProviderrequestid && (string)job.Args[1] == GasaStatus.InProgress && (bool)job.Args[2] == expectedAcceptance), It.IsAny<EnqueuedState>()), Times.Once);
+            backgroundJobClient.Verify(s => s.Create(It.Is<Job>(job => job.Method.Name == nameof(SendRequestStatusToGetASmokeAlarm.Send) &&  (string)job.Args[0] == secondProviderrequestid && (string)job.Args[1] == GasaStatus.InProgress && (bool)job.Args[2] == expectedAcceptance), It.IsAny<EnqueuedState>()), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Fixes #1765.

I settled on only one Unit Test for this. I'm not 100% convinced about it, but it seemed overkill to cover separate use-cases for a single request *and* multiple requests.

One thing I can think of that might be worth covering is a negative case, to verify that if no requests are found then nothing is queued up. One would argue we'd be testing the .NET framework, but at the very least it would verify the behaviour of this particular handler, instead of the implementation. 