### PR TITLE
Fixed "Sign up page input fields do not validate characters"

### DIFF
--- a/AllReadyApp/Web-App/AllReady/ViewModels/Account/RegisterViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Account/RegisterViewModel.cs
@@ -5,10 +5,12 @@ namespace AllReady.ViewModels.Account
     public class RegisterViewModel
     {
         [Required]
+        [RegularExpression(@"^(?!\W).+$", ErrorMessage = "The {0} should not contain any special characters.")]
         [Display(Name = "First Name")]
         public string FirstName{ get; set; }
 
         [Required]
+        [RegularExpression(@"^(?!\W).+$", ErrorMessage = "The {0} should not contain any special characters.")]
         [Display(Name = "Last Name")]
         public string LastName { get; set; }
 


### PR DESCRIPTION
Added regex to match string without special characters on the parameters FirstName and LastName. Numeric characters are still permited.