### PR TITLE
Hiding team management UI when user is not authorized to manage the team

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ItineraryAdminControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/ItineraryAdminControllerTests.cs
@@ -124,6 +124,27 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
         }
 
         [Fact]
+        public async Task DetailsGet_SetsTeamManagementEnabled_FromAuthorizableItinerary()
+        {
+            const int orgId = 1;
+            var viewModel = new ItineraryDetailsViewModel { OrganizationId = orgId };
+
+            var mediator = new Mock<IMediator>();
+            mediator.Setup(x => x.SendAsync(It.IsAny<ItineraryDetailQuery>())).ReturnsAsync(viewModel);
+            mediator.Setup(x => x.SendAsync(It.IsAny<AuthorizableItineraryQuery>())).ReturnsAsync(new FakeAuthorizableItinerary(true, false, false, false, false, true));
+
+            var userManager = UserManagerMockHelper.CreateUserManagerMock();
+            userManager.Setup(x => x.GetUserAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(new ApplicationUser());
+
+            var sut = new ItineraryController(mediator.Object, null, userManager.Object);
+
+            var result = await sut.Details(It.IsAny<int>()) as ViewResult;
+            var teamManagementEnabled = (result.ViewData.Model as ItineraryDetailsViewModel).TeamManagementEnabled;
+
+            Assert.Equal(teamManagementEnabled, true);
+        }
+
+        [Fact]
         public async Task DetailsGet_OptimizeRouteResultStatusQuery_WithExpectedValues()
         {
             const string userId = "123";

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/ItineraryController.cs
@@ -55,6 +55,7 @@ namespace AllReady.Areas.Admin.Controllers
             }
 
             itinerary.TeamLeadChangedSuccess = teamLeadSuccess;
+            itinerary.TeamManagementEnabled = await authorizableItinerary.UserCanManageTeamMembers();
 
             return View("Details", itinerary);
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Itinerary/ItineraryDetailsViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Itinerary/ItineraryDetailsViewModel.cs
@@ -90,5 +90,10 @@ namespace AllReady.Areas.Admin.ViewModels.Itinerary
         public bool? TeamLeadChangedSuccess { get; set; }
 
         public bool HasTeamLeadResult => TeamLeadChangedSuccess.HasValue;
+
+        /// <summary>
+        /// Identifies whether team management functions are enabled and should be shown in the UI.
+        /// </summary>
+        public bool TeamManagementEnabled { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -1,4 +1,5 @@
-﻿@using AllReady.Services
+﻿@using System.Linq
+@using AllReady.Services
 @model AllReady.Areas.Admin.ViewModels.Itinerary.ItineraryDetailsViewModel
 @inject AllReady.Services.ISelectListService SelectListService
 

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -1,5 +1,4 @@
-﻿@using AllReady.Constants
-@using AllReady.Services
+﻿@using AllReady.Services
 @model AllReady.Areas.Admin.ViewModels.Itinerary.ItineraryDetailsViewModel
 @inject AllReady.Services.ISelectListService SelectListService
 
@@ -10,9 +9,9 @@
 <div class="row">
     <div class="col-12">
         <ol class="breadcrumb">
-            <li><a asp-controller="Campaign" asp-action="Index" asp-area="@AreaNames.Admin">Campaigns</a></li>
-            <li><a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.CampaignId" asp-area="@AreaNames.Admin">@Model.CampaignName</a></li>
-            <li><a asp-controller="Event" asp-action="Details" asp-area="@AreaNames.Admin" asp-route-id="@Model.EventId">@Model.EventName</a></li>
+            <li><a asp-controller="Campaign" asp-action="Index" asp-area="Admin">Campaigns</a></li>
+            <li><a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.CampaignId" asp-area="Admin">@Model.CampaignName</a></li>
+            <li><a asp-controller="Event" asp-action="Details" asp-area="Admin" asp-route-id="@Model.EventId">@Model.EventName</a></li>
             <li>@Model.Name</li>
         </ol>
     </div>
@@ -62,7 +61,7 @@
     <div class="col-md-12">
         <h2>
             @Model.Name
-            <a asp-area="@AreaNames.Admin" asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
+            <a asp-area="Admin" asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
         </h2>
         <p>Scheduled for @Model.DisplayDate</p>
     </div>
@@ -76,44 +75,50 @@
     </div>
 </div>
 
-<div class="row">
-    <div class="col-md-12">
-        @if (Model.HasPotentialTeamMembers)
-        {
-            <div class="form-inline">
-                <label>Add team member:</label>
-                <form asp-action="AddTeamMember" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id">
-                    <select asp-items="Model.PotentialTeamMembers" id="selectedTeamMember" name="selectedTeamMember" class="form-control" required></select>
-                    <button type="submit" class="btn btn-default submit-form">Add</button>
-                </form>
-            </div>
-        }
-        else
-        {
-            <p>There are no potential team members to add to this itinerary. There must be volunteers (for a task occuring on the same day as the itinerary) for them to be available to assign to this team.</p>
-        }
+@if (Model.TeamManagementEnabled)
+{
+    <div class="row">
+        <div class="col-md-12">
+            @if (Model.HasPotentialTeamMembers)
+            {
+                <div class="form-inline">
+                    <label>Add team member:</label>
+                    <form asp-action="AddTeamMember" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id">
+                        <select asp-items="Model.PotentialTeamMembers" id="selectedTeamMember" name="selectedTeamMember" class="form-control" required></select>
+                        <button type="submit" class="btn btn-default submit-form">Add</button>
+                    </form>
+                </div>
+            }
+            else
+            {
+                <p>There are no potential team members to add to this itinerary. There must be volunteers (for a task occuring on the same day as the itinerary) for them to be available to assign to this team.</p>
+            }
+        </div>
     </div>
-</div>
+}
 <div class="row">
     <div class="col-md-8">
-        <h4>Assigned Team Members</h4>
-        @if (Model.HasPotentialTeamLeads)
+        @if (Model.TeamManagementEnabled)
         {
-            <div class="form-inline">
-                <label>Select a @(@Model.HasTeamLead ? "new " : "")team lead:</label>
-                <form asp-action="SetTeamLead" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id">
-                    <select asp-items="Model.PotentialTeamLeads" id="volunteerTaskSignupId" name="volunteerTaskSignupId" class="form-control" required></select>
-                    <button type="submit" class="btn btn-default submit-form">Set Team Lead</button>
-                </form>
-            </div>
-        }
-        @if (Model.HasTeamLead)
-        {
-            <div>
-                <form asp-action="RemoveTeamLead" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id">
-                    <button type="submit" class="btn btn-default submit-form">Remove Team Lead</button>
-                </form>
-            </div>
+            <h4>Assigned Team Members</h4>
+            if (Model.HasPotentialTeamLeads)
+            {
+                <div class="form-inline">
+                    <label>Select a @(@Model.HasTeamLead ? "new " : "")team lead:</label>
+                    <form asp-action="SetTeamLead" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id">
+                        <select asp-items="Model.PotentialTeamLeads" id="volunteerTaskSignupId" name="volunteerTaskSignupId" class="form-control" required></select>
+                        <button type="submit" class="btn btn-default submit-form">Set Team Lead</button>
+                    </form>
+                </div>
+            }
+            if (Model.HasTeamLead)
+            {
+                <div>
+                    <form asp-action="RemoveTeamLead" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id">
+                        <button type="submit" class="btn btn-default submit-form">Remove Team Lead</button>
+                    </form>
+                </div>
+            }
         }
         @if (Model.TeamMembers.Count > 0)
         {
@@ -127,14 +132,17 @@
                 @foreach (var tm in Model.TeamMembers)
                 {
                     string style = tm.IsTeamLead ? "font-weight:bold" : null;
-                <tr>
-                    <td style=@style>@tm.DisplayName</td>
-                    <td>@tm.VolunteerEmail</td>
-                    <td>@tm.VolunteerTaskName</td>
-                    <td>
-                        <a data-toggle="tooltip" data-placement="top" title="Remove from team" class="btn btn-danger" href=@("/Admin/Itinerary/" + @Model.Id + "/ConfirmRemoveTeamMember/" + @tm.VolunteerTaskSignupId)><span class="fa fa-remove"></span></a>
-                    </td>
-                </tr>
+                    <tr>
+                        <td style=@style>@tm.DisplayName</td>
+                        <td>@tm.VolunteerEmail</td>
+                        <td>@tm.VolunteerTaskName</td>
+                        <td>
+                            @if (Model.TeamManagementEnabled)
+                            {
+                                <a data-toggle="tooltip" data-placement="top" title="Remove from team" class="btn btn-danger" href=@("/Admin/Itinerary/" + @Model.Id + "/ConfirmRemoveTeamMember/" + @tm.VolunteerTaskSignupId)><span class="fa fa-remove"></span></a>
+                            }
+                        </td>
+                    </tr>
                 }
             </table>
         }
@@ -154,7 +162,7 @@
 </div>
 <div class="row">
     <div class="col-md-12">
-        <a asp-action="SelectRequests" asp-controller="Itinerary" asp-area="@AreaNames.Admin" class="btn btn-default">Add Requests</a>
+        <a asp-action="SelectRequests" asp-controller="Itinerary" asp-area="Admin" class="btn btn-default">Add Requests</a>
     </div>
 </div>
 @if (Model.CanOptimizeAndDisplayRoute)
@@ -180,7 +188,7 @@
 }
 @if (Model.Requests.Any())
 {
-    <form method="post" action="@Url.Action("Details", "Itinerary", new { area = AreaNames.Admin })#requests" class="form-horizontal">
+    <form method="post" action="@Url.Action("Details", "Itinerary", new { area = "Admin" })#requests" class="form-horizontal">
         @Html.AntiForgeryToken()
         <div class="row">
             <label class="col-md-1 control-label">Filter:</label>
@@ -223,14 +231,14 @@
                             <p>@request.City</p>
                         </td>
                         <td>
-                            <form asp-action="MoveRequestUp" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                            <form asp-action="MoveRequestUp" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
                                 <button type="submit" class="btn btn-default submit-form" @if (@request.IsFirst) { <text> disabled</text> }><span class="fa fa-arrow-up"></span></button>
                             </form>
-                            <form asp-action="MoveRequestDown" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                            <form asp-action="MoveRequestDown" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
                                 <button type="submit" class="btn btn-default submit-form" @if (@request.IsLast) { <text> disabled</text> }><span class="fa fa-arrow-down"></span></button>
                             </form>
 
-                            <a data-toggle="tooltip" data-placement="top" title="Remove from itinerary" asp-action="ConfirmRemoveRequest" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="btn btn-danger right-action-btn"><span class="fa fa-trash"></span></a>
+                            <a data-toggle="tooltip" data-placement="top" title="Remove from itinerary" asp-action="ConfirmRemoveRequest" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="btn btn-danger right-action-btn"><span class="fa fa-trash"></span></a>
                         </td>
                         <td>
                             @request.Status
@@ -238,22 +246,22 @@
                         <td>
                             @if (request.Status == RequestStatus.Assigned)
                             {
-                                <form asp-action="MarkComplete" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                                <form asp-action="MarkComplete" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
                                     <button type="submit" class="btn btn-success submit-form" title="Mark this request as complete"><span class="fa fa-check"></span></button>
                                 </form>
                             }
                             else if (request.Status == RequestStatus.PendingConfirmation)
                             {
-                                <form asp-action="MarkConfirmed" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                                <form asp-action="MarkConfirmed" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
                                     <button type="submit" class="btn btn-success submit-form" title="Mark this request as confirmed"><span class="fa fa-thumbs-up"></span></button>
                                 </form>
-                                <form asp-action="MarkUnassigned" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                                <form asp-action="MarkUnassigned" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
                                     <button type="submit" class="btn btn-danger submit-formm" title="Mark this request as unassigned"><span class="fa fa-ban"></span></button>
                                 </form>
                             }
                             else
                             {
-                                <form asp-action="MarkIncomplete" asp-controller="Itinerary" asp-area="@AreaNames.Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
+                                <form asp-action="MarkIncomplete" asp-controller="Itinerary" asp-area="Admin" asp-route-itineraryId="@Model.Id" asp-route-requestId="@request.Id" class="right-action-btn">
                                     <button type="submit" class="btn btn-warning submit-form" title="Reset this request to incomplete"><span class="fa fa-ban"></span></button>
                                 </form>
                             }
@@ -295,7 +303,7 @@
                     }
                 </p>
             </div>
-            <form asp-area="@AreaNames.Admin" asp-controller="Itinerary" asp-action="OptimizeRoute" asp-route-itineraryId="@Model.Id" method="post">
+            <form asp-area="Admin" asp-controller="Itinerary" asp-action="OptimizeRoute" asp-route-itineraryId="@Model.Id" method="post">
                 <input asp-for="Id" type="hidden" />
                 <div class="modal-footer">
                     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>


### PR DESCRIPTION
Fixes #1992 

- Added property on detail view model which will be used to hide/show the team management UI elements
- Set the property from the AuthorizableItinerary.CanManageTeamMembers value
- Update UI with conditional blocks to hide the team management UI elements when TeamManagementEnabled is false
- Added test to validate value is being set as expected.