### PR TITLE
Fixing incorrect javascript path after refactor of bower

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Shared/_Layout.cshtml
@@ -79,14 +79,14 @@
         <script src="~/lib/jquery/dist/jquery.js"></script>
         <script src="~/lib/bootstrap/dist/js/bootstrap.js"></script>
         <script src="~/lib/bootstrap-toggle/js/bootstrap-toggle.js"></script>
-        <script src="~/lib/knockout/dist/knockout.js"></script>
+        <script src="~/lib/knockout/build/output/knockout-latest.debug.js"></script>
         <script src="~/lib/moment/min/moment-with-locales.js"></script>
         <script src="~/lib/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
         <script src="~/lib/tota11y/build/tota11y.js"></script>
         <script src="~/lib/tinymce/tinymce.js"></script>
         <script src="~/lib/bootstrap-tagsinput/dist/bootstrap-tagsinput.js"></script>
         <script src="~/lib/d3/d3.js"></script>
-        <script src="~/lib/jquery.maskedinput/dist/jquery.maskedinput.js"></script>
+        <script src="~/lib/jquery.maskedinput/src/jquery.maskedinput.js"></script>
         <script src="~/lib/fullcalendar/dist/fullcalendar.js"></script>
     </environment>
     <environment names="Staging,Production">


### PR DESCRIPTION
Looks like there is a slight change from bower to npm. This should address the path differences.