### PR TITLE
For ISSUE #1890

### DIFF
--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/CampaignManagerInviteControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Controllers/CampaignManagerInviteControllerTests.cs
@@ -459,5 +459,59 @@ namespace AllReady.UnitTest.Areas.Admin.Controllers
 
         #endregion
 
+        #region CancelInvice tests
+        [Fact]
+        public async Task CancelReturnsUnauthorizedResult_WhenUserIsNotOrgAdminForCampaign()
+        {
+            // Arrange
+            var mockMediator = new Mock<IMediator>();
+            var campaign = new CampaignManagerInviteDetailsViewModel() { CampaignId = campaignId, OrganizationId = 1, Id = 5};
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<CampaignManagerInviteDetailQuery>())).ReturnsAsync(campaign);
+
+            var sut = new CampaignManagerInviteController(mockMediator.Object, UserManagerMockHelper.CreateUserManagerMock().Object);
+            sut.MakeUserNotAnOrgAdmin();
+
+            // Act
+            var result = await sut.Cancel(5);
+
+            // Assert
+            Assert.IsType<UnauthorizedResult>(result);
+        }
+
+        [Fact]
+        public async Task CancelReturnsNotFoundResult_WhenInviteIsMissing()
+        {
+            // Arrange
+            var mockMediator = new Mock<IMediator>();
+
+            var sut = new CampaignManagerInviteController(mockMediator.Object, UserManagerMockHelper.CreateUserManagerMock().Object);
+            sut.MakeUserAnOrgAdmin("1");
+
+            // Act
+            var result = await sut.Cancel(5);
+
+            // Assert
+            Assert.IsType<NotFoundResult>(result);
+        }
+
+        [Fact]
+        public async Task CancelReturnsRedirectResult_WhenInviteIsOk()
+        {
+            // Arrange
+            var mockMediator = new Mock<IMediator>();
+            var campaign = new CampaignManagerInviteDetailsViewModel() { CampaignId = campaignId, OrganizationId = 1, Id = 5 };
+            mockMediator.Setup(mock => mock.SendAsync(It.IsAny<CampaignManagerInviteDetailQuery>())).ReturnsAsync(campaign);
+
+            var sut = new CampaignManagerInviteController(mockMediator.Object, UserManagerMockHelper.CreateUserManagerMock().Object);
+            sut.MakeUserAnOrgAdmin("1");
+
+            // Act
+            var result = await sut.Cancel(5);
+
+            // Assert
+            Assert.IsType<RedirectToActionResult>(result);
+        }
+
+        #endregion
     }
 }

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/CampaignManagerInvites/RemoveCampaignManagerInviteCommandHandlerShould.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Areas/Admin/Features/CampaignManagerInvites/RemoveCampaignManagerInviteCommandHandlerShould.cs
@@ -1,0 +1,57 @@
+using AllReady.Areas.Admin.Features.CampaignManagerInvites;
+using AllReady.Areas.Admin.Features.Notifications;
+using AllReady.Areas.Admin.ViewModels.ManagerInvite;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Shouldly;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AllReady.Models;
+using Xunit;
+
+namespace AllReady.UnitTest.Areas.Admin.Features.CampaignManagerInvites
+{
+    public class RemoveCampaignManagerInviteCommandHandlerShould : InMemoryContextTest
+    {
+        [Fact]
+        public async Task ShouldBeAbleToRemoveExistingInvite()
+        {
+            var handler = new RemoveCampaignManagerInviteCommandHandler(Context);
+            Context.CampaignManagerInvites.Add(new CampaignManagerInvite
+            {
+                Id = 233
+            });
+            Context.SaveChanges();
+
+            var inviteCommand = new RemoveCampaignManagerInviteCommand
+            {
+                InviteId = 233
+            };
+            await handler.Handle(inviteCommand);
+
+            Context.CampaignManagerInvites.Count().ShouldBe(0);
+        }
+
+        [Fact]
+        public async Task ThrowIfGivenInviteIdDoNotExist()
+        {
+            var handler = new RemoveCampaignManagerInviteCommandHandler(Context);
+            var inviteCommand = new RemoveCampaignManagerInviteCommand
+            {
+                InviteId = 233
+            };
+
+            try
+            {
+                await handler.Handle(inviteCommand);
+            }
+            catch (InvalidOperationException ex)
+            {
+                ex.Message.ShouldContain("Failed to find invite");
+            }
+
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignManagerInviteController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignManagerInviteController.cs
@@ -1,5 +1,4 @@
 using AllReady.Areas.Admin.Features.CampaignManagerInvites;
-using AllReady.Areas.Admin.Features.Notifications;
 using AllReady.Areas.Admin.ViewModels.ManagerInvite;
 using AllReady.Features.Campaigns;
 using AllReady.Models;
@@ -11,7 +10,6 @@ using Microsoft.AspNetCore.Mvc;
 using System.Linq;
 using System.Threading.Tasks;
 using AllReady.Constants;
-using Microsoft.AspNetCore.Mvc.Routing;
 
 namespace AllReady.Areas.Admin.Controllers
 {
@@ -110,6 +108,28 @@ namespace AllReady.Areas.Admin.Controllers
 
             return View(viewModel);
         }
+
+        [Route("[area]/[controller]/[action]/{inviteId:int}")]
+        public async Task<IActionResult> Cancel(int inviteId)
+        {
+            var query = new CampaignManagerInviteDetailQuery {CampaignManagerInviteId = inviteId};
+            var viewModel = await _mediator.SendAsync(query);
+            if (viewModel == null)
+            {
+                return NotFound();
+            }
+
+            if (!User.IsOrganizationAdmin(viewModel.OrganizationId))
+            {
+                return Unauthorized();
+            }
+
+            var cmd = new RemoveCampaignManagerInviteCommand {InviteId = inviteId};
+            await _mediator.SendAsync(cmd);
+
+            return RedirectToAction("Details", "Campaign", new { area = AreaNames.Admin, id = viewModel.CampaignId });
+        }
+
 
         [Route("[area]/[controller]/[action]/{inviteId:int}", Name = "CampaignManagerInviteAcceptRoute")]
         public async Task<IActionResult> Accept(int inviteId)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/CampaignManagerInvites/RemoveCampaignManagerInviteCommand.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/CampaignManagerInvites/RemoveCampaignManagerInviteCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace AllReady.Areas.Admin.Features.CampaignManagerInvites
+{
+    public class RemoveCampaignManagerInviteCommand : IAsyncRequest
+    {
+        public int InviteId { get; set; }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/CampaignManagerInvites/RemoveCampaignManagerInviteCommandHandler.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Features/CampaignManagerInvites/RemoveCampaignManagerInviteCommandHandler.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+using AllReady.Models;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace AllReady.Areas.Admin.Features.CampaignManagerInvites
+{
+    public class RemoveCampaignManagerInviteCommandHandler : AsyncRequestHandler<RemoveCampaignManagerInviteCommand>
+    {
+        private readonly AllReadyContext _context;
+
+        public RemoveCampaignManagerInviteCommandHandler(AllReadyContext context)
+        {
+            _context = context;
+        }
+
+        protected override async Task HandleCore(RemoveCampaignManagerInviteCommand message)
+        {
+            var invite = await _context.CampaignManagerInvites.FirstOrDefaultAsync(x => x.Id == message.InviteId);
+            if (invite == null)
+                throw new InvalidOperationException($"Failed to find invite {message.InviteId}.");
+
+            _context.CampaignManagerInvites.Remove(invite);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/CampaignManagerInvite/_List.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/CampaignManagerInvite/_List.cshtml
@@ -1,4 +1,4 @@
-﻿@using AllReady.Constants
+@using AllReady.Constants
 @model AllReady.Areas.Admin.ViewModels.Campaign.CampaignDetailViewModel
 
 <div class="row">
@@ -19,6 +19,9 @@
                     <th>
                         Status
                     </th>
+                    <th>
+                        &nbsp;
+                    </th>
                 </tr>
                 @foreach (var invite in Model.CampaignManagerInvites)
                 {
@@ -28,6 +31,9 @@
                         </td>
                         <td>
                             @invite.Status.ToString()
+                        </td>
+                        <td>
+                            <a asp-action="Cancel" asp-controller="CampaignManagerInvite" asp-area="@AreaNames.Admin" asp-route-inviteId="@invite.Id"><i class="glyphicon glyphicon-trash"></i></a>
                         </td>
                     </tr>
                 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/CampaignManagerInvite/_List.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/CampaignManagerInvite/_List.cshtml
@@ -1,3 +1,4 @@
+@using AllReady.Areas.Admin.ViewModels.Campaign
 @using AllReady.Constants
 @model AllReady.Areas.Admin.ViewModels.Campaign.CampaignDetailViewModel
 
@@ -33,7 +34,10 @@
                             @invite.Status.ToString()
                         </td>
                         <td>
-                            <a asp-action="Cancel" asp-controller="CampaignManagerInvite" asp-area="@AreaNames.Admin" asp-route-inviteId="@invite.Id"><i class="glyphicon glyphicon-trash"></i></a>
+                            @if (invite.Status == CampaignDetailViewModel.CampaignManagerInviteStatus.Pending)
+                            {
+                                <a asp-action="Cancel" asp-controller="CampaignManagerInvite" asp-area="@AreaNames.Admin" asp-route-inviteId="@invite.Id"><i class="glyphicon glyphicon-trash"></i></a>
+                            }
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
Invites can now be removed if the user is an organization admin (same check as for other campaign invite actions)