### PR TITLE
Fixed delete campaign always failing

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignController.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Controllers/CampaignController.cs
@@ -1,4 +1,4 @@
-﻿using AllReady.Areas.Admin.Features.Campaigns;
+using AllReady.Areas.Admin.Features.Campaigns;
 using AllReady.Areas.Admin.ViewModels.Campaign;
 using AllReady.Extensions;
 using AllReady.Models;
@@ -174,7 +174,6 @@ namespace AllReady.Areas.Admin.Controllers
             }
 
             viewModel.Title = $"Delete campaign {viewModel.Name}";
-            viewModel.UserIsOrgAdmin = true;
 
             return View(viewModel);
         }
@@ -182,15 +181,16 @@ namespace AllReady.Areas.Admin.Controllers
         // POST: Campaign/Delete/5
         [HttpPost, ActionName("Delete")]
         [ValidateAntiForgeryToken]
-        public async Task<IActionResult> DeleteConfirmed(DeleteViewModel viewModel)
+        public async Task<IActionResult> DeleteConfirmed(int id)
         {
+            var viewModel = await _mediator.SendAsync(new CampaignSummaryQuery { CampaignId = id });
             var authorizableOrganization = await _mediator.SendAsync(new Features.Organizations.AuthorizableOrganizationQuery(viewModel.OrganizationId));
             if (!await authorizableOrganization.UserCanDelete())
             {
                 return new ForbidResult();
             }
 
-            await _mediator.SendAsync(new DeleteCampaignCommand { CampaignId = viewModel.Id });
+            await _mediator.SendAsync(new DeleteCampaignCommand { CampaignId = id });
 
             return RedirectToAction(nameof(Index), new { area = AreaNames.Admin });
         }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Campaign/DeleteViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/ViewModels/Campaign/DeleteViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace AllReady.Areas.Admin.ViewModels.Campaign
 {
@@ -16,8 +16,5 @@ namespace AllReady.Areas.Admin.ViewModels.Campaign
         public string OrganizationName { get; set; }
 
         public string Title { get; set; }
-
-        //used to carry value from GET to POST action method in controller, not stored in a model anywhere
-        public bool UserIsOrgAdmin { get; set; }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Delete.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Delete.cshtml
@@ -1,4 +1,4 @@
-﻿@using AllReady.Constants
+@using AllReady.Constants
 @model AllReady.Areas.Admin.ViewModels.Campaign.DeleteViewModel
 @{ ViewData["Title"] = Model.Title; }
 <div class="row">
@@ -39,7 +39,6 @@
             @using (Html.BeginForm())
             {
                 @Html.AntiForgeryToken()
-                <input type="hidden" asp-for="UserIsOrgAdmin" />
                 <div class="form-actions no-color">
                     <button type="submit" value="Delete" class="btn btn-default">Delete campaign</button> 
                     <a asp-controller="Campaign" asp-action="Details" asp-route-id="@Model.Id" asp-area="@AreaNames.Admin" class="btn btn-default">Cancel</a>


### PR DESCRIPTION
The delete campaign feature was always failing because the authorization checks were not working properly.  This fixes the feature.