### PR TITLE
Port legacy WebJobs to Azure Functions

### DIFF
--- a/AllReadyApp/NotificationProcessing/NotificationProcessing.csproj
+++ b/AllReadyApp/NotificationProcessing/NotificationProcessing.csproj
@@ -3,7 +3,15 @@
     <TargetFramework>net461</TargetFramework>
   </PropertyGroup>
   <ItemGroup>    
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.SendGrid" Version="2.0.0" />    
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Twilio" Version="1.0.0" />    
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.0" />    
+    <PackageReference Include="Sendgrid" Version="8.0.5" />    
+    <PackageReference Include="Twilio" Version="4.7.2" />    
+    <PackageReference Include="WindowsAzure.Storage" Version="7.2.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\AllReady.Core\AllReady.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/AllReadyApp/NotificationProcessing/ProcessEmailQueueMessage.cs
+++ b/AllReadyApp/NotificationProcessing/ProcessEmailQueueMessage.cs
@@ -1,0 +1,64 @@
+using System;
+using AllReady.Core.Notifications;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Newtonsoft.Json;
+using SendGrid.Helpers.Mail;
+
+namespace NotificationProcessing
+{
+    public static class ProcessEmailQueueMessage
+    {
+        [FunctionName("ProcessEmailQueueMessage")]
+        [StorageAccount("AzureWebJobsStorage")]
+        public static void Run([QueueTrigger("email-pending-deliveries")] string queueItem,
+            [SendGrid(ApiKey = "Authentication:SendGrid:ApiKey")] out Mail message, TraceWriter log)
+        {
+            var queuedEmailMessage = JsonConvert.DeserializeObject<QueuedEmailMessage>(queueItem);
+
+            var from = GuardAgainstInvalidEmailAddress(
+                Environment.GetEnvironmentVariable("Authentication:SendGrid:FromEmail"));
+
+            log.Info($"Sending email with subject `{queuedEmailMessage.Subject}` to `{queuedEmailMessage.Recipient}`");
+
+            message = new Mail
+            {
+                From = new Email(from, "AllReady"),
+                Subject = queuedEmailMessage.Subject
+            };
+
+            if (queuedEmailMessage.Message != null)
+            {
+                message.AddContent(new Content
+                {
+                    Type = "text/plain",
+                    Value = queuedEmailMessage.Message
+                });
+            }
+
+            if (queuedEmailMessage.HtmlMessage != null)
+            {
+                message.AddContent(new Content
+                {
+                    Type = "text/html",
+                    Value = queuedEmailMessage.HtmlMessage
+                });
+            }
+
+            var personalization = new Personalization();
+            personalization.AddTo(new Email(queuedEmailMessage.Recipient));
+            message.AddPersonalization(personalization);
+        }
+
+        private static string GuardAgainstInvalidEmailAddress(string @from)
+        {
+            if (string.IsNullOrWhiteSpace(@from))
+            {
+                throw new InvalidOperationException(
+                    "Environment variable `Authentication:SendGrid:FromEmail` is missing or contains invalid entry.");
+            }
+
+            return @from;
+        }
+    }
+}

--- a/AllReadyApp/NotificationProcessing/ProcessSmsQueueMessage.cs
+++ b/AllReadyApp/NotificationProcessing/ProcessSmsQueueMessage.cs
@@ -1,0 +1,29 @@
+using AllReady.Core.Notifications;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Newtonsoft.Json;
+using Twilio;
+
+namespace NotificationProcessing
+{
+    public static class ProcessSmsQueueMessage
+    {
+        [FunctionName("ProcessSmsQueueMessage")]
+        [StorageAccount("AzureWebJobsStorage")]
+        public static void Run([QueueTrigger("sms-pending-deliveries")] string queueItem,
+            [TwilioSms(AccountSidSetting = "Authentication:Twilio:Sid",
+                AuthTokenSetting = "Authentication:Twilio:Token",
+                From = "%Authentication:Twilio:PhoneNo%")] out SMSMessage message, TraceWriter log)
+        {
+            var queuedSmsMessage = JsonConvert.DeserializeObject<QueuedSmsMessage>(queueItem);
+
+            log.Info($"Sending SMS message `{queuedSmsMessage.Message}` to `{queuedSmsMessage.Recipient}`");
+
+            message = new SMSMessage()
+            {
+                Body = queuedSmsMessage.Message,
+                To = queuedSmsMessage.Recipient
+            };
+        }
+    }
+}


### PR DESCRIPTION
Issue #2117 

Port existing `ProcessSmsQueueMessage` and `ProcessEmailQueueMessage` WebJobs to Azure Functions.

Consistency with the existing WebJobs has mostly been retained except for the following changes:
- Storage account application setting changed to `AzureWebJobsStorage` from `Data:Storage:AzureStorage` as this is the default setting for Function Apps
- Use Twilio output binding instead of REST client
ref: https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Twilio/1.0.0
- Use SendGrid output binding instead of Web transport
ref: https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.SendGrid/2.0.0
- `Sendgrid` NuGet package updated to 8.0.5 as required by `Microsoft.Azure.WebJobs.Extensions.SendGrid`. Note: `Sendgrid` version 9.0.0 is not supported by `Microsoft.Azure.WebJobs.Extensions.SendGrid` version 2.0
- As a side effect of using the SendGrid output binding, the output mail message is constructed using the `SendGrid.Helpers.Mail.Mail` class instead of `SendGrid.SendGridMessage`
- Another side effect of using the SendGrid output binding is that authentication must be done using an API key instead of username/password. A new application setting `Authentication:SendGrid:ApiKey` has been added to accommodate this.
