### PR TITLE
App Insights TelemetryConfiguration error.

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/_ViewImports.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/_ViewImports.cshtml
@@ -1,8 +1,7 @@
-﻿@using AllReady
+@using AllReady
 @using AllReady.Models
 @using AllReady.Areas.Admin.Models;
 @using AllReady.ViewModels
 @using Microsoft.AspNetCore.Identity
 @addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
 @addTagHelper "*, AllReady"
-@inject Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration TelemetryConfiguration


### PR DESCRIPTION
I think there is a residual error from the .NET core 2.0 upgrade.  Working from a completely clean installation I'm getting the following exception:

````
ComponentNotRegisteredException: The requested service 'Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration' has not been registered. To avoid this exception, either register a component to provide the service, check for service registration using IsRegistered(), or use the ResolveOptional() method to resolve an optional dependency.
````

I can't see anywhere this is used, so I've just removed the import.