### PR TITLE
Fix date field on edit campaign view

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
@@ -1,4 +1,4 @@
-﻿@using AllReady.Constants
+@using AllReady.Constants
 @using AllReady.Security
 @model AllReady.Areas.Admin.ViewModels.Campaign.CampaignSummaryViewModel
 @inject AllReady.Services.ISelectListService SelectListService
@@ -134,14 +134,14 @@
                 <div class="form-group">
                     <label asp-for="StartDate" class="col-md-2 control-label"></label>
                     <div class="col-md-10">
-                        <input asp-for="StartDate" class="form-control datepicker" />
+                        <input type="text" asp-for="StartDate" class="form-control datepicker" autocomplete="off" />
                         <span asp-validation-for="StartDate" class="text-danger"></span>
                     </div>
                 </div>
                 <div class="form-group">
                     <label asp-for="EndDate" class="col-md-2 control-label"></label>
                     <div class="col-md-10">
-                        <input asp-for="EndDate" class="form-control datepicker" />
+                        <input type="text" asp-for="EndDate" class="form-control datepicker" autocomplete="off" />
                         <span asp-validation-for="EndDate" class="text-danger"></span>
                     </div>
                 </div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Edit.cshtml
@@ -134,14 +134,14 @@
                 <div class="form-group">
                     <label asp-for="StartDate" class="col-md-2 control-label"></label>
                     <div class="col-md-10">
-                        <input type="text" asp-for="StartDate" class="form-control datepicker" autocomplete="off" />
+                        <input type="text" asp-for="StartDate" class="form-control datepicker" />
                         <span asp-validation-for="StartDate" class="text-danger"></span>
                     </div>
                 </div>
                 <div class="form-group">
                     <label asp-for="EndDate" class="col-md-2 control-label"></label>
                     <div class="col-md-10">
-                        <input type="text" asp-for="EndDate" class="form-control datepicker" autocomplete="off" />
+                        <input type="text" asp-for="EndDate" class="form-control datepicker" />
                         <span asp-validation-for="EndDate" class="text-danger"></span>
                     </div>
                 </div>


### PR DESCRIPTION
Input type was not set on start date and end date resulting in asp.net setting it to datetime-local which added validations that expected a time and it's own datepicker that conflicted with the bootstrap datepicker.

Fixed by setting the type to text.

Fixes #2097