### PR TITLE
Moved !-circle when logged in with incomplete profile

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_LoginPartial.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_LoginPartial.cshtml
@@ -15,11 +15,11 @@
             </li>
             <li class="dropdown">
                 <a asp-area="" asp-controller="Manage" asp-action="Index" title="Manage" class="dropdown-toggle dropdown-account" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                    Hello @User.GetDisplayName(userManager)
                     @if (User.IsUserProfileIncomplete())
                     {
                         <i class="fa fa-exclamation-circle user-profile-warning" title="Click here to add more details to your profile"></i>
                     }
+                    Hello @User.GetDisplayName(userManager)
                     <span class="caret"></span>
                 </a>
                 <ul class="dropdown-menu">

--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -311,7 +311,6 @@ Navigation
 }
 
 .navbar .login-status .user-profile-warning {
-    float: right;
     line-height: 20px;
     font-size: 1.1em;
     margin-left: -7px;


### PR DESCRIPTION
Moved !-circle to be before user name when logged in with incomplete profile to not cover caret.

Closes #1982 