### PR TITLE
#2208 Privacy policy inputs now show/hide on button toggle

### DIFF
--- a/AllReadyApp/AllReady.IntegrationTest/Pages.fs
+++ b/AllReadyApp/AllReady.IntegrationTest/Pages.fs
@@ -93,6 +93,9 @@ module AdminCampaignDetails =
         click createNew
 
 module AdminOrganizationCreate =
+    let privicyPolicyFieldVisible () =
+        (elements "#pp-url").Length = 1
+
     type OrganizationDetails = {
         Name:string
         WebUrl:string
@@ -125,6 +128,8 @@ module AdminOrganizationCreate =
         "#Location_State" << details.State
         "#Location_PostalCode" << details.PostalCode.ToString()
         "#Location_Country" << details.Country
+        click "Link to an external policy"
+        waitFor privicyPolicyFieldVisible
         "#PrivacyPolicyUrl" << details.PrivacyPolicyUrl
 
     let Save _ =

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Organization/Edit.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Organization/Edit.cshtml
@@ -97,20 +97,29 @@
             </div>
         </div>
         <div class="form-group">
+            <label class="col-md-2 control-label">Privacy Policy</label>
+            <div class="col-md-10">
+                <a id="show-pp-url" class="btn btn-default">Link to an external policy</a>
+                <a id="show-pp-text" class="btn btn-default">Enter policy text</a>
+                <div class="col-md">
+                    <span asp-validation-for="PrivacyPolicyUrl" class="text-danger"></span>
+                    <span asp-validation-for="PrivacyPolicy" class="text-danger"></span>
+                </div>
+            </div>
+        </div>
+        <div id="pp-url" class="form-group">
             <label asp-for="PrivacyPolicyUrl" class="col-md-2 control-label"></label>
             <div class="col-md-10">
                 <input asp-for="PrivacyPolicyUrl" class="form-control" />
-                <span asp-validation-for="PrivacyPolicyUrl" class="text-danger"></span>
             </div>
         </div>
-        <div class="form-group">
+        <div id="pp-text" class="form-group">
             <div class="control-label col-md-2">
                 <label asp-for="PrivacyPolicy"></label>
                 <p><cite>This formatted text will be used as the organization's privacy policy content</cite></p>
             </div>
             <div class="col-md-10">
                 <textarea asp-for="PrivacyPolicy" class="form-control wysiwyg" rows="6"></textarea>
-                <span asp-validation-for="PrivacyPolicy" class="text-danger"></span>
             </div>
         </div>
 
@@ -156,3 +165,7 @@
         </div>
     </div>
 </form>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_OrganisationEditPartial"); }
+}

--- a/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Shared/_OrganisationEditPartial.cshtml
+++ b/AllReadyApp/Web-App/AllReady/Areas/Admin/Views/Shared/_OrganisationEditPartial.cshtml
@@ -1,0 +1,6 @@
+<environment names="Development">
+    <script src="~/js/organisationEditAdmin.js"></script>
+</environment>
+<environment names="Staging,Production">
+    <script src="~/js/organisationEditAdmin.js"></script>
+</environment>

--- a/AllReadyApp/Web-App/AllReady/wwwroot/js/organisationEditAdmin.js
+++ b/AllReadyApp/Web-App/AllReady/wwwroot/js/organisationEditAdmin.js
@@ -1,0 +1,16 @@
+(function() {
+    'use strict';
+    $('#pp-url').hide();
+    $('#pp-text').hide();
+
+    $('#show-pp-url').click(function(event) {
+        event.preventDefault();
+        $('#pp-text').slideUp();
+        $('#pp-url').slideDown();
+    });
+    $('#show-pp-text').click(function(event) {
+        event.preventDefault();
+        $('#pp-url').slideUp();
+        $('#pp-text').slideDown();
+    })
+}());


### PR DESCRIPTION
I've added a pair of corresponding buttons over the privacy policy inputs and hidden both of them by default. You can switch back and forth between the two input types, but once one of them has been opened you can't hide both of them again. Also moved up the asp-validation-for spans to sit under the buttons so they don't get hidden.