### PR TITLE
#2148 - Adding regular expressions

### DIFF
--- a/AllReadyApp/Web-App/AllReady/ViewModels/Account/RegisterViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Account/RegisterViewModel.cs
@@ -5,12 +5,12 @@ namespace AllReady.ViewModels.Account
     public class RegisterViewModel
     {
         [Required]
-        [RegularExpression(@"^(?!\W).+$", ErrorMessage = "The {0} should not contain any special characters.")]
+        [RegularExpression(@"^[a-zA-Z]+$", ErrorMessage = "The {0} should not contain any special characters.")]
         [Display(Name = "First Name")]
         public string FirstName{ get; set; }
 
         [Required]
-        [RegularExpression(@"^(?!\W).+$", ErrorMessage = "The {0} should not contain any special characters.")]
+        [RegularExpression(@"^[a-zA-Z]+$", ErrorMessage = "The {0} should not contain any special characters.")]
         [Display(Name = "Last Name")]
         public string LastName { get; set; }
 
@@ -21,6 +21,7 @@ namespace AllReady.ViewModels.Account
         [Required]
         [Phone]
         [Display(Name = "Mobile phone Number")]
+        [RegularExpression("^[0-9]+$", ErrorMessage = "The {0} should only contain numbers")]
         public string PhoneNumber { get; set; }
 
         [Required]

--- a/AllReadyApp/Web-App/AllReady/ViewModels/Account/RegisterViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Account/RegisterViewModel.cs
@@ -5,12 +5,12 @@ namespace AllReady.ViewModels.Account
     public class RegisterViewModel
     {
         [Required]
-        [RegularExpression(@"^[a-zA-Z]+$", ErrorMessage = "The {0} should not contain any special characters.")]
+        [RegularExpression(@"(.*?)\s([\wáâàãçéêíóôõúüÁÂÀÃÇÉÊÍÓÔÕÚÜ]+\-?\'?\w+\.*?$)", ErrorMessage = "The {0} should not contain any special characters.")]
         [Display(Name = "First Name")]
         public string FirstName{ get; set; }
 
         [Required]
-        [RegularExpression(@"^[a-zA-Z]+$", ErrorMessage = "The {0} should not contain any special characters.")]
+        [RegularExpression(@"(.*?)\s([\wáâàãçéêíóôõúüÁÂÀÃÇÉÊÍÓÔÕÚÜ]+\-?\'?\w+\.*?$)", ErrorMessage = "The {0} should not contain any special characters.")]
         [Display(Name = "Last Name")]
         public string LastName { get; set; }
 
@@ -21,7 +21,6 @@ namespace AllReady.ViewModels.Account
         [Required]
         [Phone]
         [Display(Name = "Mobile phone Number")]
-        [RegularExpression("^[0-9]+$", ErrorMessage = "The {0} should only contain numbers")]
         public string PhoneNumber { get; set; }
 
         [Required]


### PR DESCRIPTION
Altered the regular expression for first/last name
* Full disclosure I was wondering whether I needed to support spaces and hyphens (-) for double barreled names but seeing as the issues says "Name/last name should allow only alpha values" I thought I'd implement that and await feedback

Added regular expression to phone number
* Again full disclosure this does not account for the ++ area codes i.e. ++44 for uk, again issue states "Phone number text should allow only numbers"

Happy to change if this doesn't reflect what you want/need 

Thanks :)