### PR TITLE
Fixing #2152 open the campaign info by default

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Event/EventWithTasks.cshtml
@@ -65,7 +65,7 @@
                     <p>@Model.Description</p>
                 </div>
             </div>
-            <div class="row" id="CampaignInfo" data-bind="accordion">
+            <div class="row" id="CampaignInfo" data-bind="accordion: { openItem : 0 }">
                 <div class="panel-group">
                     <div data-toggle-accordion>
                         <div class="panel-heading col-sm-12" >

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/ko.bindings.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/ko.bindings.js
@@ -1,4 +1,4 @@
-﻿// knockout binding for jquery.maskedinput plugin
+// knockout binding for jquery.maskedinput plugin
 ko.bindingHandlers.masked = {
     init: function (element, valueAccessor) {
         var value = valueAccessor(),
@@ -13,7 +13,7 @@ ko.bindingHandlers.accordion = {
         var options = ko.utils.unwrapObservable(value()) || {},
             toggleClass = "[data-toggle-accordion]",
             contentClass = ".collapse",
-            openItem = ko.utils.unwrapObservable(options.openItem) || false,
+            openItem = parseInt(ko.utils.unwrapObservable(options.openItem)),
             itemClass = "." + (ko.utils.unwrapObservable(options.item) || "panel-group"),
             accordionDirectionIconClass = "." + (ko.utils.unwrapObservable(options.itemIconDirection) || "accordion-icon-direction"),
             items = $(elem).find(contentClass);
@@ -42,7 +42,7 @@ ko.bindingHandlers.accordion = {
         });
 
         // if initial open item specified, expand it
-        if (openItem) {
+        if (openItem > -1) {
             items.eq(openItem).collapse("show");
         };
 


### PR DESCRIPTION
Fixes #2152

The `accordion` binding already supported the `openItem` option however there was a bug in the implementation which prevented to open the first element:

Because this condition evaluates to false when `openItem: 0`
```
if (openItem) {	
    items.eq(openItem).collapse("show");
};
```

The fix is to check for `openItem > -1`. I've found a similar binding which also has the same fixed condition
https://stackoverflow.com/questions/30893880/collapsable-panel-with-bootstrap-and-knockout/30948743

The `parseInt` change was required to make the openItem option "optional" otherwise when the `openItem` option was omitted it always opened the first accordion element.
