### PR TITLE
Eager-loading important Event properties into the EventViewModel

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Event/EventsWithUnlockedCampaignsQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Event/EventsWithUnlockedCampaignsQueryHandlerShould.cs
@@ -26,6 +26,14 @@ namespace AllReady.UnitTest.Features.Event
                         PostalCode = "98052",
                         Address1 = "7031 148th Ave Ne",
                         Country = "US"
+                    },
+                    Campaign = new Campaign
+                    {
+                        Locked = false,
+                        ManagingOrganization = new Organization()
+                        {
+                            Name = "Humanitarian Toolbox"
+                        }
                     }
                 },
                 new Event {Id = 2, Campaign = new Campaign {Locked = true, ManagingOrganization = new Organization()}}

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Features/Event/EventsWithUnlockedCampaignsQueryHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Features/Event/EventsWithUnlockedCampaignsQueryHandlerShould.cs
@@ -17,7 +17,17 @@ namespace AllReady.UnitTest.Features.Event
 
             var campaignEvents = new List<Event>
             {
-                new Event {Id = unlockedEventId, Campaign = new Campaign {Locked = false, ManagingOrganization = new Organization()}},
+                new Event {
+                    Id = unlockedEventId,
+                    Location = new Location()
+                    {
+                        City = "Redmond",
+                        State = "WA",
+                        PostalCode = "98052",
+                        Address1 = "7031 148th Ave Ne",
+                        Country = "US"
+                    }
+                },
                 new Event {Id = 2, Campaign = new Campaign {Locked = true, ManagingOrganization = new Organization()}}
             };
             Context.Events.AddRange(campaignEvents);
@@ -27,6 +37,8 @@ namespace AllReady.UnitTest.Features.Event
             var results = await sut.Handle(new EventsWithUnlockedCampaignsQuery());
 
             Assert.Equal(results[0].Id, unlockedEventId);
+            Assert.Equal("98052", results[0].Location.PostalCode);
+            Assert.Equal("Humanitarian Toolbox", results[0].OrganizationName);
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Features/Events/EventsWithUnlockedCampaignsQueryHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Features/Events/EventsWithUnlockedCampaignsQueryHandler.cs
@@ -19,7 +19,14 @@ namespace AllReady.Features.Events
 
         public async Task<List<EventViewModel>> Handle(EventsWithUnlockedCampaignsQuery message)
         {
-            var @events = await dataContext.Events.Where(c => !c.Campaign.Locked).ToListAsync();
+            var @events = await dataContext.Events
+                .Where(c => !c.Campaign.Locked)
+                .Include(c => c.Campaign)
+                .Include(c => c.Campaign.ManagingOrganization)
+                .Include(c => c.Campaign.Location)
+                .Include(c => c.VolunteerTasks)
+                .ToListAsync();
+
             return @events.Select(@event => new EventViewModel(@event)).ToList();
         }
     }


### PR DESCRIPTION
Eager-loading important properties into the EventViewModel, so that the API consumer can get Campaign, Organization, Location, and Task information associated with an Event. Added unit test.

Closes #2030 