### PR TITLE
Move skills to own tab in profile management page.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -241,3 +241,6 @@ bower_components
 /smoke-alarm-requests-sample-data-EMPTY.csv
 /smoke-alarm-requests-sample-data-DUPLICATE.csv
 /AllReadyApp/Web-App/AllReady/wwwroot/upload
+
+# VS Code Assets
+.vscode/

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerTests.cs
@@ -223,6 +223,7 @@ namespace AllReady.UnitTest.Controllers
                 nameof(ManageController.SaveProfile), 
                 new[] { typeof(ProfileViewModel) });
         }
+
         [Fact]
         public async Task SaveProfilePostSendsRemoveUserProfileIncompleteClaimCommandWithCorrectUserIdWhenUsersProfileIsComplete()
         {
@@ -248,6 +249,25 @@ namespace AllReady.UnitTest.Controllers
 
             controllerAndMocks.mediatorMock.Verify(m => m.SendAsync(It.Is<RemoveUserProfileIncompleteClaimCommand>(u => u.UserId == user.Id)), Times.Once);
         }
+
+
+        [Fact]
+        public void SaveSkillsPostHasHttpPostAttribute()
+        {
+            CheckManageControllerMethodAttribute<HttpPostAttribute>(
+                nameof(ManageController.SaveSkills), 
+                new [] {typeof(SkillsViewModel) });
+        }
+
+        [Fact]
+        public void SaveSkillsPostHasValidateAntiForgeryTokenAttribute()
+        {
+            CheckManageControllerMethodAttribute<ValidateAntiForgeryTokenAttribute>(
+                nameof(ManageController.SaveSkills), 
+                new[] { typeof(SkillsViewModel) });
+        }
+
+        // TODO 2231 Analyze what SaveSkills POST is doing; then add appropriate unit tests.
 
         [Fact]
         public async Task UpdateUserProfileCompletenessInvokesRefreshSignInAsyncWithCorrectUserWhenUsersProfileIsComplete()

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerTests.cs
@@ -125,9 +125,9 @@ namespace AllReady.UnitTest.Controllers
            
             var result = await controller.Index(ManageMessageId.RemovePhoneSuccess);
             var resultViewModel = ((ViewResult)result);
-            var vm = (ProfileViewModel)resultViewModel.ViewData.Model;
+            var vm = (IndexViewModel)resultViewModel.ViewData.Model;
            
-            Assert.IsType<ProfileViewModel>(vm);
+            Assert.IsType<IndexViewModel>(vm);
         }
 
         [Fact]
@@ -168,9 +168,9 @@ namespace AllReady.UnitTest.Controllers
            
             var result = await controller.SaveProfile(invalidVm);
             var resultViewModel = ((ViewResult)result);
-            var vm = (ProfileViewModel)resultViewModel.ViewData.Model;
+            var vm = (IndexViewModel)resultViewModel.ViewData.Model;
             
-            Assert.IsType<ProfileViewModel>(vm);
+            Assert.IsType<IndexViewModel>(vm);
         }
 
         [Fact]

--- a/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerTests.cs
+++ b/AllReadyApp/Web-App/AllReady.UnitTest/Controllers/ManageControllerTests.cs
@@ -125,13 +125,13 @@ namespace AllReady.UnitTest.Controllers
            
             var result = await controller.Index(ManageMessageId.RemovePhoneSuccess);
             var resultViewModel = ((ViewResult)result);
-            var vm = (IndexViewModel)resultViewModel.ViewData.Model;
+            var vm = (ProfileViewModel)resultViewModel.ViewData.Model;
            
-            Assert.IsType<IndexViewModel>(vm);
+            Assert.IsType<ProfileViewModel>(vm);
         }
 
         [Fact]
-        public async Task IndexPostSendsUserByUserIdQueryWithCorrectUserId()
+        public async Task SaveProfilePostSendsUserByUserIdQueryWithCorrectUserId()
         {           
             var userId = "userId";
 
@@ -139,42 +139,42 @@ namespace AllReady.UnitTest.Controllers
             ManageController controller = controllerAndMocks.controller;
             controller.SetFakeUser(userId);
 
-            var vm = new IndexViewModel();
+            var vm = new ProfileViewModel();
 
-            await controller.Index(vm);
+            await controller.SaveProfile(vm);
             controllerAndMocks.mediatorMock.Verify(m => m.SendAsync(It.Is<AllReady.Features.Manage.UserByUserIdQuery>(u => u.UserId == userId)), Times.Once);
         }
 
         [Fact]
-        public async Task IndexPostReturnsCorrectViewWhenModelStateIsInvalid()
+        public async Task SaveProfilePostReturnsCorrectViewWhenModelStateIsInvalid()
         {
             ManageController controller = InitializeControllerWithValidUser(new ApplicationUser()).controller;
             controller.SetFakeUser("userId");
-            IndexViewModel invalidVm = new IndexViewModel();
+            ProfileViewModel invalidVm = new ProfileViewModel();
             controller.ModelState.AddModelError("FirstName", "Can't be a number");
             
-            var result = await controller.Index(invalidVm);
+            var result = await controller.SaveProfile(invalidVm);
           
             Assert.IsType<ViewResult>(result);
         }
 
         [Fact]
-        public async Task IndexPostReturnsCorrectViewModelWhenModelStateIsInvalid()
+        public async Task SaveProfilePostReturnsCorrectViewModelWhenModelStateIsInvalid()
         {
             ManageController controller = InitializeControllerWithValidUser(new ApplicationUser()).controller;
             controller.SetFakeUser("userId");
-            IndexViewModel invalidVm = new IndexViewModel();
+            ProfileViewModel invalidVm = new ProfileViewModel();
             controller.ModelState.AddModelError("FirstName", "Can't be a number");
            
-            var result = await controller.Index(invalidVm);
+            var result = await controller.SaveProfile(invalidVm);
             var resultViewModel = ((ViewResult)result);
-            var vm = (IndexViewModel)resultViewModel.ViewData.Model;
+            var vm = (ProfileViewModel)resultViewModel.ViewData.Model;
             
-            Assert.IsType<IndexViewModel>(vm);
+            Assert.IsType<ProfileViewModel>(vm);
         }
 
         [Fact]
-        public async Task IndexPostInvokesRemoveClaimsAsyncWithCorrectParametersWhenUsersTimeZoneDoesNotEqualModelsTimeZone()
+        public async Task SaveProfilePostInvokesRemoveClaimsAsyncWithCorrectParametersWhenUsersTimeZoneDoesNotEqualModelsTimeZone()
         {
             var user = new ApplicationUser { TimeZoneId = "timeZoneId" };
             var controllerAndMocks = InitializeControllerWithValidUser(user);
@@ -182,16 +182,16 @@ namespace AllReady.UnitTest.Controllers
             controller.SetFakeUser("userId");
             controllerAndMocks.userManagerMock.Setup(x => x.RemoveClaimsAsync(It.IsAny<ApplicationUser>(), It.IsAny<IEnumerable<Claim>>())).ReturnsAsync(IdentityResult.Success);
 
-            var vM = new IndexViewModel { TimeZoneId = "differentTimeZoneId" };
+            var vM = new ProfileViewModel { TimeZoneId = "differentTimeZoneId" };
            
-            await controller.Index(vM);
+            await controller.SaveProfile(vM);
          
             IEnumerable<Claim> claims = controller.User.Claims.Where(c => c.Type == AllReady.Security.ClaimTypes.TimeZoneId).ToList();
             controllerAndMocks.userManagerMock.Verify(x => x.RemoveClaimsAsync(user, claims), Times.Once);
         }
 
         [Fact]
-        public async Task IndexPostInvokesAddClaimAsyncWithCorrectParametersWhenUsersTimeZoneDoesNotEqualModelsTimeZone()
+        public async Task SaveProfilePostInvokesAddClaimAsyncWithCorrectParametersWhenUsersTimeZoneDoesNotEqualModelsTimeZone()
         {            
             var user = new ApplicationUser { TimeZoneId = "timeZoneId" };
             var controllerAndMocks = InitializeControllerWithValidUser(user);
@@ -199,9 +199,9 @@ namespace AllReady.UnitTest.Controllers
             controller.SetFakeUser("userId");
             controllerAndMocks.userManagerMock.Setup(x => x.AddClaimAsync(It.IsAny<ApplicationUser>(), It.IsAny<Claim>())).ReturnsAsync(IdentityResult.Success);
 
-            var vM = new IndexViewModel { TimeZoneId = "differentTimeZoneId" };
+            var vM = new ProfileViewModel { TimeZoneId = "differentTimeZoneId" };
             
-            await controller.Index(vM);
+            await controller.SaveProfile(vM);
            
             controllerAndMocks.userManagerMock.Verify(x => x.AddClaimAsync(user, It.Is<Claim>(c=>c.Type == AllReady.Security.ClaimTypes.TimeZoneId)), Times.Once);
         }
@@ -209,18 +209,22 @@ namespace AllReady.UnitTest.Controllers
         //TODO: come back to finsih these stubs... there is a lot going on in Index Post
 
         [Fact]
-        public void IndexPostHasHttpPostAttribute()
+        public void SaveProfilePostHasHttpPostAttribute()
         {
-            CheckManageControllerMethodAttribute<HttpPostAttribute>(nameof(ManageController.Index), new [] {typeof(IndexViewModel) });
+            CheckManageControllerMethodAttribute<HttpPostAttribute>(
+                nameof(ManageController.SaveProfile), 
+                new [] {typeof(ProfileViewModel) });
         }
 
         [Fact]
-        public void IndexPostHasValidateAntiForgeryTokenAttribute()
+        public void SaveProfilePostHasValidateAntiForgeryTokenAttribute()
         {
-            CheckManageControllerMethodAttribute<ValidateAntiForgeryTokenAttribute>(nameof(ManageController.Index), new[] { typeof(IndexViewModel) });
+            CheckManageControllerMethodAttribute<ValidateAntiForgeryTokenAttribute>(
+                nameof(ManageController.SaveProfile), 
+                new[] { typeof(ProfileViewModel) });
         }
         [Fact]
-        public async Task IndexPostSendsRemoveUserProfileIncompleteClaimCommandWithCorrectUserIdWhenUsersProfileIsComplete()
+        public async Task SaveProfilePostSendsRemoveUserProfileIncompleteClaimCommandWithCorrectUserIdWhenUsersProfileIsComplete()
         {
             ApplicationUser user = new ApplicationUser
             {
@@ -234,14 +238,13 @@ namespace AllReady.UnitTest.Controllers
                 TimeZoneId = "TimeZonedID",
             };
 
-
             var controllerAndMocks = InitializeControllerWithValidUser(user);
             controllerAndMocks.signInManagerMock.Setup(m => m.RefreshSignInAsync(It.IsAny<ApplicationUser>())).Returns(Task.FromResult(user));
             controllerAndMocks.controller.SetFakeUser(user.Id);
             
-            var viewModel = new IndexViewModel { FirstName = "Name", LastName = "Last Name", TimeZoneId = "TimeZonedID"};
+            var viewModel = new ProfileViewModel { FirstName = "Name", LastName = "Last Name", TimeZoneId = "TimeZonedID"};
 
-            await controllerAndMocks.controller.Index(viewModel);
+            await controllerAndMocks.controller.SaveProfile(viewModel);
 
             controllerAndMocks.mediatorMock.Verify(m => m.SendAsync(It.Is<RemoveUserProfileIncompleteClaimCommand>(u => u.UserId == user.Id)), Times.Once);
         }
@@ -273,9 +276,9 @@ namespace AllReady.UnitTest.Controllers
             manageController.SetFakeUser(user.Id);
 
             //Only set props required for modelstate to be valid.
-            IndexViewModel viewModel = new IndexViewModel { FirstName = "Name", LastName = "Last Name", TimeZoneId = "TimeZonedID" };
+            ProfileViewModel viewModel = new ProfileViewModel { FirstName = "Name", LastName = "Last Name", TimeZoneId = "TimeZonedID" };
 
-            await manageController.Index(viewModel);
+            await manageController.SaveProfile(viewModel);
 
             signInManagerMock.Verify(s=>s.RefreshSignInAsync(It.Is<ApplicationUser>(u=>u == user)),Times.AtLeastOnce);
         }

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -56,9 +56,6 @@ namespace AllReady.Controllers
         {
             var user = await GetCurrentUser();
 
-            Console.WriteLine("------------------");
-            Console.WriteLine("SaveProfile");
-
             if (!ModelState.IsValid)
             {
                 var vm = await user.ToViewModel(_userManager, _signInManager);
@@ -68,6 +65,9 @@ namespace AllReady.Controllers
                 vm.ProfileViewModel.LastName = model.LastName;
                 vm.ProfileViewModel.TimeZoneId = model.TimeZoneId;
 
+                // TODO 2231 Solve the problem: When the model is invalid, the 
+                // address bar says "Manage/SaveProfile" when we would expect
+                // it to say "Manage/Index".
                 return View("Index", vm);
             }
 
@@ -75,8 +75,6 @@ namespace AllReady.Controllers
 
             await _mediator.SendAsync(new UpdateUser { User = user });
             await UpdateUserProfileCompleteness(user);
-
-            Console.WriteLine("------------------");
 
             return RedirectToAction(nameof(Index));
         }

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -58,11 +58,14 @@ namespace AllReady.Controllers
 
             if (!ModelState.IsValid)
             {
-                var viewModelWithInputs = await user.ToViewModel(_userManager, _signInManager);
-                viewModelWithInputs.FirstName= model.FirstName;
-                viewModelWithInputs.LastName = model.LastName;
-                viewModelWithInputs.TimeZoneId = model.TimeZoneId;
-                return View(viewModelWithInputs);
+                var vm = await user.ToViewModel(_userManager, _signInManager);
+
+                // TODO 2231 Adhere to the Law of Demeter.
+                vm.ProfileViewModel.FirstName= model.FirstName;
+                vm.ProfileViewModel.LastName = model.LastName;
+                vm.ProfileViewModel.TimeZoneId = model.TimeZoneId;
+
+                return View(vm);
             }
 
             await SaveProfile(model, user);

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -58,7 +58,6 @@ namespace AllReady.Controllers
 
             if (command == "SaveProfile") 
             {
-                // TODO: 1871 determine a better way to handle partial model validation
                 if (!ModelState.IsValid)
                 {
                     var viewModelWithInputs = await user.ToViewModel(_userManager, _signInManager);

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -56,22 +56,28 @@ namespace AllReady.Controllers
         {
             var user = await GetCurrentUser();
 
+            Console.WriteLine("------------------");
+            Console.WriteLine("SaveProfile");
+
             if (!ModelState.IsValid)
             {
                 var vm = await user.ToViewModel(_userManager, _signInManager);
 
                 // TODO 2231 Adhere to the Law of Demeter.
-                vm.ProfileViewModel.FirstName= model.FirstName;
+                vm.ProfileViewModel.FirstName = model.FirstName;
                 vm.ProfileViewModel.LastName = model.LastName;
                 vm.ProfileViewModel.TimeZoneId = model.TimeZoneId;
 
-                return View(vm);
+                return View("Index", vm);
             }
 
             await SaveProfile(model, user);
 
             await _mediator.SendAsync(new UpdateUser { User = user });
             await UpdateUserProfileCompleteness(user);
+
+            Console.WriteLine("------------------");
+
             return RedirectToAction(nameof(Index));
         }
 

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -67,22 +67,6 @@ namespace AllReady.Controllers
 
             await SaveProfile(model, user);
 
-            // TODO 2231 Consider putting this shared block into a private method.
-            await _mediator.SendAsync(new UpdateUser { User = user });
-            await UpdateUserProfileCompleteness(user);
-            return RedirectToAction(nameof(Index));
-        }
-
-        // POST: /Manage/SaveSkills
-        [HttpPost]
-        [ValidateAntiForgeryToken]
-        public async Task<IActionResult> SaveSkills(SkillsViewModel model)
-        {
-            var user = await GetCurrentUser();
-
-            SaveSkills(model, user);
-
-            // TODO 2231 Consider putting this shared block into a private method.
             await _mediator.SendAsync(new UpdateUser { User = user });
             await UpdateUserProfileCompleteness(user);
             return RedirectToAction(nameof(Index));
@@ -118,9 +102,24 @@ namespace AllReady.Controllers
             }
         }
 
+        // POST: /Manage/SaveSkills
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> SaveSkills(SkillsViewModel model)
+        {
+            var user = await GetCurrentUser();
+
+            SaveSkills(model, user);
+
+            // TODO 2231 Question: do we need to SendAsync for the saving of skills?
+            await _mediator.SendAsync(new UpdateUser { User = user });
+            return RedirectToAction(nameof(Index));
+        }
+
         private void SaveSkills(SkillsViewModel model, ApplicationUser user) 
         {
             // TODO 2231 Figure out what this expression is doing.
+            // Then consider breaking it out into a local function.
             user.AssociatedSkills.RemoveAll(
                 usk => model.AssociatedSkills == null || 
                 !model.AssociatedSkills.Any(msk => msk.SkillId == usk.SkillId));
@@ -128,6 +127,7 @@ namespace AllReady.Controllers
             if (model.AssociatedSkills != null)
             {
                 // TODO 2231 Figure out what this expression is doing.
+                // Then consider breaking it out into a local function.
                 var skillsToAdd = model.AssociatedSkills
                     .Where(msk => !user.AssociatedSkills
                         .Any(usk => usk.SkillId == msk.SkillId));

--- a/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
+++ b/AllReadyApp/Web-App/AllReady/Controllers/ManageController.cs
@@ -56,17 +56,19 @@ namespace AllReady.Controllers
         {
             var user = await GetCurrentUser();
 
-            if (!ModelState.IsValid)
+            if (command == "SaveProfile") 
             {
-                var viewModelWithInputs = await user.ToViewModel(_userManager, _signInManager);
-                viewModelWithInputs.FirstName= model.FirstName;
-                viewModelWithInputs.LastName = model.LastName;
-                viewModelWithInputs.TimeZoneId = model.TimeZoneId;
-                viewModelWithInputs.AssociatedSkills = model.AssociatedSkills;
-                return View(viewModelWithInputs);
-            }
-            else if (command == "SaveProfile") 
-            {
+                // TODO: 1871 determine a better way to handle partial model validation
+                if (!ModelState.IsValid)
+                {
+                    var viewModelWithInputs = await user.ToViewModel(_userManager, _signInManager);
+                    viewModelWithInputs.FirstName= model.FirstName;
+                    viewModelWithInputs.LastName = model.LastName;
+                    viewModelWithInputs.TimeZoneId = model.TimeZoneId;
+                    viewModelWithInputs.AssociatedSkills = model.AssociatedSkills;
+                    return View(viewModelWithInputs);
+                }
+
                 await SaveProfile(model, user);
             } 
             else if (command == "SaveSkills") 

--- a/AllReadyApp/Web-App/AllReady/Security/ApplicationUserExtensions.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/ApplicationUserExtensions.cs
@@ -28,10 +28,13 @@ namespace AllReady.Security
             return result;
         }
 
-        public static async Task<IndexViewModel> ToViewModel(this ApplicationUser user, UserManager<ApplicationUser> userManager, SignInManager<ApplicationUser> signInManager)
+        public static async Task<ProfileViewModel> ToViewModel(
+            this ApplicationUser user, 
+            UserManager<ApplicationUser> userManager, 
+            SignInManager<ApplicationUser> signInManager)
         {
             var profileCompletenessWarnings = user.ValidateProfileCompleteness();
-            var result = new IndexViewModel
+            var result = new ProfileViewModel
             {
                 HasPassword = await userManager.HasPasswordAsync(user),
                 EmailAddress = user.Email,
@@ -41,7 +44,6 @@ namespace AllReady.Security
                 TwoFactor = await userManager.GetTwoFactorEnabledAsync(user),
                 Logins = await userManager.GetLoginsAsync(user),
                 BrowserRemembered = await signInManager.IsTwoFactorClientRememberedAsync(user),
-                AssociatedSkills = user.AssociatedSkills,
                 TimeZoneId = user.TimeZoneId,
                 FirstName = user.FirstName,
                 LastName = user.LastName,

--- a/AllReadyApp/Web-App/AllReady/Security/ApplicationUserExtensions.cs
+++ b/AllReadyApp/Web-App/AllReady/Security/ApplicationUserExtensions.cs
@@ -28,13 +28,18 @@ namespace AllReady.Security
             return result;
         }
 
-        public static async Task<ProfileViewModel> ToViewModel(
+        public static async Task<IndexViewModel> ToViewModel(
             this ApplicationUser user, 
             UserManager<ApplicationUser> userManager, 
             SignInManager<ApplicationUser> signInManager)
         {
+            var skills = new SkillsViewModel
+            {
+                AssociatedSkills = user.AssociatedSkills
+            };
+
             var profileCompletenessWarnings = user.ValidateProfileCompleteness();
-            var result = new ProfileViewModel
+            var profile = new ProfileViewModel
             {
                 HasPassword = await userManager.HasPasswordAsync(user),
                 EmailAddress = user.Email,
@@ -51,7 +56,12 @@ namespace AllReady.Security
                 IsProfileComplete = user.IsProfileComplete(),
                 ProfileCompletenessWarnings = profileCompletenessWarnings.Select(p => p.ErrorMessage)
             };
-            return result;
+
+            return new IndexViewModel
+            {
+                ProfileViewModel = profile,
+                SkillsViewModel = skills,
+            };
         }
     }
 }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/Manage/IndexViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Manage/IndexViewModel.cs
@@ -1,0 +1,11 @@
+namespace AllReady.ViewModels.Manage
+{
+    public class IndexViewModel
+    {
+        public ProfileViewModel ProfileViewModel { get; set; }
+            = new ProfileViewModel();
+
+        public SkillsViewModel SkillsViewModel { get; set; }
+            = new SkillsViewModel();
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/ViewModels/Manage/ProfileViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Manage/ProfileViewModel.cs
@@ -5,14 +5,8 @@ using Microsoft.AspNetCore.Identity;
 
 namespace AllReady.ViewModels.Manage
 {
-    public class IndexViewModel
+    public class ProfileViewModel
     {
-        public IndexViewModel()
-        {
-            Logins = new List<UserLoginInfo>();
-            AssociatedSkills = new List<UserSkill>();
-        }
-
         [Required]
         [Display(Name = "First Name")]
         [MaxLength(200, ErrorMessage = "Name cannot be longer than 200 characters.")]
@@ -32,7 +26,7 @@ namespace AllReady.ViewModels.Manage
 
         public bool HasPassword { get; set; }
 
-        public IList<UserLoginInfo> Logins { get; set; }
+        public IList<UserLoginInfo> Logins { get; set; } = new List<UserLoginInfo>();
 
         public string PhoneNumber { get; set; }
 
@@ -40,11 +34,8 @@ namespace AllReady.ViewModels.Manage
 
         public bool BrowserRemembered { get; set; }
 
-        [Display(Name = "My skills")]
-        public List<UserSkill> AssociatedSkills { get; set; }
-
-        [Display(Name = "Time Zone")]
         [Required]
+        [Display(Name = "Time Zone")]
         public string TimeZoneId { get; set; }
 
         public string ProposedNewEmailAddress { get; set; }

--- a/AllReadyApp/Web-App/AllReady/ViewModels/Manage/SkillsViewModel.cs
+++ b/AllReadyApp/Web-App/AllReady/ViewModels/Manage/SkillsViewModel.cs
@@ -1,0 +1,13 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using AllReady.Models;
+using Microsoft.AspNetCore.Identity;
+
+namespace AllReady.ViewModels.Manage
+{
+    public class SkillsViewModel
+    {
+        [Display(Name = "My skills")]
+        public List<UserSkill> AssociatedSkills { get; set; } = new List<UserSkill>();
+    }
+}

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -48,6 +48,8 @@
 
         <div id="account-tab" class="tab-pane fade in active">
 
+            <!-- Begin ManageController.ResentEmailConfirmation form -->
+
             <form asp-controller="Manage" asp-action="ResendEmailConfirmation">
                 <div class="form-horizontal">
                     <div class="form-group">
@@ -82,6 +84,8 @@
                 </div>
             </form>
 
+            <!-- End ManageController.ResentEmailConfirmation form -->
+
             @if (Model.ProposedNewEmailAddress != null)
             {
                 <div class="alert alert-warning" role="alert">
@@ -100,6 +104,8 @@
                     </form>
                 </div>
             }
+
+            <!-- Begin ManageController.Index form -->
 
             @using (Html.BeginForm())
             {
@@ -203,6 +209,29 @@
                         </div>
                     </div>
                     <div class="form-group">
+                        <div class="col-md-offset-2 col-md-10">
+                            <button type="submit" name="command" value="SaveProfile" class="btn btn-default">Save</button>
+                            <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
+                        </div>
+                    </div>
+                </div>
+            }
+
+            <!-- End ManageController.Index form -->
+
+        </div>
+
+        <!-- End account tab -->
+
+        <!-- Begin skills tab -->
+
+        <div id="skills-tab" class="tab-pane">
+
+            @using (Html.BeginForm())
+            {
+                @Html.AntiForgeryToken()
+                <div class="form-horizontal">
+                    <div class="form-group">
                         <label asp-for="AssociatedSkills" class="control-label col-md-2"></label>
                         <div class="col-md-10">
                             <div data-bind="foreach: skills">
@@ -223,7 +252,7 @@
                     </div>
                     <div class="form-group">
                         <div class="col-md-offset-2 col-md-10">
-                            <button type="submit" name="button" value="Save" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
+                            <button type="submit" name="command" value="SaveSkills" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
                             <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
                             <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.AssociatedSkills)" must be unique</span>
                         </div>
@@ -231,14 +260,6 @@
                 </div>
             }
 
-        </div>
-
-        <!-- End account tab -->
-
-        <!-- Begin skills tab -->
-
-        <div id="skills-tab" class="tab-pane">
-            TODO Move skills details here.
         </div>
 
         <!-- End skills tab -->

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -35,6 +35,22 @@
         Code: Areas\Admin\Views\Campaign\Edit.cshtml
     -->
 
+    <ul class="nav nav-tabs">
+        <li class="active"><a data-toggle="tab" href="#account-tab">Account</a></li>
+        <li><a data-toggle="tab" href="#skills-tab">Skills</a></li>
+    </ul>
+
+    <div class="tab-content">
+
+        <div id="account-tab" class="tab-pane fade in active">
+            TODO Move account details here.
+        </div>
+        <div id="skills-tab" class="tab-pane">
+            TODO Move skills details here.
+        </div>
+
+    </div>
+
     <form asp-controller="Manage" asp-action="ResendEmailConfirmation">
         <div class="form-horizontal">
             <div class="form-group">

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -33,6 +33,8 @@
         Emulate the tabs here: 
         Live: http://localhost:5000/Admin/Campaign/Edit/1
         Code: Areas\Admin\Views\Campaign\Edit.cshtml
+        Ideas: 
+        * Break tabs out into separate cshtml pages.
     -->
 
     <ul class="nav nav-tabs">
@@ -41,6 +43,8 @@
     </ul>
 
     <div class="tab-content">
+
+        <!-- Begin account-tab -->
 
         <div id="account-tab" class="tab-pane fade in active">
 
@@ -96,8 +100,6 @@
                     </form>
                 </div>
             }
-
-            <!-- End Email Form -->
 
             @using (Html.BeginForm())
             {
@@ -230,9 +232,16 @@
             }
 
         </div>
+
+        <!-- End account tab -->
+
+        <!-- Begin skills tab -->
+
         <div id="skills-tab" class="tab-pane">
             TODO Move skills details here.
         </div>
+
+        <!-- End skills tab -->
 
     </div>
 

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -43,7 +43,60 @@
     <div class="tab-content">
 
         <div id="account-tab" class="tab-pane fade in active">
-            TODO Move account details here.
+
+            <form asp-controller="Manage" asp-action="ResendEmailConfirmation">
+                <div class="form-horizontal">
+                    <div class="form-group">
+                        <label asp-for="EmailAddress" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input type="hidden" asp-for="EmailAddress">
+                            <p class="form-control-static">
+                                <span>
+                                    <i class="@(Model.IsEmailAddressConfirmed ? "fa fa-check text-success" : "")"
+                                    title="@(Model.IsEmailAddressConfirmed ? "Your email address has been confirmed" : "")"></i> @Model.EmailAddress
+                                    @if (string.IsNullOrEmpty(Model.ProposedNewEmailAddress))
+                                    {
+                                        <span> | <a asp-controller="Manage" asp-action="ChangeEmail">Change</a></span>
+                                    }
+                                </span>
+                                @if (!Model.IsEmailAddressConfirmed)
+                                {
+                                    <br />
+                                    <div class="alert alert-warning" role="alert">
+                                        <i class="fa fa-exclamation-circle"></i> Your email address has not been confirmed.
+                                        <br />
+                                        allReady cannot send you email notifications until your email address has been confirmed.
+                                        <br />
+                                        Check your inbox for a confirmation email.
+                                        <br />
+                                        <button class="btn btn-default" type="submit">Send me a new confirmation email</button>
+                                    </div>
+                                }
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </form>
+
+            @if (Model.ProposedNewEmailAddress != null)
+            {
+                <div class="alert alert-warning" role="alert">
+                    <p>
+                        <i class="fa fa-exclamation-circle"></i> You have requested that your email address is changed to @Model.ProposedNewEmailAddress but this has not been confirmed.
+                        <br />
+                        allReady cannot update your email address until your new email address has been confirmed.
+                        <br />
+                        Check your inbox for a confirmation email.
+                    </p>
+                    <form asp-controller="Manage" asp-action="ResendChangeEmailConfirmation">
+                        <br /><button class="btn btn-default" type="submit">Send me a new confirmation email</button>
+                    </form>
+                    <form asp-controller="Manage" asp-action="CancelChangeEmail">
+                        <button class="btn btn-default" type="submit">Cancel email change</button>
+                    </form>
+                </div>
+            }
+
         </div>
         <div id="skills-tab" class="tab-pane">
             TODO Move skills details here.
@@ -51,58 +104,6 @@
 
     </div>
 
-    <form asp-controller="Manage" asp-action="ResendEmailConfirmation">
-        <div class="form-horizontal">
-            <div class="form-group">
-                <label asp-for="EmailAddress" class="control-label col-md-2"></label>
-                <div class="col-md-10">
-                    <input type="hidden" asp-for="EmailAddress">
-                    <p class="form-control-static">
-                        <span>
-                            <i class="@(Model.IsEmailAddressConfirmed ? "fa fa-check text-success" : "")"
-                               title="@(Model.IsEmailAddressConfirmed ? "Your email address has been confirmed" : "")"></i> @Model.EmailAddress
-                            @if (string.IsNullOrEmpty(Model.ProposedNewEmailAddress))
-                            {
-                                <span> | <a asp-controller="Manage" asp-action="ChangeEmail">Change</a></span>
-                            }
-                        </span>
-                        @if (!Model.IsEmailAddressConfirmed)
-                        {
-                            <br />
-                            <div class="alert alert-warning" role="alert">
-                                <i class="fa fa-exclamation-circle"></i> Your email address has not been confirmed.
-                                <br />
-                                allReady cannot send you email notifications until your email address has been confirmed.
-                                <br />
-                                Check your inbox for a confirmation email.
-                                <br />
-                                <button class="btn btn-default" type="submit">Send me a new confirmation email</button>
-                            </div>
-                        }
-                    </p>
-                </div>
-            </div>
-        </div>
-    </form>
-
-    @if (Model.ProposedNewEmailAddress != null)
-    {
-        <div class="alert alert-warning" role="alert">
-            <p>
-                <i class="fa fa-exclamation-circle"></i> You have requested that your email address is changed to @Model.ProposedNewEmailAddress but this has not been confirmed.
-                <br />
-                allReady cannot update your email address until your new email address has been confirmed.
-                <br />
-                Check your inbox for a confirmation email.
-            </p>
-            <form asp-controller="Manage" asp-action="ResendChangeEmailConfirmation">
-                <br /><button class="btn btn-default" type="submit">Send me a new confirmation email</button>
-            </form>
-            <form asp-controller="Manage" asp-action="CancelChangeEmail">
-                <button class="btn btn-default" type="submit">Cancel email change</button>
-            </form>
-        </div>
-    }
 
     @using (Html.BeginForm())
     {

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -97,6 +97,138 @@
                 </div>
             }
 
+            <!-- End Email Form -->
+
+            @using (Html.BeginForm())
+            {
+                @Html.AntiForgeryToken()
+                <hr />
+                <div class="form-horizontal">
+                    <div class="form-group">
+                        <label asp-for="FirstName" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input type="text" asp-for="FirstName" class="form-control"/>
+                            <span asp-validation-for="FirstName" class="text-danger"></span>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="LastName" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <input type="text" asp-for="LastName" class="form-control" />
+                            <span asp-validation-for="LastName" class="text-danger"></span>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="control-label col-md-2">Mobile phone number</label>
+                        <div class="col-md-10">
+                            <p class="form-control-static">
+                                @(Model.PhoneNumber ?? "None")
+                                @if (Model.PhoneNumber != null)
+                                {
+                                    <a asp-controller="Manage" asp-action="AddPhoneNumber">Change</a>
+                                        @: &nbsp;|&nbsp;
+                                        <a asp-controller="Manage" asp-action="RemovePhoneNumber">Remove</a>
+                                        @if (!Model.IsPhoneNumberConfirmed)
+                                        {
+                                            @: &nbsp;|&nbsp;
+                                            <a asp-controller="Manage" asp-action="VerifyPhoneNumber" asp-route-phoneNumber="@Model.PhoneNumber">Verify</a>
+                                        }
+                                }
+                                else
+                                {
+                                    <a asp-controller="Manage" asp-action="AddPhoneNumber">Add</a>
+                                }
+                                @if (!Model.IsPhoneNumberConfirmed && Model.PhoneNumber != null)
+                                {
+                                    <br />
+                                    <div class="alert alert-warning" role="alert">
+                                        <i class="fa fa-exclamation-circle"></i> Your mobile phone number has not been confirmed.
+                                        <br />
+                                        allReady cannot send you SMS notifications until your mobile phone number has been confirmed.
+                                        <br />
+                                        Please check your messages for your confirmation code.
+                                    </div>
+                                }
+                            </p>
+                        </div>
+                    </div>
+                    @if (User.IsOrganizationAdmin())
+                        {
+                        @if (User.IsUserType(UserType.SiteAdmin))
+                            {
+                            <div class="form-group">
+                                <label class="control-label col-md-2">Approve users</label>
+                                <div class="col-md-10">
+                                    <p class="form-control-static">
+                                        <a asp-controller="Site" asp-action="Index" asp-area="@AreaNames.Admin">Find</a>
+                                    </p>
+                                </div>
+                            </div>
+                        }
+                    }
+                    else
+                    {
+                        <div class="form-group">
+                            <label class="control-label col-md-2">Social media logins</label>
+                            <div class="col-md-10">
+                                <p class="form-control-static">
+                                    @Model.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]
+                                </p>
+                            </div>
+                        </div>
+
+                    }
+                    <div class="form-group">
+                        <label class="control-label col-md-2">Password</label>
+                        <div class="col-md-10">
+                            <p class="form-control-static">
+                                @if (Model.HasPassword)
+                                {
+                                    <a asp-controller="Manage" asp-action="ChangePassword">Change</a>
+                                }
+                                else
+                                {
+                                    <a asp-controller="Manage" asp-action="SetPassword">Create</a>
+                                }
+                            </p>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="TimeZoneId" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <select asp-for="TimeZoneId" asp-items="@SelectListService.GetTimeZones()" class="form-control"></select>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="AssociatedSkills" class="control-label col-md-2"></label>
+                        <div class="col-md-10">
+                            <div data-bind="foreach: skills">
+                                <div class="form-inline">
+                                    <select class="form-control" data-bind="attr: { name: ControlName($index) }, options: $root.availableSkills, optionsText: 'Name', optionsValue: 'Id', value: Id"></select>
+                                    <span class="fa fa-question-circle" data-bind="visible: Description, tooltip: { title: Description, placement: 'top' }" aria-hidden="true"></span>
+                                    <a href="#" data-bind="click: $root.deleteSkill" title="Delete skill">
+                                        <span class="fa fa-remove" aria-hidden="true"></span>
+                                        Delete
+                                    </a>
+                                </div>
+                            </div>
+                            <a href="#" data-bind="click: addSkill" title="Add skill">
+                                <span class="fa fa-plus" aria-hidden="true"></span>
+                                Add
+                            </a>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="col-md-offset-2 col-md-10">
+                            <button type="submit" name="button" value="Save" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
+                            <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
+                            <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.AssociatedSkills)" must be unique</span>
+                        </div>
+                    </div>
+                </div>
+            }
+
         </div>
         <div id="skills-tab" class="tab-pane">
             TODO Move skills details here.
@@ -105,135 +237,6 @@
     </div>
 
 
-    @using (Html.BeginForm())
-    {
-        @Html.AntiForgeryToken()
-        <hr />
-        <div class="form-horizontal">
-            <div class="form-group">
-                <label asp-for="FirstName" class="control-label col-md-2"></label>
-                <div class="col-md-10">
-                    <input type="text" asp-for="FirstName" class="form-control"/>
-                    <span asp-validation-for="FirstName" class="text-danger"></span>
-                </div>
-            </div>
-            <div class="form-group">
-                <label asp-for="LastName" class="control-label col-md-2"></label>
-                <div class="col-md-10">
-                    <input type="text" asp-for="LastName" class="form-control" />
-                    <span asp-validation-for="LastName" class="text-danger"></span>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label class="control-label col-md-2">Mobile phone number</label>
-                <div class="col-md-10">
-                    <p class="form-control-static">
-                        @(Model.PhoneNumber ?? "None")
-                        @if (Model.PhoneNumber != null)
-                        {
-                            <a asp-controller="Manage" asp-action="AddPhoneNumber">Change</a>
-                                @: &nbsp;|&nbsp;
-                                <a asp-controller="Manage" asp-action="RemovePhoneNumber">Remove</a>
-                                @if (!Model.IsPhoneNumberConfirmed)
-                                {
-                                    @: &nbsp;|&nbsp;
-                                    <a asp-controller="Manage" asp-action="VerifyPhoneNumber" asp-route-phoneNumber="@Model.PhoneNumber">Verify</a>
-                                }
-                        }
-                        else
-                        {
-                            <a asp-controller="Manage" asp-action="AddPhoneNumber">Add</a>
-                        }
-                        @if (!Model.IsPhoneNumberConfirmed && Model.PhoneNumber != null)
-                        {
-                            <br />
-                            <div class="alert alert-warning" role="alert">
-                                <i class="fa fa-exclamation-circle"></i> Your mobile phone number has not been confirmed.
-                                <br />
-                                allReady cannot send you SMS notifications until your mobile phone number has been confirmed.
-                                <br />
-                                Please check your messages for your confirmation code.
-                            </div>
-                        }
-                    </p>
-                </div>
-            </div>
-            @if (User.IsOrganizationAdmin())
-                {
-                @if (User.IsUserType(UserType.SiteAdmin))
-                    {
-                    <div class="form-group">
-                        <label class="control-label col-md-2">Approve users</label>
-                        <div class="col-md-10">
-                            <p class="form-control-static">
-                                <a asp-controller="Site" asp-action="Index" asp-area="@AreaNames.Admin">Find</a>
-                            </p>
-                        </div>
-                    </div>
-                }
-            }
-            else
-            {
-                <div class="form-group">
-                    <label class="control-label col-md-2">Social media logins</label>
-                    <div class="col-md-10">
-                        <p class="form-control-static">
-                            @Model.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]
-                        </p>
-                    </div>
-                </div>
-
-            }
-            <div class="form-group">
-                <label class="control-label col-md-2">Password</label>
-                <div class="col-md-10">
-                    <p class="form-control-static">
-                        @if (Model.HasPassword)
-                        {
-                            <a asp-controller="Manage" asp-action="ChangePassword">Change</a>
-                        }
-                        else
-                        {
-                            <a asp-controller="Manage" asp-action="SetPassword">Create</a>
-                        }
-                    </p>
-                </div>
-            </div>
-            <div class="form-group">
-                <label asp-for="TimeZoneId" class="control-label col-md-2"></label>
-                <div class="col-md-10">
-                    <select asp-for="TimeZoneId" asp-items="@SelectListService.GetTimeZones()" class="form-control"></select>
-                </div>
-            </div>
-            <div class="form-group">
-                <label asp-for="AssociatedSkills" class="control-label col-md-2"></label>
-                <div class="col-md-10">
-                    <div data-bind="foreach: skills">
-                        <div class="form-inline">
-                            <select class="form-control" data-bind="attr: { name: ControlName($index) }, options: $root.availableSkills, optionsText: 'Name', optionsValue: 'Id', value: Id"></select>
-                            <span class="fa fa-question-circle" data-bind="visible: Description, tooltip: { title: Description, placement: 'top' }" aria-hidden="true"></span>
-                            <a href="#" data-bind="click: $root.deleteSkill" title="Delete skill">
-                                <span class="fa fa-remove" aria-hidden="true"></span>
-                                Delete
-                            </a>
-                        </div>
-                    </div>
-                    <a href="#" data-bind="click: addSkill" title="Add skill">
-                        <span class="fa fa-plus" aria-hidden="true"></span>
-                        Add
-                    </a>
-                </div>
-            </div>
-            <div class="form-group">
-                <div class="col-md-offset-2 col-md-10">
-                    <button type="submit" name="button" value="Save" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
-                    <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
-                    <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.AssociatedSkills)" must be unique</span>
-                </div>
-            </div>
-        </div>
-    }
 </div>
 
 @section scripts {

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -98,7 +98,7 @@
 
             <!-- Begin ManageController.Index form -->
 
-            @using (Html.BeginForm())
+            @using (Html.BeginForm("SaveProfile"))
             {
                 @Html.AntiForgeryToken()
                 <hr />
@@ -201,7 +201,7 @@
                     </div>
                     <div class="form-group">
                         <div class="col-md-offset-2 col-md-10">
-                            <button type="submit" name="command" value="SaveProfile" class="btn btn-default">Save</button>
+                            <button type="submit" class="btn btn-default">Save</button>
                             <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
                         </div>
                     </div>
@@ -218,7 +218,7 @@
 
         <div id="skills-tab" class="tab-pane">
 
-            @using (Html.BeginForm())
+            @using (Html.BeginForm("SaveSkills"))
             {
                 @Html.AntiForgeryToken()
                 <div class="form-horizontal">
@@ -243,7 +243,7 @@
                     </div>
                     <div class="form-group">
                         <div class="col-md-offset-2 col-md-10">
-                            <button type="submit" name="command" value="SaveSkills" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
+                            <button type="submit" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
                             <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
                             <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.AssociatedSkills)" must be unique</span>
                         </div>

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -1,14 +1,11 @@
-﻿@using AllReady.Constants
+﻿<!-- TODO 2231 Which of the follow four are necessary? -->
+@using AllReady.Constants
 @using AllReady.Security;
-<!-- 
-    TODO 2231 Break the Profile and Skills sections into their own Partial Views. 
-    That way we can avoid doing Model.ChildViewModel.SomeProperty
--->
-
 @using AllReady.ViewModels.Manage
 @inject AllReady.Services.ISelectListService SelectListService
 
 @model IndexViewModel
+
 @{
     ViewData["Title"] = "Manage your account";
 }
@@ -39,233 +36,22 @@
     </ul>
 
     <div class="tab-content">
-
-        <!-- Begin account-tab -->
-
         <div id="account-tab" class="tab-pane fade in active">
 
-            <!-- Begin ManageController.ResentEmailConfirmation form -->
-
-            <form asp-controller="Manage" asp-action="ResendEmailConfirmation">
-                <div class="form-horizontal">
-                    <div class="form-group">
-                        <label asp-for="ProfileViewModel.EmailAddress" class="control-label col-md-2"></label>
-                        <div class="col-md-10">
-                            <input type="hidden" asp-for="ProfileViewModel.EmailAddress">
-                            <p class="form-control-static">
-                                <span>
-                                    <i class="@(Model.ProfileViewModel.IsEmailAddressConfirmed ? "fa fa-check text-success" : "")"
-                                    title="@(Model.ProfileViewModel.IsEmailAddressConfirmed ? "Your email address has been confirmed" : "")"></i> @Model.ProfileViewModel.EmailAddress
-                                    @if (string.IsNullOrEmpty(Model.ProfileViewModel.ProposedNewEmailAddress))
-                                    {
-                                        <span> | <a asp-controller="Manage" asp-action="ChangeEmail">Change</a></span>
-                                    }
-                                </span>
-                                @if (!Model.ProfileViewModel.IsEmailAddressConfirmed)
-                                {
-                                    <br />
-                                    <div class="alert alert-warning" role="alert">
-                                        <i class="fa fa-exclamation-circle"></i> Your email address has not been confirmed.
-                                        <br />
-                                        allReady cannot send you email notifications until your email address has been confirmed.
-                                        <br />
-                                        Check your inbox for a confirmation email.
-                                        <br />
-                                        <button class="btn btn-default" type="submit">Send me a new confirmation email</button>
-                                    </div>
-                                }
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            </form>
-
-            <!-- End ManageController.ResentEmailConfirmation form -->
-
-            @if (Model.ProfileViewModel.ProposedNewEmailAddress != null)
-            {
-                <div class="alert alert-warning" role="alert">
-                    <p>
-                        <i class="fa fa-exclamation-circle"></i> You have requested that your email address is changed to @Model.ProfileViewModel.ProposedNewEmailAddress but this has not been confirmed.
-                        <br />
-                        allReady cannot update your email address until your new email address has been confirmed.
-                        <br />
-                        Check your inbox for a confirmation email.
-                    </p>
-                    <form asp-controller="Manage" asp-action="ResendChangeEmailConfirmation">
-                        <br /><button class="btn btn-default" type="submit">Send me a new confirmation email</button>
-                    </form>
-                    <form asp-controller="Manage" asp-action="CancelChangeEmail">
-                        <button class="btn btn-default" type="submit">Cancel email change</button>
-                    </form>
-                </div>
-            }
-
-            <!-- Begin ManageController.Index form -->
-
-            @using (Html.BeginForm("SaveProfile"))
-            {
-                @Html.AntiForgeryToken()
-                <hr />
-                <div class="form-horizontal">
-                    <div class="form-group">
-                        <label asp-for="ProfileViewModel.FirstName" class="control-label col-md-2"></label>
-                        <div class="col-md-10">
-                            <input type="text" asp-for="ProfileViewModel.FirstName" class="form-control"/>
-                            <span asp-validation-for="ProfileViewModel.FirstName" class="text-danger"></span>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label asp-for="ProfileViewModel.LastName" class="control-label col-md-2"></label>
-                        <div class="col-md-10">
-                            <input type="text" asp-for="ProfileViewModel.LastName" class="form-control" />
-                            <span asp-validation-for="ProfileViewModel.LastName" class="text-danger"></span>
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label class="control-label col-md-2">Mobile phone number</label>
-                        <div class="col-md-10">
-                            <p class="form-control-static">
-                                @(Model.ProfileViewModel.PhoneNumber ?? "None")
-                                @if (Model.ProfileViewModel.PhoneNumber != null)
-                                {
-                                    <a asp-controller="Manage" asp-action="AddPhoneNumber">Change</a>
-                                        @: &nbsp;|&nbsp;
-                                        <a asp-controller="Manage" asp-action="RemovePhoneNumber">Remove</a>
-                                        @if (!Model.ProfileViewModel.IsPhoneNumberConfirmed)
-                                        {
-                                            @: &nbsp;|&nbsp;
-                                            <a asp-controller="Manage" asp-action="VerifyPhoneNumber" asp-route-phoneNumber="@Model.ProfileViewModel.PhoneNumber">Verify</a>
-                                        }
-                                }
-                                else
-                                {
-                                    <a asp-controller="Manage" asp-action="AddPhoneNumber">Add</a>
-                                }
-                                @if (!Model.ProfileViewModel.IsPhoneNumberConfirmed && Model.ProfileViewModel.PhoneNumber != null)
-                                {
-                                    <br />
-                                    <div class="alert alert-warning" role="alert">
-                                        <i class="fa fa-exclamation-circle"></i> Your mobile phone number has not been confirmed.
-                                        <br />
-                                        allReady cannot send you SMS notifications until your mobile phone number has been confirmed.
-                                        <br />
-                                        Please check your messages for your confirmation code.
-                                    </div>
-                                }
-                            </p>
-                        </div>
-                    </div>
-                    @if (User.IsOrganizationAdmin())
-                        {
-                        @if (User.IsUserType(UserType.SiteAdmin))
-                            {
-                            <div class="form-group">
-                                <label class="control-label col-md-2">Approve users</label>
-                                <div class="col-md-10">
-                                    <p class="form-control-static">
-                                        <a asp-controller="Site" asp-action="Index" asp-area="@AreaNames.Admin">Find</a>
-                                    </p>
-                                </div>
-                            </div>
-                        }
-                    }
-                    else
-                    {
-                        <div class="form-group">
-                            <label class="control-label col-md-2">Social media logins</label>
-                            <div class="col-md-10">
-                                <p class="form-control-static">
-                                    @Model.ProfileViewModel.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]
-                                </p>
-                            </div>
-                        </div>
-
-                    }
-                    <div class="form-group">
-                        <label class="control-label col-md-2">Password</label>
-                        <div class="col-md-10">
-                            <p class="form-control-static">
-                                @if (Model.ProfileViewModel.HasPassword)
-                                {
-                                    <a asp-controller="Manage" asp-action="ChangePassword">Change</a>
-                                }
-                                else
-                                {
-                                    <a asp-controller="Manage" asp-action="SetPassword">Create</a>
-                                }
-                            </p>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <label asp-for="ProfileViewModel.TimeZoneId" class="control-label col-md-2"></label>
-                        <div class="col-md-10">
-                            <select asp-for="ProfileViewModel.TimeZoneId" asp-items="@SelectListService.GetTimeZones()" class="form-control"></select>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <div class="col-md-offset-2 col-md-10">
-                            <button type="submit" class="btn btn-default">Save</button>
-                            <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
-                        </div>
-                    </div>
-                </div>
-            }
-
-            <!-- End ManageController.Index form -->
+            @Html.Partial("_ManageProfile", Model.ProfileViewModel)
 
         </div>
-
-        <!-- End account tab -->
-
-        <!-- Begin skills tab -->
 
         <div id="skills-tab" class="tab-pane">
 
-            @using (Html.BeginForm("SaveSkills"))
-            {
-                @Html.AntiForgeryToken()
-                <div class="form-horizontal">
-                    <div class="form-group">
-                        <label asp-for="SkillsViewModel.AssociatedSkills" class="control-label col-md-2"></label>
-                        <div class="col-md-10">
-                            <div data-bind="foreach: skills">
-                                <div class="form-inline">
-                                    <select class="form-control" data-bind="attr: { name: ControlName($index) }, options: $root.availableSkills, optionsText: 'Name', optionsValue: 'Id', value: Id"></select>
-                                    <span class="fa fa-question-circle" data-bind="visible: Description, tooltip: { title: Description, placement: 'top' }" aria-hidden="true"></span>
-                                    <a href="#" data-bind="click: $root.deleteSkill" title="Delete skill">
-                                        <span class="fa fa-remove" aria-hidden="true"></span>
-                                        Delete
-                                    </a>
-                                </div>
-                            </div>
-                            <a href="#" data-bind="click: addSkill" title="Add skill">
-                                <span class="fa fa-plus" aria-hidden="true"></span>
-                                Add
-                            </a>
-                        </div>
-                    </div>
-                    <div class="form-group">
-                        <div class="col-md-offset-2 col-md-10">
-                            <button type="submit" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
-                            <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
-                            <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.SkillsViewModel.AssociatedSkills)" must be unique</span>
-                        </div>
-                    </div>
-                </div>
-            }
+            @Html.Partial("_ManageSkills", Model.SkillsViewModel)
 
         </div>
-
-        <!-- End skills tab -->
-
     </div>
-
-
 </div>
 
 @section scripts {
+
     <script type="text/javascript">
         (function (ko, $, skills, availableSkills) {
 
@@ -297,8 +83,12 @@
             }
 
             ko.applyBindings(new ManageUserViewModel(skills, availableSkills));
-        })(ko, $,
+        })(
+            ko, 
+            $,
+            // TODO 2231 Figure out how to run this script from the _ManageSkills partial View.
             @Json.Serialize(Model.SkillsViewModel.AssociatedSkills.Select(rs => new { Id = rs.SkillId })),
             @Json.Serialize(SelectListService.GetSkills()));
+
     </script>
 }

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -28,7 +28,12 @@
         </div>
     }
 
-    <!-- TODO: 1871 Add bootstrap tabs here. -->
+    <!-- 
+        TODO: 1871 Add tabs here.
+        Emulate the tabs here: 
+        Live: http://localhost:5000/Admin/Campaign/Edit/1
+        Code: Areas\Admin\Views\Campaign\Edit.cshtml
+    -->
 
     <form asp-controller="Manage" asp-action="ResendEmailConfirmation">
         <div class="form-horizontal">

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -28,15 +28,6 @@
         </div>
     }
 
-    <!-- 
-        TODO: 1871 Add tabs here.
-        Emulate the tabs here: 
-        Live: http://localhost:5000/Admin/Campaign/Edit/1
-        Code: Areas\Admin\Views\Campaign\Edit.cshtml
-        Ideas: 
-        * Break tabs out into separate cshtml pages.
-    -->
-
     <ul class="nav nav-tabs">
         <li class="active"><a data-toggle="tab" href="#account-tab">Account</a></li>
         <li><a data-toggle="tab" href="#skills-tab">Skills</a></li>

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -1,5 +1,10 @@
 ﻿@using AllReady.Constants
 @using AllReady.Security;
+<!-- 
+    TODO 2231 Break the Profile and Skills sections into their own Partial Views. 
+    That way we can avoid doing Model.ChildViewModel.SomeProperty
+-->
+
 @using AllReady.ViewModels.Manage
 @inject AllReady.Services.ISelectListService SelectListService
 
@@ -12,14 +17,14 @@
 <p class="text-success">@ViewData["StatusMessage"]</p>
 <div>
 
-    @if (!Model.IsProfileComplete)
+    @if (!Model.ProfileViewModel.IsProfileComplete)
     {
         <div class="alert alert-info" role="alert">
             <p class="text-info">
                 <i class="fa fa-exclamation-circle"></i> Please complete your allReady account profile
                 <br />
                 <ul>
-                    @foreach(var warning in Model.ProfileCompletenessWarnings)
+                    @foreach(var warning in Model.ProfileViewModel.ProfileCompletenessWarnings)
                     {
                         <li>@warning</li>
                     }
@@ -44,19 +49,19 @@
             <form asp-controller="Manage" asp-action="ResendEmailConfirmation">
                 <div class="form-horizontal">
                     <div class="form-group">
-                        <label asp-for="EmailAddress" class="control-label col-md-2"></label>
+                        <label asp-for="ProfileViewModel.EmailAddress" class="control-label col-md-2"></label>
                         <div class="col-md-10">
-                            <input type="hidden" asp-for="EmailAddress">
+                            <input type="hidden" asp-for="ProfileViewModel.EmailAddress">
                             <p class="form-control-static">
                                 <span>
-                                    <i class="@(Model.IsEmailAddressConfirmed ? "fa fa-check text-success" : "")"
-                                    title="@(Model.IsEmailAddressConfirmed ? "Your email address has been confirmed" : "")"></i> @Model.EmailAddress
-                                    @if (string.IsNullOrEmpty(Model.ProposedNewEmailAddress))
+                                    <i class="@(Model.ProfileViewModel.IsEmailAddressConfirmed ? "fa fa-check text-success" : "")"
+                                    title="@(Model.ProfileViewModel.IsEmailAddressConfirmed ? "Your email address has been confirmed" : "")"></i> @Model.ProfileViewModel.EmailAddress
+                                    @if (string.IsNullOrEmpty(Model.ProfileViewModel.ProposedNewEmailAddress))
                                     {
                                         <span> | <a asp-controller="Manage" asp-action="ChangeEmail">Change</a></span>
                                     }
                                 </span>
-                                @if (!Model.IsEmailAddressConfirmed)
+                                @if (!Model.ProfileViewModel.IsEmailAddressConfirmed)
                                 {
                                     <br />
                                     <div class="alert alert-warning" role="alert">
@@ -77,11 +82,11 @@
 
             <!-- End ManageController.ResentEmailConfirmation form -->
 
-            @if (Model.ProposedNewEmailAddress != null)
+            @if (Model.ProfileViewModel.ProposedNewEmailAddress != null)
             {
                 <div class="alert alert-warning" role="alert">
                     <p>
-                        <i class="fa fa-exclamation-circle"></i> You have requested that your email address is changed to @Model.ProposedNewEmailAddress but this has not been confirmed.
+                        <i class="fa fa-exclamation-circle"></i> You have requested that your email address is changed to @Model.ProfileViewModel.ProposedNewEmailAddress but this has not been confirmed.
                         <br />
                         allReady cannot update your email address until your new email address has been confirmed.
                         <br />
@@ -104,17 +109,17 @@
                 <hr />
                 <div class="form-horizontal">
                     <div class="form-group">
-                        <label asp-for="FirstName" class="control-label col-md-2"></label>
+                        <label asp-for="ProfileViewModel.FirstName" class="control-label col-md-2"></label>
                         <div class="col-md-10">
-                            <input type="text" asp-for="FirstName" class="form-control"/>
-                            <span asp-validation-for="FirstName" class="text-danger"></span>
+                            <input type="text" asp-for="ProfileViewModel.FirstName" class="form-control"/>
+                            <span asp-validation-for="ProfileViewModel.FirstName" class="text-danger"></span>
                         </div>
                     </div>
                     <div class="form-group">
-                        <label asp-for="LastName" class="control-label col-md-2"></label>
+                        <label asp-for="ProfileViewModel.LastName" class="control-label col-md-2"></label>
                         <div class="col-md-10">
-                            <input type="text" asp-for="LastName" class="form-control" />
-                            <span asp-validation-for="LastName" class="text-danger"></span>
+                            <input type="text" asp-for="ProfileViewModel.LastName" class="form-control" />
+                            <span asp-validation-for="ProfileViewModel.LastName" class="text-danger"></span>
                         </div>
                     </div>
 
@@ -122,23 +127,23 @@
                         <label class="control-label col-md-2">Mobile phone number</label>
                         <div class="col-md-10">
                             <p class="form-control-static">
-                                @(Model.PhoneNumber ?? "None")
-                                @if (Model.PhoneNumber != null)
+                                @(Model.ProfileViewModel.PhoneNumber ?? "None")
+                                @if (Model.ProfileViewModel.PhoneNumber != null)
                                 {
                                     <a asp-controller="Manage" asp-action="AddPhoneNumber">Change</a>
                                         @: &nbsp;|&nbsp;
                                         <a asp-controller="Manage" asp-action="RemovePhoneNumber">Remove</a>
-                                        @if (!Model.IsPhoneNumberConfirmed)
+                                        @if (!Model.ProfileViewModel.IsPhoneNumberConfirmed)
                                         {
                                             @: &nbsp;|&nbsp;
-                                            <a asp-controller="Manage" asp-action="VerifyPhoneNumber" asp-route-phoneNumber="@Model.PhoneNumber">Verify</a>
+                                            <a asp-controller="Manage" asp-action="VerifyPhoneNumber" asp-route-phoneNumber="@Model.ProfileViewModel.PhoneNumber">Verify</a>
                                         }
                                 }
                                 else
                                 {
                                     <a asp-controller="Manage" asp-action="AddPhoneNumber">Add</a>
                                 }
-                                @if (!Model.IsPhoneNumberConfirmed && Model.PhoneNumber != null)
+                                @if (!Model.ProfileViewModel.IsPhoneNumberConfirmed && Model.ProfileViewModel.PhoneNumber != null)
                                 {
                                     <br />
                                     <div class="alert alert-warning" role="alert">
@@ -172,7 +177,7 @@
                             <label class="control-label col-md-2">Social media logins</label>
                             <div class="col-md-10">
                                 <p class="form-control-static">
-                                    @Model.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]
+                                    @Model.ProfileViewModel.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]
                                 </p>
                             </div>
                         </div>
@@ -182,7 +187,7 @@
                         <label class="control-label col-md-2">Password</label>
                         <div class="col-md-10">
                             <p class="form-control-static">
-                                @if (Model.HasPassword)
+                                @if (Model.ProfileViewModel.HasPassword)
                                 {
                                     <a asp-controller="Manage" asp-action="ChangePassword">Change</a>
                                 }
@@ -194,9 +199,9 @@
                         </div>
                     </div>
                     <div class="form-group">
-                        <label asp-for="TimeZoneId" class="control-label col-md-2"></label>
+                        <label asp-for="ProfileViewModel.TimeZoneId" class="control-label col-md-2"></label>
                         <div class="col-md-10">
-                            <select asp-for="TimeZoneId" asp-items="@SelectListService.GetTimeZones()" class="form-control"></select>
+                            <select asp-for="ProfileViewModel.TimeZoneId" asp-items="@SelectListService.GetTimeZones()" class="form-control"></select>
                         </div>
                     </div>
                     <div class="form-group">
@@ -223,7 +228,7 @@
                 @Html.AntiForgeryToken()
                 <div class="form-horizontal">
                     <div class="form-group">
-                        <label asp-for="AssociatedSkills" class="control-label col-md-2"></label>
+                        <label asp-for="SkillsViewModel.AssociatedSkills" class="control-label col-md-2"></label>
                         <div class="col-md-10">
                             <div data-bind="foreach: skills">
                                 <div class="form-inline">
@@ -245,7 +250,7 @@
                         <div class="col-md-offset-2 col-md-10">
                             <button type="submit" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
                             <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
-                            <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.AssociatedSkills)" must be unique</span>
+                            <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.SkillsViewModel.AssociatedSkills)" must be unique</span>
                         </div>
                     </div>
                 </div>
@@ -293,7 +298,7 @@
 
             ko.applyBindings(new ManageUserViewModel(skills, availableSkills));
         })(ko, $,
-            @Json.Serialize(Model.AssociatedSkills.Select(rs => new { Id = rs.SkillId })),
+            @Json.Serialize(Model.SkillsViewModel.AssociatedSkills.Select(rs => new { Id = rs.SkillId })),
             @Json.Serialize(SelectListService.GetSkills()));
     </script>
 }

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/Index.cshtml
@@ -28,6 +28,8 @@
         </div>
     }
 
+    <!-- TODO: 1871 Add bootstrap tabs here. -->
+
     <form asp-controller="Manage" asp-action="ResendEmailConfirmation">
         <div class="form-horizontal">
             <div class="form-group">

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/_ManageProfile.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/_ManageProfile.cshtml
@@ -1,0 +1,178 @@
+<!-- TODO 2231 Which of the follow four are necessary? -->
+@using AllReady.Constants
+@using AllReady.Security;
+@using AllReady.ViewModels.Manage
+@inject AllReady.Services.ISelectListService SelectListService
+
+@model AllReady.ViewModels.Manage.ProfileViewModel
+
+<!-- Begin ManageController.ResentEmailConfirmation form -->
+
+<form asp-controller="Manage" asp-action="ResendEmailConfirmation">
+    <div class="form-horizontal">
+        <div class="form-group">
+            <label asp-for="EmailAddress" class="control-label col-md-2"></label>
+            <div class="col-md-10">
+                <input type="hidden" asp-for="EmailAddress">
+                <p class="form-control-static">
+                    <span>
+                        <i class="@(Model.IsEmailAddressConfirmed ? "fa fa-check text-success" : "")"
+                        title="@(Model.IsEmailAddressConfirmed ? "Your email address has been confirmed" : "")"></i> @Model.EmailAddress
+                        @if (string.IsNullOrEmpty(Model.ProposedNewEmailAddress))
+                        {
+                            <span> | <a asp-controller="Manage" asp-action="ChangeEmail">Change</a></span>
+                        }
+                    </span>
+                    @if (!Model.IsEmailAddressConfirmed)
+                    {
+                        <br />
+                        <div class="alert alert-warning" role="alert">
+                            <i class="fa fa-exclamation-circle"></i> Your email address has not been confirmed.
+                            <br />
+                            allReady cannot send you email notifications until your email address has been confirmed.
+                            <br />
+                            Check your inbox for a confirmation email.
+                            <br />
+                            <button class="btn btn-default" type="submit">Send me a new confirmation email</button>
+                        </div>
+                    }
+                </p>
+            </div>
+        </div>
+    </div>
+</form>
+
+<!-- End ManageController.ResentEmailConfirmation form -->
+
+@if (Model.ProposedNewEmailAddress != null)
+{
+    <div class="alert alert-warning" role="alert">
+        <p>
+            <i class="fa fa-exclamation-circle"></i> You have requested that your email address is changed to @Model.ProposedNewEmailAddress but this has not been confirmed.
+            <br />
+            allReady cannot update your email address until your new email address has been confirmed.
+            <br />
+            Check your inbox for a confirmation email.
+        </p>
+        <form asp-controller="Manage" asp-action="ResendChangeEmailConfirmation">
+            <br /><button class="btn btn-default" type="submit">Send me a new confirmation email</button>
+        </form>
+        <form asp-controller="Manage" asp-action="CancelChangeEmail">
+            <button class="btn btn-default" type="submit">Cancel email change</button>
+        </form>
+    </div>
+}
+
+<!-- Begin ManageController.Index form -->
+
+@using (Html.BeginForm("SaveProfile", "Manage"))
+{
+    @Html.AntiForgeryToken()
+    <hr />
+    <div class="form-horizontal">
+        <div class="form-group">
+            <label asp-for="FirstName" class="control-label col-md-2"></label>
+            <div class="col-md-10">
+                <input type="text" asp-for="FirstName" class="form-control"/>
+                <span asp-validation-for="FirstName" class="text-danger"></span>
+            </div>
+        </div>
+        <div class="form-group">
+            <label asp-for="LastName" class="control-label col-md-2"></label>
+            <div class="col-md-10">
+                <input type="text" asp-for="LastName" class="form-control" />
+                <span asp-validation-for="LastName" class="text-danger"></span>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label class="control-label col-md-2">Mobile phone number</label>
+            <div class="col-md-10">
+                <p class="form-control-static">
+                    @(Model.PhoneNumber ?? "None")
+                    @if (Model.PhoneNumber != null)
+                    {
+                        <a asp-controller="Manage" asp-action="AddPhoneNumber">Change</a>
+                            @: &nbsp;|&nbsp;
+                            <a asp-controller="Manage" asp-action="RemovePhoneNumber">Remove</a>
+                            @if (!Model.IsPhoneNumberConfirmed)
+                            {
+                                @: &nbsp;|&nbsp;
+                                <a asp-controller="Manage" asp-action="VerifyPhoneNumber" asp-route-phoneNumber="@Model.PhoneNumber">Verify</a>
+                            }
+                    }
+                    else
+                    {
+                        <a asp-controller="Manage" asp-action="AddPhoneNumber">Add</a>
+                    }
+                    @if (!Model.IsPhoneNumberConfirmed && Model.PhoneNumber != null)
+                    {
+                        <br />
+                        <div class="alert alert-warning" role="alert">
+                            <i class="fa fa-exclamation-circle"></i> Your mobile phone number has not been confirmed.
+                            <br />
+                            allReady cannot send you SMS notifications until your mobile phone number has been confirmed.
+                            <br />
+                            Please check your messages for your confirmation code.
+                        </div>
+                    }
+                </p>
+            </div>
+        </div>
+        @if (User.IsOrganizationAdmin())
+            {
+            @if (User.IsUserType(UserType.SiteAdmin))
+                {
+                <div class="form-group">
+                    <label class="control-label col-md-2">Approve users</label>
+                    <div class="col-md-10">
+                        <p class="form-control-static">
+                            <a asp-controller="Site" asp-action="Index" asp-area="@AreaNames.Admin">Find</a>
+                        </p>
+                    </div>
+                </div>
+            }
+        }
+        else
+        {
+            <div class="form-group">
+                <label class="control-label col-md-2">Social media logins</label>
+                <div class="col-md-10">
+                    <p class="form-control-static">
+                        @Model.Logins.Count [<a asp-controller="Manage" asp-action="ManageLogins">Manage</a>]
+                    </p>
+                </div>
+            </div>
+
+        }
+        <div class="form-group">
+            <label class="control-label col-md-2">Password</label>
+            <div class="col-md-10">
+                <p class="form-control-static">
+                    @if (Model.HasPassword)
+                    {
+                        <a asp-controller="Manage" asp-action="ChangePassword">Change</a>
+                    }
+                    else
+                    {
+                        <a asp-controller="Manage" asp-action="SetPassword">Create</a>
+                    }
+                </p>
+            </div>
+        </div>
+        <div class="form-group">
+            <label asp-for="TimeZoneId" class="control-label col-md-2"></label>
+            <div class="col-md-10">
+                <select asp-for="TimeZoneId" asp-items="@SelectListService.GetTimeZones()" class="form-control"></select>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-md-offset-2 col-md-10">
+                <button type="submit" class="btn btn-default">Save</button>
+                <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
+            </div>
+        </div>
+    </div>
+}
+
+<!-- End ManageController.Index form -->

--- a/AllReadyApp/Web-App/AllReady/Views/Manage/_ManageSkills.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Views/Manage/_ManageSkills.cshtml
@@ -1,0 +1,40 @@
+<!-- TODO 2231 Which of the follow four are necessary? -->
+@using AllReady.Constants
+@using AllReady.Security;
+@using AllReady.ViewModels.Manage
+@inject AllReady.Services.ISelectListService SelectListService
+
+@model AllReady.ViewModels.Manage.SkillsViewModel
+
+@using (Html.BeginForm("SaveSkills", "Manage"))
+{
+    @Html.AntiForgeryToken()
+    <div class="form-horizontal">
+        <div class="form-group">
+            <label asp-for="AssociatedSkills" class="control-label col-md-2"></label>
+            <div class="col-md-10">
+                <div data-bind="foreach: skills">
+                    <div class="form-inline">
+                        <select class="form-control" data-bind="attr: { name: ControlName($index) }, options: $root.availableSkills, optionsText: 'Name', optionsValue: 'Id', value: Id"></select>
+                        <span class="fa fa-question-circle" data-bind="visible: Description, tooltip: { title: Description, placement: 'top' }" aria-hidden="true"></span>
+                        <a href="#" data-bind="click: $root.deleteSkill" title="Delete skill">
+                            <span class="fa fa-remove" aria-hidden="true"></span>
+                            Delete
+                        </a>
+                    </div>
+                </div>
+                <a href="#" data-bind="click: addSkill" title="Add skill">
+                    <span class="fa fa-plus" aria-hidden="true"></span>
+                    Add
+                </a>
+            </div>
+        </div>
+        <div class="form-group">
+            <div class="col-md-offset-2 col-md-10">
+                <button type="submit" class="btn btn-default" data-bind="enable: skills.isValid">Save</button>
+                <a asp-controller="Manage" asp-action="Index" class="btn btn-danger">Cancel</a>
+                <span class="label label-danger" data-bind="visible: !skills.isValid()">"@Html.DisplayNameFor(m => m.AssociatedSkills)" must be unique</span>
+            </div>
+        </div>
+    </div>
+}

--- a/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/css/site.css
@@ -859,3 +859,7 @@ a:hover .myevents-block {
 .featured-campaign h4, p{
     color: black;
 }
+
+.nav-tabs {
+    margin-bottom:15px;
+}

--- a/AllReadyApp/Web-App/Web-App.sln
+++ b/AllReadyApp/Web-App/Web-App.sln
@@ -1,0 +1,48 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AllReady", "AllReady\AllReady.csproj", "{293412D4-4181-4796-87B3-1EC1E56A818D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AllReady.UnitTest", "AllReady.UnitTest\AllReady.UnitTest.csproj", "{D59D238E-3BF4-4E06-A136-73F379D6EE65}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Debug|x64.ActiveCfg = Debug|x64
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Debug|x64.Build.0 = Debug|x64
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Debug|x86.ActiveCfg = Debug|x86
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Debug|x86.Build.0 = Debug|x86
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Release|x64.ActiveCfg = Release|x64
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Release|x64.Build.0 = Release|x64
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Release|x86.ActiveCfg = Release|x86
+		{293412D4-4181-4796-87B3-1EC1E56A818D}.Release|x86.Build.0 = Release|x86
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Debug|x64.ActiveCfg = Debug|x64
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Debug|x64.Build.0 = Debug|x64
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Debug|x86.ActiveCfg = Debug|x86
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Debug|x86.Build.0 = Debug|x86
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Release|x64.ActiveCfg = Release|x64
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Release|x64.Build.0 = Release|x64
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Release|x86.ActiveCfg = Release|x86
+		{D59D238E-3BF4-4E06-A136-73F379D6EE65}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This is a work in progress that resolves https://github.com/HTBox/allReady/issues/1871.

* [x] Add tabs for Account and Skills. 
* [x] Move all existing forms in to the Account tab. 
* [x] Move the skills form in to the Skills tab. 
* [x] Add unit tests.

Moving the skills form into the Skills tab requires a decision about whether to have

* a single save button for all the tabs or 
* a save button per tab.

My own sense is to use a save button per tab. Doing that might require adding another `Action` to the `ManageController`, which seems fine. 