### PR TITLE
Stop adding Nuget v3 api source in appveyor builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ cache:
   - '%APPDATA%\npm-cache'             # npm cache
   
 install:
- - cmd: nuget sources add -Name api.nuget.org -Source https://api.nuget.org/v3/index.json
  - choco install firefox
  
 before_build:


### PR DESCRIPTION
v3 api is now the default in the latest build images and hence attempting to add the source is causing a failure.

See https://github.com/appveyor/ci/issues/1869