### PR TITLE
#2109 - Date picker on event page broken in responsive layout

### DIFF
--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -40,19 +40,20 @@ input[type="checkbox"].form-control, input[type="radio"].form-control {
     margin-left: -50px;
 }
 
-/* Set widths on the form inputs since otherwise they're 100% wide */
-input,
-select,
-textarea {
-    max-width: 380px;
-}
+@media (min-width: 768px) {
+    /* On larger screens set widths on the form inputs since otherwise they're 100% wide */
+    input,
+    select,
+    textarea {
+        max-width: 380px;
+    }
 
     input.wide,
     select.wide,
     textarea.wide {
         max-width: inherit;
     }
-
+}
 /* Wrapping element */
 /* Set some basic padding to keep content from hitting the edges */
 .body-content {


### PR DESCRIPTION
Fixes #2109 

This PR changes the CSS so that the `max-width` on form inputs is only applied to screens larger than 768px.  In smaller layouts form fields are stacked to preserve horizontal space, so we should be utilizing all of the screen anyway.

Below is a screenshot of the corrected layout:
![Screenshot](https://user-images.githubusercontent.com/427494/31112404-b97989d2-a7d0-11e7-8803-99c087103277.png)
