### PR TITLE
WIP - Displays version of Node and NPM used for build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,9 @@ build_script:
  - cmd: dotnet build AllReadyApp\Web-App\AllReady.UnitTest\AllReady.UnitTest.csproj
  - cmd: dotnet build AllReadyApp\AllReady.NotificationsWebJob\AllReady.NotificationsWebJob.csproj
  - cmd: msbuild /p:Configuration=Release AllReadyApp\AllReady.IntegrationTest\AllReady.ScenarioTest.fsproj
-
+ - ps: Write-Host "Content of Published folder"
+ - ps: dir c:\Published\wwwroot\
+ 
 test_script:
 # === Run Unit Tests
  - ps: cd .\AllReadyApp\Web-App\AllReady.UnitTest
@@ -51,8 +53,6 @@ test_script:
  - ps: dotnet ef database update > (Join-Path $env:APPVEYOR_BUILD_FOLDER "db_update.log")
  - ps: Write-Host "== starting web server =="
  - ps: cd c:\Published
- - ps: Write-Host "Content of Published folder"
- - ps: dir
  - ps: $webhost = start-process "dotnet" "AllReady.dll" -PassThru -RedirectStandardOutput (Join-Path $env:APPVEYOR_BUILD_FOLDER kestrel.log)
  - ps: Start-Sleep 30  # Wait for webserver to warm up
  - ps: cd $env:APPVEYOR_BUILD_FOLDER 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,8 @@ test_script:
  - ps: dotnet ef database update > (Join-Path $env:APPVEYOR_BUILD_FOLDER "db_update.log")
  - ps: Write-Host "== starting web server =="
  - ps: cd c:\Published
+ - ps: Write-Host "Content of Published folder"
+ - ps: dir
  - ps: $webhost = start-process "dotnet" "AllReady.dll" -PassThru -RedirectStandardOutput (Join-Path $env:APPVEYOR_BUILD_FOLDER kestrel.log)
  - ps: Start-Sleep 30  # Wait for webserver to warm up
  - ps: cd $env:APPVEYOR_BUILD_FOLDER 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,9 @@ before_build:
  - cmd: dotnet restore AllReadyApp\Web-App\AllReady.UnitTest\AllReady.UnitTest.csproj
  - cmd: dotnet restore AllReadyApp\AllReady.NotificationsWebJob\AllReady.NotificationsWebJob.csproj
  - nuget restore AllReadyApp\AllReady.IntegrationTest\AllReady.ScenarioTest.fsproj -SolutionDirectory .\AllReadyApp
+ - ps: Write-Host "Version of Node and NPM used for Build"
+ - ps: node -v
+ - ps: npm -v
  - cmd: npm install gulp -g
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,7 @@ build_script:
  - cmd: msbuild /p:Configuration=Release AllReadyApp\AllReady.IntegrationTest\AllReady.ScenarioTest.fsproj
  - ps: Write-Host "Content of Published folder"
  - ps: dir c:\Published\wwwroot\
+ - ps: dir c:\Published\wwwroot\lib\
  
 test_script:
 # === Run Unit Tests


### PR DESCRIPTION
**Do not merge this PR**

Need to confirm the AppVeyor build server setup.  The initial assumption was the Node 10 was being used but other tests indicate that it's Node 8.15.