### PR TITLE
Remove events from locked or not published campaigns from start page

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Home/ActiveOrUpcomingEventsQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Home/ActiveOrUpcomingEventsQueryHandlerShould.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using AllReady.Features.Home;
@@ -11,6 +11,8 @@ namespace AllReady.UnitTest.Features.Home
     public class ActiveOrUpcomingEventsQueryHandlerShould : InMemoryContextTest
     {
         private const string Expired = "Expired";
+        private const string EventForLockedCampaign = "Event for locked campaign";
+        private const string EventForNotPublishedCampaign = "Event for not published campaign";
 
         private static DateTime DateTimeUtcTestDate = new DateTime(2016, 12, 01, 10, 00, 00, DateTimeKind.Utc);
         private static readonly DateTimeOffset DateTimeOffsetNow = new DateTimeOffset(DateTimeUtcTestDate);
@@ -46,17 +48,61 @@ namespace AllReady.UnitTest.Features.Home
             result.Any(x => x.Name == Expired).ShouldBeFalse();
         }
 
+        [Fact]
+        public async Task NotReturnEventsForLockedCampaigns()
+        {
+            // Arrange
+            var handler = new ActiveOrUpcomingEventsQueryHandler(Context);
+
+            // Act
+            var result = await handler.Handle(new ActiveOrUpcomingEventsQuery());
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Any(x => x.Name == EventForLockedCampaign).ShouldBeFalse();
+        }
+
+        [Fact]
+        public async Task NotReturnEventsForNotPublishedCampaigns()
+        {
+            // Arrange
+            var handler = new ActiveOrUpcomingEventsQueryHandler(Context);
+
+            // Act
+            var result = await handler.Handle(new ActiveOrUpcomingEventsQuery());
+
+            // Assert
+            result.ShouldNotBeNull();
+            result.Any(x => x.Name == EventForNotPublishedCampaign).ShouldBeFalse();
+        }
 
         protected override void LoadTestData()
         {
+            var managingOrganization = new Organization
+            {
+                Name = "Some Managing Organization Name"
+            };
         
             var campaign = new Campaign()
             {
                 Name = "Some Campaign",
-                ManagingOrganization = new Organization()
-                {
-                    Name = "Some Managing Organization Name"
-                }
+                ManagingOrganization = managingOrganization,
+                Published = true,
+            };
+
+            var lockedCampaign = new Campaign
+            {
+                Name = "Locked campaign",
+                ManagingOrganization = managingOrganization,
+                Published = true,
+                Locked = true,
+            };
+
+            var notPublishedCampaign = new Campaign
+            {
+                Name = "Not published campaign",
+                ManagingOrganization = managingOrganization,
+                Published = false
             };
             
             Context.Events.Add(new AllReady.Models.Event
@@ -105,6 +151,22 @@ namespace AllReady.UnitTest.Features.Home
                 Campaign = campaign,
                 StartDateTime = DateTimeUtcTestDate.AddDays(-10),
                 EndDateTime = new DateTime(2016, 11, 30, 23, 59, 59)
+            });
+
+            Context.Events.Add(new AllReady.Models.Event
+            {
+                Name = EventForLockedCampaign,
+                Campaign = lockedCampaign,
+                StartDateTime = DateTimeUtcTestDate.AddDays(1),
+                EndDateTime = DateTimeUtcTestDate.AddDays(10)
+            });
+
+            Context.Events.Add(new AllReady.Models.Event
+            {
+                Name = EventForNotPublishedCampaign,
+                Campaign = notPublishedCampaign,
+                StartDateTime = DateTimeUtcTestDate.AddDays(1),
+                EndDateTime = DateTimeUtcTestDate.AddDays(10)
             });
 
             Context.SaveChanges();

--- a/AllReadyApp/Web-App/AllReady/Features/Home/ActiveOrUpcomingEventsQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Home/ActiveOrUpcomingEventsQueryHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -24,7 +24,9 @@ namespace AllReady.Features.Home
             return await _context.Events
                 .AsNoTracking()
                 .Include(x => x.Campaign).ThenInclude(x => x.ManagingOrganization)
-                .Where(ev => ev.EndDateTime.Date >= DateTimeOffsetUtcNow().Date)
+                .Where(ev => ev.EndDateTime.Date >= DateTimeOffsetUtcNow().Date && 
+                            !ev.Campaign.Locked && 
+                             ev.Campaign.Published)
                 .Select(ev => new ActiveOrUpcomingEvent()
                 {
                     Id = ev.Id,


### PR DESCRIPTION
Remove events from locked or not published campaigns from start page

Closes #1925 