### PR TITLE
#2237 Make edit buttons show text "Edit".

### DIFF
--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Details.cshtml
@@ -28,7 +28,7 @@
                 }
                 @Model.Name
             </h2>
-            <a asp-controller="Campaign" asp-action="Edit" asp-area="@AreaNames.Admin" asp-route-id="@Model.Id" class="btn btn-default inline-form" title="Edit"><i class="fa fa-edit"></i></a>
+            <a asp-controller="Campaign" asp-action="Edit" asp-area="@AreaNames.Admin" asp-route-id="@Model.Id" class="btn btn-default inline-form" title="Edit">Edit</a>
             <a asp-controller="Campaign" asp-action="Delete" asp-area="@AreaNames.Admin" asp-route-id="@Model.Id" class="btn btn-default inline-form" title="Delete"><i class="glyphicon glyphicon-trash"></i></a>
             @if (!Model.Published)
             {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/Index.cshtml
@@ -35,7 +35,7 @@
                 <tr>
                     <td>
                         <div class="btn-group btn-group-sm row-btn-margin">
-                            <a data-toggle="tooltip" data-placement="top" title="Edit" asp-controller="Campaign" asp-action="Edit" asp-area="@AreaNames.Admin" asp-route-id="@item.Id" class="btn btn-success"><span class="fa fa-edit"></span></a>
+                            <a data-toggle="tooltip" data-placement="top" title="Edit" asp-controller="Campaign" asp-action="Edit" asp-area="@AreaNames.Admin" asp-route-id="@item.Id" class="btn btn-success">Edit</a>
                         </div>
                         @if (!item.Published)
                         {

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/_CampaignGoal.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Campaign/_CampaignGoal.cshtml
@@ -5,7 +5,7 @@
 <div class="panel panel-success campaign-goal @if (!Model.Display){ <text>not-displayed</text> } ">
     <div class="panel-heading">
         <div class="actions">
-            <a asp-controller="Goal" asp-action="Edit" asp-area="@AreaNames.Admin" asp-route-id="@Model.Id" class="btn btn-default inline-form" title="Edit"><i class="fa fa-edit"></i></a>
+            <a asp-controller="Goal" asp-action="Edit" asp-area="@AreaNames.Admin" asp-route-id="@Model.Id" class="btn btn-default inline-form" title="Edit">Edit</a>
             <a asp-controller="Goal" asp-action="Delete" asp-area="@AreaNames.Admin" asp-route-id="@Model.Id"  class="btn btn-default inline-form"><i class="glyphicon glyphicon-trash"></i></a>
         </div>
         @Html.Raw(Model.TextualGoal)

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Event/Details.cshtml
@@ -28,7 +28,7 @@
     <div class="col-md-10">
         <h2>
             <span data-event-title>@Model.Name</span>
-            <a asp-area="@AreaNames.Admin" asp-controller="Event" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default" title="Edit This Event" aria-label="Edit This Event"><i class="fa fa-edit"></i></a>
+            <a asp-area="@AreaNames.Admin" asp-controller="Event" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default" title="Edit This Event" aria-label="Edit This Event">Edit</a>
             @if (Model.ShowDeleteButton)
             {
                 <a asp-area="@AreaNames.Admin" asp-controller="Event" asp-action="Duplicate" asp-route-id="@Model.Id" class="btn btn-default">Duplicate</a>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Itinerary/Details.cshtml
@@ -62,7 +62,7 @@
     <div class="col-md-12">
         <h2>
             @Model.Name
-            <a asp-area="Admin" asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
+            <a asp-area="Admin" asp-controller="Itinerary" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default">Edit</a>
         </h2>
         <p>Scheduled for @Model.DisplayDate</p>
     </div>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Organization/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Organization/Index.cshtml
@@ -38,7 +38,7 @@
                 <tr>
                     <td>
                         <div class="row-btn-margin btn-toolbar">
-                            <a data-toggle="tooltip" data-placement="top" title="Edit" href="@Url.Action("Edit", "Organization", new {id = item.Id})" class="btn btn-sm btn-success"><span class="fa fa-edit"></span></a>
+                            <a data-toggle="tooltip" data-placement="top" title="Edit" href="@Url.Action("Edit", "Organization", new {id = item.Id})" class="btn btn-sm btn-success">Edit</a>
                             &nbsp; <a data-toggle="tooltip" data-placement="top" title="Delete" href="@Url.Action("Delete", "Organization", new { id = item.Id })" class="btn btn-sm  btn-danger"><span class="fa fa-remove"></span></a>
                         </div>
                     </td>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Resource/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Resource/Details.cshtml
@@ -20,7 +20,7 @@
     <div class="col-md-10">
         <h2>
             <span>@Model.Name</span>
-            <a asp-area="@AreaNames.Admin" asp-controller="Resource" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a>
+            <a asp-area="@AreaNames.Admin" asp-controller="Resource" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default">Edit</a>
             <a asp-area="@AreaNames.Admin" asp-controller="Resource" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="fa fa-trash"></i></a>
         </h2>
         <p>@Model.Description</p>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Skill/Index.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Skill/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@model IEnumerable<AllReady.Areas.Admin.ViewModels.Skill.SkillSummaryViewModel>
+@model IEnumerable<AllReady.Areas.Admin.ViewModels.Skill.SkillSummaryViewModel>
 @using AllReady.Constants
 @using AllReady.Security;
 
@@ -38,7 +38,7 @@
                 <tr>
                     <td>
                         <div class="btn-toolbar">
-                            <a data-toggle="tooltip" data-placement="top" title="Edit" asp-area="@AreaNames.Admin" asp-controller="Skill" asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-success"><span class="fa fa-edit"></span></a>
+                            <a data-toggle="tooltip" data-placement="top" title="Edit" asp-area="@AreaNames.Admin" asp-controller="Skill" asp-action="Edit" asp-route-id="@item.Id" class="btn btn-sm btn-success">Edit</a>
                             <a data-toggle="tooltip" data-placement="top" title="Delete" asp-area="@AreaNames.Admin" asp-controller="Skill" asp-action="Delete" asp-route-id="@item.Id" class="btn btn-sm btn-danger"><span class="fa fa-remove"></span></a>
                         </div>
                     </td>

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/VolunteerTask/Details.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/VolunteerTask/Details.cshtml
@@ -19,7 +19,7 @@
 
 <div class="row">
     <div class="col-md-10">
-        <h2>@Model.Name <a asp-area="@AreaNames.Admin" asp-controller="VolunteerTask" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default"><i class="fa fa-edit"></i></a> <a asp-area="@AreaNames.Admin" asp-controller="VolunteerTask" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="glyphicon glyphicon-trash"></i></a></h2>
+        <h2>@Model.Name <a asp-area="@AreaNames.Admin" asp-controller="VolunteerTask" asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-default">Edit</a> <a asp-area="@AreaNames.Admin" asp-controller="VolunteerTask" asp-action="Delete" asp-route-id="@Model.Id" class="btn btn-danger"><i class="glyphicon glyphicon-trash"></i></a></h2>
         <p>@Model.Description</p>
         <p>
             <time value="Model.StartDateTime"></time> - <time value="Model.EndDateTime"></time>


### PR DESCRIPTION
Make edit buttons show text "Edit" instead of showing the FontAwesome "fa-edit" icon.

Fixes #2237