### PR TITLE
Removed console log config to stop duplicating log entries

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Program.cs
+++ b/AllReadyApp/Web-App/AllReady/Program.cs
@@ -14,7 +14,6 @@ namespace AllReady
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .ConfigureLogging(x => x.AddConsole())
                 .ConfigureAppConfiguration((ctx, config) =>
                     config.SetBasePath(ctx.HostingEnvironment.ContentRootPath)
                         .AddJsonFile("version.json"))


### PR DESCRIPTION
In asp.net core 2.0 the console log output is added by default.
It looks like adding it again makes all log entries appear twice, so I removed it.

closes #2181