### PR TITLE
#2121 Prevent Itenery items to get invalid with the SampleDataGenerator

### DIFF
--- a/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
+++ b/AllReadyApp/Web-App/AllReady/DataAccess/SampleDataGenerator.cs
@@ -576,7 +576,7 @@ namespace AllReady.DataAccess
                     Description = "Description of a very important volunteerTask # " + i,
                     Name = "Task # " + i,
                     EndDateTime = AdjustToTimezone(DateTime.Today.AddHours(17).AddDays(i), _timeZone),
-                    StartDateTime = AdjustToTimezone(DateTime.Today.AddHours(9).AddDays(i - 1), _timeZone),
+                    StartDateTime = AdjustToTimezone(DateTime.Today.AddHours(9).AddDays(campaignEvent.EventType == EventType.Itinerary ? i : i - 1), _timeZone),
                     Organization = organization,
                     NumberOfVolunteersRequired = 5
                 });


### PR DESCRIPTION
#2121 Check if eventtype is Itinerary and change the starttype on sample data to not be invalid timelenght